### PR TITLE
fix: fix browserUrl not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,9 @@ The Chrome DevTools MCP server supports the following configuration option:
   - **Default:** `false`
 
 - **`--channel`**
-  Specify a different Chrome channel that should be used.
+  Specify a different Chrome channel that should be used. The default is the stable channel version.
   - **Type:** string
   - **Choices:** `stable`, `canary`, `beta`, `dev`
-  - **Default:** `stable`
 
 <!-- END AUTO GENERATED OPTIONS -->
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,10 +72,10 @@ export const cliOptions = {
   },
   channel: {
     type: 'string' as const,
-    description: 'Specify a different Chrome channel that should be used.',
+    description:
+      'Specify a different Chrome channel that should be used. The default is the stable channel version.',
     choices: ['stable', 'canary', 'beta', 'dev'] as const,
     conflicts: ['browserUrl', 'executablePath'],
-    default: 'stable',
   },
   logFile: {
     type: 'string' as const,


### PR DESCRIPTION
Setting the default channel in the CLI resulted in our mutually exclusive check for browserUrl and channel to fail.