### PR TITLE
fix: avoid reporting page close errors as errors

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -13,7 +13,7 @@ import {
   SerializedAXNode,
   PredefinedNetworkConditions,
 } from 'puppeteer-core';
-import {Context} from './tools/ToolDefinition.js';
+import {CLOSE_PAGE_ERROR, Context} from './tools/ToolDefinition.js';
 import {Debugger} from 'debug';
 import {NetworkCollector, PageCollector} from './PageCollector.js';
 import fs from 'node:fs/promises';
@@ -133,9 +133,7 @@ export class McpContext implements Context {
   }
   async closePage(pageIdx: number): Promise<void> {
     if (this.#pages.length === 1) {
-      throw new Error(
-        'Unable to close the last page in the browser. It is fine to keep the last page open.',
-      );
+      throw new Error(CLOSE_PAGE_ERROR);
     }
     const page = this.getPageByIdx(pageIdx);
     this.setSelectedPageIdx(0);

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -79,3 +79,6 @@ export function defineTool<Schema extends Zod.ZodRawShape>(
 ) {
   return definition;
 }
+
+export const CLOSE_PAGE_ERROR =
+  'The last open page cannot be closed. It is fine to keep it open.';

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -5,7 +5,7 @@
  */
 
 import z from 'zod';
-import {defineTool} from './ToolDefinition.js';
+import {CLOSE_PAGE_ERROR, defineTool} from './ToolDefinition.js';
 import {ToolCategories} from './categories.js';
 
 export const listPages = defineTool({
@@ -58,7 +58,15 @@ export const closePage = defineTool({
       ),
   },
   handler: async (request, response, context) => {
-    await context.closePage(request.params.pageIdx);
+    try {
+      await context.closePage(request.params.pageIdx);
+    } catch (err) {
+      if (err.message === CLOSE_PAGE_ERROR) {
+        response.appendResponseLine(err.message);
+      } else {
+        throw err;
+      }
+    }
     response.setIncludePages(true);
   },
 });

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -56,15 +56,12 @@ describe('pages', () => {
     it('cannot close the last page', async () => {
       await withBrowser(async (response, context) => {
         const page = context.getSelectedPage();
-        try {
-          await closePage.handler({params: {pageIdx: 0}}, response, context);
-          assert.fail('not reached');
-        } catch (err) {
-          assert.strictEqual(
-            err.message,
-            'Unable to close the last page in the browser. It is fine to keep the last page open.',
-          );
-        }
+        await closePage.handler({params: {pageIdx: 0}}, response, context);
+        assert.deepStrictEqual(
+          response.responseLines[0],
+          `The last open page cannot be closed. It is fine to keep it open.`,
+        );
+        assert.ok(response.includePages);
         assert.ok(!page.isClosed());
       });
     });


### PR DESCRIPTION
Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/125