### PR TITLE
fix: support node20

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
           - windows-latest
           - macos-latest
         node:
-          - 22.12.0
+          - 20
           - 22
           - 23
           - 24
@@ -34,19 +34,34 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           cache: npm
-          node-version: ${{ matrix.node }}
+          node-version: 22 # build works only with 22+.
 
       - name: Install dependencies
         shell: bash
         run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Set up Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          cache: npm
+          node-version: ${{ matrix.node }}
 
       - name: Disable AppArmor
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
+      - name: Run tests (node20)
+        if: ${{ matrix.node == '20' }}
+        shell: bash
+        run: npm run test:node20
+
       - name: Run tests
         shell: bash
+        if: ${{ matrix.node != '20' }}
         run: npm run test
 
   # Gating job for branch protection.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ MCP clients.
 
 ## Requirements
 
-- [Node.js 22.12.0](https://nodejs.org/) or newer.
+- [Node.js 20](https://nodejs.org/) or a newer [latest maintainance LTS](https://github.com/nodejs/Release#release-schedule) version.
 - [Chrome](https://www.google.com/chrome/) current stable version or newer.
 - [npm](https://www.npmjs.com/).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.18.2",
+        "core-js": "3.45.1",
         "debug": "4.4.3",
         "puppeteer-core": "24.22.3",
         "yargs": "18.0.0"
@@ -1905,6 +1906,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cors": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "docs:generate": "node --experimental-strip-types scripts/generate-docs.ts",
     "start": "npm run build && node build/src/index.js",
     "start-debug": "DEBUG=mcp:* DEBUG_COLORS=false npm run build && node build/src/index.js",
+    "test:node20": "node --require ./build/tests/setup.js --test-reporter spec --test-force-exit --test build/tests",
     "test": "npm run build && node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-reporter spec --test-force-exit --test \"build/tests/**/*.test.js\"",
     "test:only": "npm run build && node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-reporter spec --test-force-exit --test --test-only \"build/tests/**/*.test.js\"",
     "test:only:no-build": "node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-reporter spec --test-force-exit --test --test-only \"build/tests/**/*.test.js\"",
@@ -37,6 +38,7 @@
   "mcpName": "io.github.ChromeDevTools/chrome-devtools-mcp",
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.18.2",
+    "core-js": "3.45.1",
     "debug": "4.4.3",
     "puppeteer-core": "24.22.3",
     "yargs": "18.0.0"
@@ -53,14 +55,14 @@
     "@typescript-eslint/parser": "^8.43.0",
     "chrome-devtools-frontend": "1.0.1520535",
     "eslint": "^9.35.0",
-    "eslint-plugin-import": "^2.32.0",
     "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-plugin-import": "^2.32.0",
     "globals": "^16.4.0",
     "prettier": "^3.6.2",
     "puppeteer": "24.22.3",
     "sinon": "^21.0.0",
-    "typescript-eslint": "^8.43.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "typescript-eslint": "^8.43.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,16 @@ import {version} from 'node:process';
 
 const [major, minor] = version.substring(1).split('.').map(Number);
 
-if (major < 22 || (major === 22 && minor < 12)) {
+if (major === 22 && minor < 12) {
   console.error(
-    `ERROR: \`chrome-devtools-mcp\` does not support Node ${process.version}. Please upgrade to Node 22.12.0 or newer.`,
+    `ERROR: \`chrome-devtools-mcp\` does not support Node ${process.version}. Please upgrade to Node 22.12.0 LTS or a newer LTS.`,
+  );
+  process.exit(1);
+}
+
+if (major < 20) {
+  console.error(
+    `ERROR: \`chrome-devtools-mcp\` does not support Node ${process.version}. Please upgrade to Node 20 LTS or a newer LTS.`,
   );
   process.exit(1);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import './polyfill.js';
+
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import 'core-js/modules/es.promise.with-resolvers.js';
+import 'core-js/proposals/iterator-helpers.js';

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,6 +3,8 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import '../src/polyfill.js';
+
 import path from 'node:path';
 import {it} from 'node:test';
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -3,7 +3,6 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import logger from 'debug';
 import type {Browser} from 'puppeteer';
 import puppeteer from 'puppeteer';


### PR DESCRIPTION
Initially, we started with the support of Node22+ but since Node20 is an LTS that is still in the maintenance mode it makes sense to support it.