### PR TITLE
test: use cft for e2e tests

### DIFF
--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -7,6 +7,7 @@ import {describe, it} from 'node:test';
 import assert from 'node:assert';
 import os from 'node:os';
 import path from 'node:path';
+import {executablePath} from 'puppeteer';
 import {launch} from '../src/browser.js';
 
 describe('browser', () => {
@@ -17,6 +18,7 @@ describe('browser', () => {
       headless: true,
       isolated: false,
       userDataDir: folderPath,
+      executablePath: executablePath(),
     });
     try {
       try {
@@ -24,6 +26,7 @@ describe('browser', () => {
           headless: true,
           isolated: false,
           userDataDir: folderPath,
+          executablePath: executablePath(),
         });
         await browser2.close();
         assert.fail('not reached');

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,12 +9,19 @@ import {describe, it} from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import {ToolDefinition} from '../src/tools/ToolDefinition.js';
+import {executablePath} from 'puppeteer';
 
 describe('e2e', () => {
   async function withClient(cb: (client: Client) => Promise<void>) {
     const transport = new StdioClientTransport({
       command: 'node',
-      args: ['build/src/index.js', '--headless', '--isolated'],
+      args: [
+        'build/src/index.js',
+        '--headless',
+        '--isolated',
+        '--executable-path',
+        executablePath(),
+      ],
     });
     const client = new Client(
       {


### PR DESCRIPTION
we were using the Chrome version pre-installed on the GitHub actions and I wonder if it could have been the source for the flakiness.