### PR TITLE
chore: unblock uses with Deno and Bun

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const [major, minor] = process.version.substring(1).split('.').map(Number);
+import {version} from 'node:process';
+
+const [major, minor] = version.substring(1).split('.').map(Number);
 
 if (major < 22 || (major === 22 && minor < 12)) {
   console.error(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,8 @@
       "ESNext.Iterator",
       "ESNext.Collection"
     ],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "outDir": "./build",
     "rootDir": ".",
     "strict": true,


### PR DESCRIPTION
I wanna test more NodeJS versions to see that this does not cause other issues.

Deno test command: 
```sh
npx @modelcontextprotocol/inspector deno --allow-env --allow-read ./build/src/index.js 
```

Bun test command:
```sh
npx @modelcontextprotocol/inspector bun ./build/src/index.js 
```