### PR TITLE
fix: detect multiple instances and throw

### DIFF
--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {describe, it} from 'node:test';
+import assert from 'node:assert';
+import os from 'node:os';
+import path from 'node:path';
+import {launch} from '../src/browser.js';
+
+describe('browser', () => {
+  it('cannot launch multiple times with the same profile', async () => {
+    const tmpDir = os.tmpdir();
+    const folderPath = path.join(tmpDir, `temp-folder-${crypto.randomUUID()}`);
+    const browser1 = await launch({
+      headless: true,
+      isolated: false,
+      userDataDir: folderPath,
+    });
+    try {
+      try {
+        const browser2 = await launch({
+          headless: true,
+          isolated: false,
+          userDataDir: folderPath,
+        });
+        await browser2.close();
+        assert.fail('not reached');
+      } catch (err) {
+        assert.strictEqual(
+          err.message,
+          `The browser is already running for ${folderPath}. Use --isolated to run multiple browser instances.`,
+        );
+      }
+    } finally {
+      await browser1.close();
+    }
+  });
+});


### PR DESCRIPTION
We should be checking for browser logs in Puppeteer instead.