### PR TITLE
fix: manually bump server.json versions based on package.json

### DIFF
--- a/.github/workflows/publish-to-npm-on-tag.yml
+++ b/.github/workflows/publish-to-npm-on-tag.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Bump
+        run: npm run sync-server-json-version
+
       - name: Install MCP Publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:only": "npm run build && node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-reporter spec --test-force-exit --test --test-only \"build/tests/**/*.test.js\"",
     "test:only:no-build": "node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-reporter spec --test-force-exit --test --test-only \"build/tests/**/*.test.js\"",
     "test:update-snapshots": "npm run build && node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-force-exit --test --test-update-snapshots \"build/tests/**/*.test.js\"",
-    "prepare": "node --experimental-strip-types scripts/prepare.ts"
+    "prepare": "node --experimental-strip-types scripts/prepare.ts",
+    "sync-server-json-version": "node  --experimental-strip-types scripts/sync-server-json-version.ts && npm run format"
   },
   "files": [
     "build/src",

--- a/scripts/sync-server-json-version.ts
+++ b/scripts/sync-server-json-version.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import fs from 'node:fs';
+
+const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
+const serverJson = JSON.parse(fs.readFileSync('./server.json', 'utf-8'));
+
+serverJson.version = packageJson.version;
+for (const pkg of serverJson.packages) {
+  pkg.version = packageJson.version;
+}
+
+fs.writeFileSync('./server.json', JSON.stringify(serverJson, null, 2));

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
     "source": "github"
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "chrome-devtools-mcp",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
it appears that mcp registry publishing tools would not sync automatically with package.json.