### PR TITLE
chore: experimental devtools-on-devtools support

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -89,16 +89,8 @@ export class McpContext implements Context {
 
   #nextSnapshotId = 1;
   #traceResults: TraceResult[] = [];
-  #devtools = false;
 
-  private constructor(
-    browser: Browser,
-    logger: Debugger,
-    options: {
-      devtools: boolean;
-    },
-  ) {
-    this.#devtools = options.devtools;
+  private constructor(browser: Browser, logger: Debugger) {
     this.browser = browser;
     this.logger = logger;
 
@@ -131,14 +123,8 @@ export class McpContext implements Context {
     await this.#consoleCollector.init();
   }
 
-  static async from(
-    browser: Browser,
-    logger: Debugger,
-    options: {
-      devtools: boolean;
-    },
-  ) {
-    const context = new McpContext(browser, logger, options);
+  static async from(browser: Browser, logger: Debugger) {
+    const context = new McpContext(browser, logger);
     await context.#init();
     return context;
   }
@@ -316,16 +302,6 @@ export class McpContext implements Context {
    */
   async createPagesSnapshot(): Promise<Page[]> {
     this.#pages = await this.browser.pages();
-    // if (this.#devtools) {
-    //   for (const target of this.browser.targets()) {
-    //     if (
-    //       target.type() === 'other' &&
-    //       target.url().startsWith('devtools://')
-    //     ) {
-    //       this.#pages.push(await target.asPage());
-    //     }
-    //   }
-    // }
     return this.#pages;
   }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -52,12 +52,7 @@ export async function ensureBrowserConnected(options: {
     targetFilter: makeTargetFilter(options.devtools),
     browserURL: options.browserURL,
     defaultViewport: null,
-    // @ts-expect-error no types.
-    _isPageTarget(target) {
-      return (
-        target.type() === 'other' && target.url().startsWith('devtools://')
-      );
-    },
+    handleDevToolsAsPage: options.devtools,
   });
   return browser;
 }
@@ -77,7 +72,7 @@ interface McpLaunchOptions {
   };
   args?: string[];
   devtools: boolean;
-};
+}
 
 export async function launch(options: McpLaunchOptions): Promise<Browser> {
   const {channel, executablePath, customDevTools, headless, isolated} = options;
@@ -131,12 +126,7 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
       headless,
       args,
       acceptInsecureCerts: options.acceptInsecureCerts,
-      // @ts-expect-error no types.
-      _isPageTarget(target) {
-        return (
-          target.type() === 'other' && target.url().startsWith('devtools://')
-        );
-      },
+      handleDevToolsAsPage: options.devtools,
     });
     if (options.logFile) {
       // FIXME: we are probably subscribing too late to catch startup logs. We

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,9 +76,9 @@ async function getContext(): Promise<McpContext> {
   const devtools = args.experimentalDevtools ?? false;
   const browser = args.browserUrl
     ? await ensureBrowserConnected({
-      browserURL: args.browserUrl,
-      devtools,
-    })
+        browserURL: args.browserUrl,
+        devtools,
+      })
     : await ensureBrowserLaunched({
         headless: args.headless,
         executablePath: args.executablePath,
@@ -93,9 +93,7 @@ async function getContext(): Promise<McpContext> {
       });
 
   if (context?.browser !== browser) {
-    context = await McpContext.from(browser, logger, {
-      devtools,
-    });
+    context = await McpContext.from(browser, logger);
   }
   return context;
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -35,9 +35,7 @@ export async function withBrowser(
     }),
   );
   const response = new McpResponse();
-  const context = await McpContext.from(browser, logger('test'), {
-    devtools: false,
-  });
+  const context = await McpContext.from(browser, logger('test'));
 
   await cb(response, context);
 }


### PR DESCRIPTION
Allows using the MCP server for the devtools development.