### PR TITLE
fix: add a message indicating that no console messages exist

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -172,7 +172,11 @@ Call browser_handle_dialog to handle it before continuing.`);
 
     if (this.#includeConsoleData && this.#formattedConsoleData) {
       response.push('## Console messages');
-      response.push(...this.#formattedConsoleData);
+      if (this.#formattedConsoleData.length) {
+        response.push(...this.#formattedConsoleData);
+      } else {
+        response.push('<no console messages found>');
+      }
     }
 
     const text: TextContent = {

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -246,4 +246,18 @@ Log>`),
       assert.ok(result[0].text.toString().includes('Hello from the test'));
     });
   });
+
+  it('adds a message when no console messages exist', async () => {
+    await withBrowser(async (response, context) => {
+      response.setIncludeConsoleData(true);
+      const result = await response.handle('test', context);
+      assert.ok(result[0].text);
+      assert.strictEqual(
+        result[0].text.toString(),
+        `# test response
+## Console messages
+<no console messages found>`,
+      );
+    });
+  });
 });


### PR DESCRIPTION
To avoid clients being confused about the lack of console messages.

Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/87