### PR TITLE
fix(performance): ImageDelivery insight errors

### DIFF
--- a/scripts/post-build.ts
+++ b/scripts/post-build.ts
@@ -103,6 +103,30 @@ export const TimeUtilities = {
 
     return parts.map(part => part.value).join('');
   }
+};
+
+// TODO(jacktfranklin): once the ImageDelivery insight does not depend on this method, we can remove this stub.
+export const ByteUtilities = {
+  bytesToString(x) {
+    const separator = '\xA0';
+    const formatter = new Intl.NumberFormat('en-US', {
+      style: 'unit',
+      unit: 'kilobyte',
+      unitDisplay: 'narrow',
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    });
+    const parts = formatter.formatToParts(x / 1000);
+    for (const part of parts) {
+      if (part.type === 'literal') {
+        if (part.value === ' ') {
+          part.value = separator;
+        }
+      }
+    }
+
+    return parts.map(part => part.value).join('');
+  }
 };`;
   writeFile(i18nFile, i18nContent);
 


### PR DESCRIPTION
This fixes the ImageDelivery insight which throws when we try to generate it
because of its dependency on core/i18n. The long term fix here is to
remove the reliance of models/trace on the core/i18n package, or at
least dependency inject it, but this is a quick fix to at least make
this insight available.

The irony is that we don't even use the string in the AI output; but if
we don't have the method available we cannot generate the insight.

This fixes part of #124 by making this insight not error. The other
required work for that bug is to deal with Insights that do error. That
work is done in DevTools, but we need to ship & roll a new version into
the MCP server.
