### PR TITLE
fix: forbid closing the last page

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -116,7 +116,7 @@
 
 ### `close_page`
 
-**Description:** Closes the page by its index.
+**Description:** Closes the page by its index. The last open page cannot be closed.
 
 **Parameters:**
 

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -131,6 +131,16 @@ export class McpContext implements Context {
     this.#consoleCollector.addPage(page);
     return page;
   }
+  async closePage(pageIdx: number): Promise<void> {
+    if (this.#pages.length === 1) {
+      throw new Error(
+        'Unable to close the last page in the browser. It is fine to keep the last page open.',
+      );
+    }
+    const page = this.getPageByIdx(pageIdx);
+    this.setSelectedPageIdx(0);
+    await page.close({runBeforeUnload: false});
+  }
 
   getNetworkRequestByUrl(url: string): HTTPRequest {
     const requests = this.getNetworkRequests();

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -62,6 +62,7 @@ export type Context = Readonly<{
   clearDialog(): void;
   getPageByIdx(idx: number): Page;
   newPage(): Promise<Page>;
+  closePage(pageIdx: number): Promise<void>;
   setSelectedPageIdx(idx: number): void;
   getElementByUid(uid: string): Promise<ElementHandle<Element>>;
   setNetworkConditions(conditions: string | null): void;

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -45,7 +45,7 @@ export const selectPage = defineTool({
 
 export const closePage = defineTool({
   name: 'close_page',
-  description: `Closes the page by its index.`,
+  description: `Closes the page by its index. The last open page cannot be closed.`,
   annotations: {
     category: ToolCategories.NAVIGATION_AUTOMATION,
     readOnlyHint: false,
@@ -58,9 +58,7 @@ export const closePage = defineTool({
       ),
   },
   handler: async (request, response, context) => {
-    const page = context.getPageByIdx(request.params.pageIdx);
-    context.setSelectedPageIdx(0);
-    await page.close({runBeforeUnload: false});
+    await context.closePage(request.params.pageIdx);
     response.setIncludePages(true);
   },
 });

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -53,6 +53,21 @@ describe('pages', () => {
         assert.ok(response.includePages);
       });
     });
+    it('cannot close the last page', async () => {
+      await withBrowser(async (response, context) => {
+        const page = context.getSelectedPage();
+        try {
+          await closePage.handler({params: {pageIdx: 0}}, response, context);
+          assert.fail('not reached');
+        } catch (err) {
+          assert.strictEqual(
+            err.message,
+            'Unable to close the last page in the browser. It is fine to keep the last page open.',
+          );
+        }
+        assert.ok(!page.isClosed());
+      });
+    });
   });
   describe('browser_select_page', () => {
     it('selects a page', async () => {


### PR DESCRIPTION
McpContext currently assumes that there is a page. Eventually we might support closing the browser by closing the last page but right now we do not really have responses that indicate that the browser was closed. So this PR helps the LLM understand that it is okay to keep the last page running (and there are platform-specific differences as to what happens if the last page is closed).

Ref https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/87