### PR TITLE
feat: add network request filtering by resource type

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -266,7 +266,7 @@
 
 - **pageIdx** (integer) _(optional)_: Page number to return (0-based). When omitted, returns the first page.
 - **pageSize** (integer) _(optional)_: Maximum number of requests to return. When omitted, returns all requests.
-- **resourceType** (array) _(optional)_: Filter requests by resource type. When omitted, returns all requests.
+- **resourceType** (array) _(optional)_: Filter requests to only return requests of the specified resource types. When omitted, returns all requests.
 
 ---
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -266,7 +266,7 @@
 
 - **pageIdx** (integer) _(optional)_: Page number to return (0-based). When omitted, returns the first page.
 - **pageSize** (integer) _(optional)_: Maximum number of requests to return. When omitted, returns all requests.
-- **resourceType** (array) _(optional)_: Filter requests to only return requests of the specified resource types. When omitted, returns all requests.
+- **resourceTypes** (array) _(optional)_: Filter requests to only return requests of the specified resource types. When omitted or empty, returns all requests.
 
 ---
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -266,6 +266,7 @@
 
 - **pageIdx** (integer) _(optional)_: Page number to return (0-based). When omitted, returns the first page.
 - **pageSize** (integer) _(optional)_: Maximum number of requests to return. When omitted, returns all requests.
+- **resourceType** (array) _(optional)_: Filter requests by resource type. When omitted, returns all requests.
 
 ---
 

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -7,18 +7,18 @@ import type {
   ImageContent,
   TextContent,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { ResourceType } from 'puppeteer-core';
+import type {ResourceType} from 'puppeteer-core';
 
-import { formatConsoleEvent } from './formatters/consoleFormatter.js';
+import {formatConsoleEvent} from './formatters/consoleFormatter.js';
 import {
   getFormattedHeaderValue,
   getShortDescriptionForRequest,
   getStatusFromRequest,
 } from './formatters/networkFormatter.js';
-import { formatA11ySnapshot } from './formatters/snapshotFormatter.js';
-import type { McpContext } from './McpContext.js';
-import type { ImageContentData, Response } from './tools/ToolDefinition.js';
-import { paginate, type PaginationOptions } from './utils/pagination.js';
+import {formatA11ySnapshot} from './formatters/snapshotFormatter.js';
+import type {McpContext} from './McpContext.js';
+import type {ImageContentData, Response} from './tools/ToolDefinition.js';
+import {paginate, type PaginationOptions} from './utils/pagination.js';
 
 export class McpResponse implements Response {
   #includePages = false;
@@ -44,7 +44,11 @@ export class McpResponse implements Response {
 
   setIncludeNetworkRequests(
     value: boolean,
-    options?: { pageSize?: number; pageIdx?: number; resourceTypes?: ResourceType[] },
+    options?: {
+      pageSize?: number;
+      pageIdx?: number;
+      resourceTypes?: ResourceType[];
+    },
   ): void {
     if (!value) {
       this.#networkRequestsOptions = undefined;
@@ -53,10 +57,13 @@ export class McpResponse implements Response {
 
     this.#networkRequestsOptions = {
       include: value,
-      pagination: options?.pageSize || options?.pageIdx ? {
-        pageSize: options.pageSize,
-        pageIdx: options.pageIdx,
-      } : undefined,
+      pagination:
+        options?.pageSize || options?.pageIdx
+          ? {
+              pageSize: options.pageSize,
+              pageIdx: options.pageIdx,
+            }
+          : undefined,
       resourceTypes: options?.resourceTypes,
     };
   }
@@ -191,7 +198,9 @@ Call browser_handle_dialog to handle it before continuing.`);
 
       // Apply resource type filtering if specified
       if (this.#networkRequestsOptions.resourceTypes) {
-        const normalizedTypes = new Set(this.#networkRequestsOptions.resourceTypes);
+        const normalizedTypes = new Set(
+          this.#networkRequestsOptions.resourceTypes,
+        );
         requests = requests.filter(request => {
           const type = request.resourceType();
           return normalizedTypes.has(type);
@@ -208,7 +217,7 @@ Call browser_handle_dialog to handle it before continuing.`);
           response.push('Invalid page number provided. Showing first page.');
         }
 
-        const { startIndex, endIndex, currentPage, totalPages } =
+        const {startIndex, endIndex, currentPage, totalPages} =
           paginationResult;
         response.push(
           `Showing ${startIndex + 1}-${endIndex} of ${requests.length} (Page ${currentPage + 1} of ${totalPages}).`,

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -7,18 +7,18 @@ import type {
   ImageContent,
   TextContent,
 } from '@modelcontextprotocol/sdk/types.js';
-import type {ResourceType} from 'puppeteer-core';
+import type { ResourceType } from 'puppeteer-core';
 
-import {formatConsoleEvent} from './formatters/consoleFormatter.js';
+import { formatConsoleEvent } from './formatters/consoleFormatter.js';
 import {
   getFormattedHeaderValue,
   getShortDescriptionForRequest,
   getStatusFromRequest,
 } from './formatters/networkFormatter.js';
-import {formatA11ySnapshot} from './formatters/snapshotFormatter.js';
-import type {McpContext} from './McpContext.js';
-import type {ImageContentData, Response} from './tools/ToolDefinition.js';
-import {paginate, type PaginationOptions} from './utils/pagination.js';
+import { formatA11ySnapshot } from './formatters/snapshotFormatter.js';
+import type { McpContext } from './McpContext.js';
+import type { ImageContentData, Response } from './tools/ToolDefinition.js';
+import { paginate, type PaginationOptions } from './utils/pagination.js';
 
 export class McpResponse implements Response {
   #includePages = false;
@@ -60,9 +60,9 @@ export class McpResponse implements Response {
       pagination:
         options?.pageSize || options?.pageIdx
           ? {
-              pageSize: options.pageSize,
-              pageIdx: options.pageIdx,
-            }
+            pageSize: options.pageSize,
+            pageIdx: options.pageIdx,
+          }
           : undefined,
       resourceTypes: options?.resourceTypes,
     };
@@ -197,7 +197,7 @@ Call browser_handle_dialog to handle it before continuing.`);
       let requests = context.getNetworkRequests();
 
       // Apply resource type filtering if specified
-      if (this.#networkRequestsOptions.resourceTypes) {
+      if (this.#networkRequestsOptions.resourceTypes?.length) {
         const normalizedTypes = new Set(
           this.#networkRequestsOptions.resourceTypes,
         );
@@ -217,7 +217,7 @@ Call browser_handle_dialog to handle it before continuing.`);
           response.push('Invalid page number provided. Showing first page.');
         }
 
-        const {startIndex, endIndex, currentPage, totalPages} =
+        const { startIndex, endIndex, currentPage, totalPages } =
           paginationResult;
         response.push(
           `Showing ${startIndex + 1}-${endIndex} of ${requests.length} (Page ${currentPage + 1} of ${totalPages}).`,

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -7,18 +7,18 @@ import type {
   ImageContent,
   TextContent,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { ResourceType } from 'puppeteer-core';
+import type {ResourceType} from 'puppeteer-core';
 
-import { formatConsoleEvent } from './formatters/consoleFormatter.js';
+import {formatConsoleEvent} from './formatters/consoleFormatter.js';
 import {
   getFormattedHeaderValue,
   getShortDescriptionForRequest,
   getStatusFromRequest,
 } from './formatters/networkFormatter.js';
-import { formatA11ySnapshot } from './formatters/snapshotFormatter.js';
-import type { McpContext } from './McpContext.js';
-import type { ImageContentData, Response } from './tools/ToolDefinition.js';
-import { paginate, type PaginationOptions } from './utils/pagination.js';
+import {formatA11ySnapshot} from './formatters/snapshotFormatter.js';
+import type {McpContext} from './McpContext.js';
+import type {ImageContentData, Response} from './tools/ToolDefinition.js';
+import {paginate, type PaginationOptions} from './utils/pagination.js';
 
 export class McpResponse implements Response {
   #includePages = false;
@@ -60,9 +60,9 @@ export class McpResponse implements Response {
       pagination:
         options?.pageSize || options?.pageIdx
           ? {
-            pageSize: options.pageSize,
-            pageIdx: options.pageIdx,
-          }
+              pageSize: options.pageSize,
+              pageIdx: options.pageIdx,
+            }
           : undefined,
       resourceTypes: options?.resourceTypes,
     };
@@ -217,7 +217,7 @@ Call browser_handle_dialog to handle it before continuing.`);
           response.push('Invalid page number provided. Showing first page.');
         }
 
-        const { startIndex, endIndex, currentPage, totalPages } =
+        const {startIndex, endIndex, currentPage, totalPages} =
           paginationResult;
         response.push(
           `Showing ${startIndex + 1}-${endIndex} of ${requests.length} (Page ${currentPage + 1} of ${totalPages}).`,

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Dialog, ElementHandle, Page } from 'puppeteer-core';
+import type {Dialog, ElementHandle, Page} from 'puppeteer-core';
 import type z from 'zod';
 
-import type { TraceResult } from '../trace-processing/parse.js';
+import type {TraceResult} from '../trace-processing/parse.js';
 
-import type { ToolCategories } from './categories.js';
+import type {ToolCategories} from './categories.js';
 
 export interface ToolDefinition<Schema extends z.ZodRawShape = z.ZodRawShape> {
   name: string;
@@ -44,7 +44,7 @@ export interface Response {
   setIncludePages(value: boolean): void;
   setIncludeNetworkRequests(
     value: boolean,
-    options?: { pageSize?: number; pageIdx?: number; resourceTypes?: string[] },
+    options?: {pageSize?: number; pageIdx?: number; resourceTypes?: string[]},
   ): void;
   setIncludeConsoleData(value: boolean): void;
   setIncludeSnapshot(value: boolean): void;
@@ -73,7 +73,7 @@ export type Context = Readonly<{
   saveTemporaryFile(
     data: Uint8Array<ArrayBufferLike>,
     mimeType: 'image/png' | 'image/jpeg',
-  ): Promise<{ filename: string }>;
+  ): Promise<{filename: string}>;
   waitForEventsAfterAction(action: () => Promise<unknown>): Promise<void>;
 }>;
 

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Dialog, ElementHandle, Page} from 'puppeteer-core';
+import type { Dialog, ElementHandle, Page } from 'puppeteer-core';
 import type z from 'zod';
 
-import type {TraceResult} from '../trace-processing/parse.js';
+import type { TraceResult } from '../trace-processing/parse.js';
 
-import type {ToolCategories} from './categories.js';
+import type { ToolCategories } from './categories.js';
 
 export interface ToolDefinition<Schema extends z.ZodRawShape = z.ZodRawShape> {
   name: string;
@@ -44,7 +44,7 @@ export interface Response {
   setIncludePages(value: boolean): void;
   setIncludeNetworkRequests(
     value: boolean,
-    options?: {pageSize?: number; pageIdx?: number},
+    options?: { pageSize?: number; pageIdx?: number; resourceTypes?: string[] },
   ): void;
   setIncludeConsoleData(value: boolean): void;
   setIncludeSnapshot(value: boolean): void;
@@ -73,7 +73,7 @@ export type Context = Readonly<{
   saveTemporaryFile(
     data: Uint8Array<ArrayBufferLike>,
     mimeType: 'image/png' | 'image/jpeg',
-  ): Promise<{filename: string}>;
+  ): Promise<{ filename: string }>;
   waitForEventsAfterAction(action: () => Promise<unknown>): Promise<void>;
 }>;
 

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -10,7 +10,7 @@ import z from 'zod';
 import { ToolCategories } from './categories.js';
 import { defineTool } from './ToolDefinition.js';
 
-export const FILTERABLE_RESOURCE_TYPES = [
+const FILTERABLE_RESOURCE_TYPES = [
   'document',
   'stylesheet',
   'image',

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -10,27 +10,30 @@ import z from 'zod';
 import { ToolCategories } from './categories.js';
 import { defineTool } from './ToolDefinition.js';
 
-const FILTERABLE_RESOURCE_TYPES = [
-  'document',
-  'stylesheet',
-  'image',
-  'media',
-  'font',
-  'script',
-  'texttrack',
-  'xhr',
-  'fetch',
-  'prefetch',
-  'eventsource',
-  'websocket',
-  'manifest',
-  'signedexchange',
-  'ping',
-  'cspviolationreport',
-  'preflight',
-  'fedcm',
-  'other',
-] as const satisfies readonly ResourceType[];
+const FILTERABLE_RESOURCE_TYPES: readonly [
+  ResourceType,
+  ...ResourceType[],
+] = [
+    'document',
+    'stylesheet',
+    'image',
+    'media',
+    'font',
+    'script',
+    'texttrack',
+    'xhr',
+    'fetch',
+    'prefetch',
+    'eventsource',
+    'websocket',
+    'manifest',
+    'signedexchange',
+    'ping',
+    'cspviolationreport',
+    'preflight',
+    'fedcm',
+    'other',
+  ];
 
 export const listNetworkRequests = defineTool({
   name: 'list_network_requests',
@@ -58,12 +61,7 @@ export const listNetworkRequests = defineTool({
       ),
     resourceTypes: z
       .array(
-        z.enum(
-          FILTERABLE_RESOURCE_TYPES as unknown as [
-            ResourceType,
-            ...ResourceType[],
-          ],
-        ),
+        z.enum(FILTERABLE_RESOURCE_TYPES),
       )
       .optional()
       .describe(

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -65,7 +65,7 @@ export const listNetworkRequests = defineTool({
       )
       .optional()
       .describe(
-        'Filter requests to only return requests of the specified resource types. When omitted, returns all requests.',
+        'Filter requests to only return requests of the specified resource types. When omitted or empty, returns all requests.',
       ),
   },
   handler: async (request, response) => {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -67,7 +67,7 @@ export const listNetworkRequests = defineTool({
       )
       .optional()
       .describe(
-        'Filter requests by resource type. When omitted, returns all requests.',
+        'Filter requests to only return requests of the specified resource types. When omitted, returns all requests.',
       ),
   },
   handler: async (request, response) => {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ResourceType} from 'puppeteer-core';
+import type { ResourceType } from 'puppeteer-core';
 import z from 'zod';
 
-import {ToolCategories} from './categories.js';
-import {defineTool} from './ToolDefinition.js';
+import { ToolCategories } from './categories.js';
+import { defineTool } from './ToolDefinition.js';
 
 const FILTERABLE_RESOURCE_TYPES = [
   'document',
@@ -56,7 +56,7 @@ export const listNetworkRequests = defineTool({
       .describe(
         'Page number to return (0-based). When omitted, returns the first page.',
       ),
-    resourceType: z
+    resourceTypes: z
       .array(
         z.enum(
           FILTERABLE_RESOURCE_TYPES as unknown as [
@@ -74,7 +74,7 @@ export const listNetworkRequests = defineTool({
     response.setIncludeNetworkRequests(true, {
       pageSize: request.params.pageSize,
       pageIdx: request.params.pageIdx,
-      resourceTypes: request.params.resourceType,
+      resourceTypes: request.params.resourceTypes,
     });
   },
 });

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -4,36 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ResourceType } from 'puppeteer-core';
+import type {ResourceType} from 'puppeteer-core';
 import z from 'zod';
 
-import { ToolCategories } from './categories.js';
-import { defineTool } from './ToolDefinition.js';
+import {ToolCategories} from './categories.js';
+import {defineTool} from './ToolDefinition.js';
 
-const FILTERABLE_RESOURCE_TYPES: readonly [
-  ResourceType,
-  ...ResourceType[],
-] = [
-    'document',
-    'stylesheet',
-    'image',
-    'media',
-    'font',
-    'script',
-    'texttrack',
-    'xhr',
-    'fetch',
-    'prefetch',
-    'eventsource',
-    'websocket',
-    'manifest',
-    'signedexchange',
-    'ping',
-    'cspviolationreport',
-    'preflight',
-    'fedcm',
-    'other',
-  ];
+const FILTERABLE_RESOURCE_TYPES: readonly [ResourceType, ...ResourceType[]] = [
+  'document',
+  'stylesheet',
+  'image',
+  'media',
+  'font',
+  'script',
+  'texttrack',
+  'xhr',
+  'fetch',
+  'prefetch',
+  'eventsource',
+  'websocket',
+  'manifest',
+  'signedexchange',
+  'ping',
+  'cspviolationreport',
+  'preflight',
+  'fedcm',
+  'other',
+];
 
 export const listNetworkRequests = defineTool({
   name: 'list_network_requests',
@@ -60,9 +57,7 @@ export const listNetworkRequests = defineTool({
         'Page number to return (0-based). When omitted, returns the first page.',
       ),
     resourceTypes: z
-      .array(
-        z.enum(FILTERABLE_RESOURCE_TYPES),
-      )
+      .array(z.enum(FILTERABLE_RESOURCE_TYPES))
       .optional()
       .describe(
         'Filter requests to only return requests of the specified resource types. When omitted or empty, returns all requests.',

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ResourceType } from 'puppeteer-core';
+import type {ResourceType} from 'puppeteer-core';
 import z from 'zod';
 
-import { ToolCategories } from './categories.js';
-import { defineTool } from './ToolDefinition.js';
+import {ToolCategories} from './categories.js';
+import {defineTool} from './ToolDefinition.js';
 
 const FILTERABLE_RESOURCE_TYPES = [
   'document',
@@ -57,7 +57,14 @@ export const listNetworkRequests = defineTool({
         'Page number to return (0-based). When omitted, returns the first page.',
       ),
     resourceType: z
-      .array(z.enum(FILTERABLE_RESOURCE_TYPES as any))
+      .array(
+        z.enum(
+          FILTERABLE_RESOURCE_TYPES as unknown as [
+            ResourceType,
+            ...ResourceType[],
+          ],
+        ),
+      )
       .optional()
       .describe(
         'Filter requests by resource type. When omitted, returns all requests.',

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -4,10 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { ResourceType } from 'puppeteer-core';
 import z from 'zod';
 
-import {ToolCategories} from './categories.js';
-import {defineTool} from './ToolDefinition.js';
+import { ToolCategories } from './categories.js';
+import { defineTool } from './ToolDefinition.js';
+
+export const FILTERABLE_RESOURCE_TYPES = [
+  'document',
+  'stylesheet',
+  'image',
+  'media',
+  'font',
+  'script',
+  'texttrack',
+  'xhr',
+  'fetch',
+  'prefetch',
+  'eventsource',
+  'websocket',
+  'manifest',
+  'signedexchange',
+  'ping',
+  'cspviolationreport',
+  'preflight',
+  'fedcm',
+  'other',
+] as const satisfies readonly ResourceType[];
 
 export const listNetworkRequests = defineTool({
   name: 'list_network_requests',
@@ -33,11 +56,18 @@ export const listNetworkRequests = defineTool({
       .describe(
         'Page number to return (0-based). When omitted, returns the first page.',
       ),
+    resourceType: z
+      .array(z.enum(FILTERABLE_RESOURCE_TYPES as any))
+      .optional()
+      .describe(
+        'Filter requests by resource type. When omitted, returns all requests.',
+      ),
   },
   handler: async (request, response) => {
     response.setIncludeNetworkRequests(true, {
       pageSize: request.params.pageSize,
       pageIdx: request.params.pageIdx,
+      resourceTypes: request.params.resourceType,
     });
   },
 });

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import assert from 'node:assert';
-import {describe, it} from 'node:test';
+import { describe, it } from 'node:test';
 
-import {getMockRequest, html, withBrowser} from './utils.js';
+import { getMockRequest, html, withBrowser } from './utils.js';
 
 describe('McpResponse', () => {
   it('list pages', async () => {
@@ -120,7 +120,7 @@ Navigation timeout set to 100000 ms`,
   });
   it('adds image when image is attached', async () => {
     await withBrowser(async (response, context) => {
-      response.attachImage({data: 'imageBase64', mimeType: 'image/png'});
+      response.attachImage({ data: 'imageBase64', mimeType: 'image/png' });
       const result = await response.handle('test', context);
       assert.strictEqual(result[0].text, `# test response`);
       assert.equal(result[1].type, 'image');
@@ -273,10 +273,10 @@ describe('McpResponse network request filtering', () => {
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({resourceType: 'script'}),
-          getMockRequest({resourceType: 'image'}),
-          getMockRequest({resourceType: 'stylesheet'}),
-          getMockRequest({resourceType: 'document'}),
+          getMockRequest({ resourceType: 'script' }),
+          getMockRequest({ resourceType: 'image' }),
+          getMockRequest({ resourceType: 'stylesheet' }),
+          getMockRequest({ resourceType: 'document' }),
         ];
       };
       const result = await response.handle('test', context);
@@ -298,9 +298,9 @@ http://example.com GET [pending]`,
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({resourceType: 'script'}),
-          getMockRequest({resourceType: 'image'}),
-          getMockRequest({resourceType: 'stylesheet'}),
+          getMockRequest({ resourceType: 'script' }),
+          getMockRequest({ resourceType: 'image' }),
+          getMockRequest({ resourceType: 'stylesheet' }),
         ];
       };
       const result = await response.handle('test', context);
@@ -321,9 +321,9 @@ http://example.com GET [pending]`,
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({resourceType: 'script'}),
-          getMockRequest({resourceType: 'image'}),
-          getMockRequest({resourceType: 'stylesheet'}),
+          getMockRequest({ resourceType: 'script' }),
+          getMockRequest({ resourceType: 'image' }),
+          getMockRequest({ resourceType: 'stylesheet' }),
         ];
       };
       const result = await response.handle('test', context);
@@ -341,11 +341,40 @@ No requests found.`,
       response.setIncludeNetworkRequests(true);
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({resourceType: 'script'}),
-          getMockRequest({resourceType: 'image'}),
-          getMockRequest({resourceType: 'stylesheet'}),
-          getMockRequest({resourceType: 'document'}),
-          getMockRequest({resourceType: 'font'}),
+          getMockRequest({ resourceType: 'script' }),
+          getMockRequest({ resourceType: 'image' }),
+          getMockRequest({ resourceType: 'stylesheet' }),
+          getMockRequest({ resourceType: 'document' }),
+          getMockRequest({ resourceType: 'font' }),
+        ];
+      };
+      const result = await response.handle('test', context);
+      assert.strictEqual(
+        result[0].text,
+        `# test response
+## Network requests
+Showing 1-5 of 5 (Page 1 of 1).
+http://example.com GET [pending]
+http://example.com GET [pending]
+http://example.com GET [pending]
+http://example.com GET [pending]
+http://example.com GET [pending]`,
+      );
+    });
+  });
+
+  it('shows all requests when empty resourceTypes array is provided', async () => {
+    await withBrowser(async (response, context) => {
+      response.setIncludeNetworkRequests(true, {
+        resourceTypes: [],
+      });
+      context.getNetworkRequests = () => {
+        return [
+          getMockRequest({ resourceType: 'script' }),
+          getMockRequest({ resourceType: 'image' }),
+          getMockRequest({ resourceType: 'stylesheet' }),
+          getMockRequest({ resourceType: 'document' }),
+          getMockRequest({ resourceType: 'font' }),
         ];
       };
       const result = await response.handle('test', context);
@@ -367,7 +396,7 @@ http://example.com GET [pending]`,
 describe('McpResponse network pagination', () => {
   it('returns all requests when pagination is not provided', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({length: 5}, () => getMockRequest());
+      const requests = Array.from({ length: 5 }, () => getMockRequest());
       context.getNetworkRequests = () => requests;
       response.setIncludeNetworkRequests(true);
       const result = await response.handle('test', context);
@@ -380,13 +409,13 @@ describe('McpResponse network pagination', () => {
 
   it('returns first page by default', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({length: 30}, (_, idx) =>
-        getMockRequest({method: `GET-${idx}`}),
+      const requests = Array.from({ length: 30 }, (_, idx) =>
+        getMockRequest({ method: `GET-${idx}` }),
       );
       context.getNetworkRequests = () => {
         return requests;
       };
-      response.setIncludeNetworkRequests(true, {pageSize: 10});
+      response.setIncludeNetworkRequests(true, { pageSize: 10 });
       const result = await response.handle('test', context);
       const text = (result[0].text as string).toString();
       assert.ok(text.includes('Showing 1-10 of 30 (Page 1 of 3).'));
@@ -397,8 +426,8 @@ describe('McpResponse network pagination', () => {
 
   it('returns subsequent page when pageIdx provided', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({length: 25}, (_, idx) =>
-        getMockRequest({method: `GET-${idx}`}),
+      const requests = Array.from({ length: 25 }, (_, idx) =>
+        getMockRequest({ method: `GET-${idx}` }),
       );
       context.getNetworkRequests = () => requests;
       response.setIncludeNetworkRequests(true, {
@@ -415,7 +444,7 @@ describe('McpResponse network pagination', () => {
 
   it('handles invalid page number by showing first page', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({length: 5}, () => getMockRequest());
+      const requests = Array.from({ length: 5 }, () => getMockRequest());
       context.getNetworkRequests = () => requests;
       response.setIncludeNetworkRequests(true, {
         pageSize: 2,

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import assert from 'node:assert';
-import { describe, it } from 'node:test';
+import {describe, it} from 'node:test';
 
-import { getMockRequest, html, withBrowser } from './utils.js';
+import {getMockRequest, html, withBrowser} from './utils.js';
 
 describe('McpResponse', () => {
   it('list pages', async () => {
@@ -120,7 +120,7 @@ Navigation timeout set to 100000 ms`,
   });
   it('adds image when image is attached', async () => {
     await withBrowser(async (response, context) => {
-      response.attachImage({ data: 'imageBase64', mimeType: 'image/png' });
+      response.attachImage({data: 'imageBase64', mimeType: 'image/png'});
       const result = await response.handle('test', context);
       assert.strictEqual(result[0].text, `# test response`);
       assert.equal(result[1].type, 'image');
@@ -273,10 +273,10 @@ describe('McpResponse network request filtering', () => {
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({ resourceType: 'script' }),
-          getMockRequest({ resourceType: 'image' }),
-          getMockRequest({ resourceType: 'stylesheet' }),
-          getMockRequest({ resourceType: 'document' }),
+          getMockRequest({resourceType: 'script'}),
+          getMockRequest({resourceType: 'image'}),
+          getMockRequest({resourceType: 'stylesheet'}),
+          getMockRequest({resourceType: 'document'}),
         ];
       };
       const result = await response.handle('test', context);
@@ -298,9 +298,9 @@ http://example.com GET [pending]`,
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({ resourceType: 'script' }),
-          getMockRequest({ resourceType: 'image' }),
-          getMockRequest({ resourceType: 'stylesheet' }),
+          getMockRequest({resourceType: 'script'}),
+          getMockRequest({resourceType: 'image'}),
+          getMockRequest({resourceType: 'stylesheet'}),
         ];
       };
       const result = await response.handle('test', context);
@@ -321,9 +321,9 @@ http://example.com GET [pending]`,
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({ resourceType: 'script' }),
-          getMockRequest({ resourceType: 'image' }),
-          getMockRequest({ resourceType: 'stylesheet' }),
+          getMockRequest({resourceType: 'script'}),
+          getMockRequest({resourceType: 'image'}),
+          getMockRequest({resourceType: 'stylesheet'}),
         ];
       };
       const result = await response.handle('test', context);
@@ -341,11 +341,11 @@ No requests found.`,
       response.setIncludeNetworkRequests(true);
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({ resourceType: 'script' }),
-          getMockRequest({ resourceType: 'image' }),
-          getMockRequest({ resourceType: 'stylesheet' }),
-          getMockRequest({ resourceType: 'document' }),
-          getMockRequest({ resourceType: 'font' }),
+          getMockRequest({resourceType: 'script'}),
+          getMockRequest({resourceType: 'image'}),
+          getMockRequest({resourceType: 'stylesheet'}),
+          getMockRequest({resourceType: 'document'}),
+          getMockRequest({resourceType: 'font'}),
         ];
       };
       const result = await response.handle('test', context);
@@ -370,11 +370,11 @@ http://example.com GET [pending]`,
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({ resourceType: 'script' }),
-          getMockRequest({ resourceType: 'image' }),
-          getMockRequest({ resourceType: 'stylesheet' }),
-          getMockRequest({ resourceType: 'document' }),
-          getMockRequest({ resourceType: 'font' }),
+          getMockRequest({resourceType: 'script'}),
+          getMockRequest({resourceType: 'image'}),
+          getMockRequest({resourceType: 'stylesheet'}),
+          getMockRequest({resourceType: 'document'}),
+          getMockRequest({resourceType: 'font'}),
         ];
       };
       const result = await response.handle('test', context);
@@ -396,7 +396,7 @@ http://example.com GET [pending]`,
 describe('McpResponse network pagination', () => {
   it('returns all requests when pagination is not provided', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({ length: 5 }, () => getMockRequest());
+      const requests = Array.from({length: 5}, () => getMockRequest());
       context.getNetworkRequests = () => requests;
       response.setIncludeNetworkRequests(true);
       const result = await response.handle('test', context);
@@ -409,13 +409,13 @@ describe('McpResponse network pagination', () => {
 
   it('returns first page by default', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({ length: 30 }, (_, idx) =>
-        getMockRequest({ method: `GET-${idx}` }),
+      const requests = Array.from({length: 30}, (_, idx) =>
+        getMockRequest({method: `GET-${idx}`}),
       );
       context.getNetworkRequests = () => {
         return requests;
       };
-      response.setIncludeNetworkRequests(true, { pageSize: 10 });
+      response.setIncludeNetworkRequests(true, {pageSize: 10});
       const result = await response.handle('test', context);
       const text = (result[0].text as string).toString();
       assert.ok(text.includes('Showing 1-10 of 30 (Page 1 of 3).'));
@@ -426,8 +426,8 @@ describe('McpResponse network pagination', () => {
 
   it('returns subsequent page when pageIdx provided', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({ length: 25 }, (_, idx) =>
-        getMockRequest({ method: `GET-${idx}` }),
+      const requests = Array.from({length: 25}, (_, idx) =>
+        getMockRequest({method: `GET-${idx}`}),
       );
       context.getNetworkRequests = () => requests;
       response.setIncludeNetworkRequests(true, {
@@ -444,7 +444,7 @@ describe('McpResponse network pagination', () => {
 
   it('handles invalid page number by showing first page', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({ length: 5 }, () => getMockRequest());
+      const requests = Array.from({length: 5}, () => getMockRequest());
       context.getNetworkRequests = () => requests;
       response.setIncludeNetworkRequests(true, {
         pageSize: 2,

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import assert from 'node:assert';
-import { describe, it } from 'node:test';
+import {describe, it} from 'node:test';
 
-import { getMockRequest, html, withBrowser } from './utils.js';
+import {getMockRequest, html, withBrowser} from './utils.js';
 
 describe('McpResponse', () => {
   it('list pages', async () => {
@@ -120,7 +120,7 @@ Navigation timeout set to 100000 ms`,
   });
   it('adds image when image is attached', async () => {
     await withBrowser(async (response, context) => {
-      response.attachImage({ data: 'imageBase64', mimeType: 'image/png' });
+      response.attachImage({data: 'imageBase64', mimeType: 'image/png'});
       const result = await response.handle('test', context);
       assert.strictEqual(result[0].text, `# test response`);
       assert.equal(result[1].type, 'image');
@@ -273,10 +273,10 @@ describe('McpResponse network request filtering', () => {
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({ resourceType: 'script' }),
-          getMockRequest({ resourceType: 'image' }),
-          getMockRequest({ resourceType: 'stylesheet' }),
-          getMockRequest({ resourceType: 'document' }),
+          getMockRequest({resourceType: 'script'}),
+          getMockRequest({resourceType: 'image'}),
+          getMockRequest({resourceType: 'stylesheet'}),
+          getMockRequest({resourceType: 'document'}),
         ];
       };
       const result = await response.handle('test', context);
@@ -298,9 +298,9 @@ http://example.com GET [pending]`,
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({ resourceType: 'script' }),
-          getMockRequest({ resourceType: 'image' }),
-          getMockRequest({ resourceType: 'stylesheet' }),
+          getMockRequest({resourceType: 'script'}),
+          getMockRequest({resourceType: 'image'}),
+          getMockRequest({resourceType: 'stylesheet'}),
         ];
       };
       const result = await response.handle('test', context);
@@ -321,9 +321,9 @@ http://example.com GET [pending]`,
       });
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({ resourceType: 'script' }),
-          getMockRequest({ resourceType: 'image' }),
-          getMockRequest({ resourceType: 'stylesheet' }),
+          getMockRequest({resourceType: 'script'}),
+          getMockRequest({resourceType: 'image'}),
+          getMockRequest({resourceType: 'stylesheet'}),
         ];
       };
       const result = await response.handle('test', context);
@@ -341,11 +341,11 @@ No requests found.`,
       response.setIncludeNetworkRequests(true);
       context.getNetworkRequests = () => {
         return [
-          getMockRequest({ resourceType: 'script' }),
-          getMockRequest({ resourceType: 'image' }),
-          getMockRequest({ resourceType: 'stylesheet' }),
-          getMockRequest({ resourceType: 'document' }),
-          getMockRequest({ resourceType: 'font' }),
+          getMockRequest({resourceType: 'script'}),
+          getMockRequest({resourceType: 'image'}),
+          getMockRequest({resourceType: 'stylesheet'}),
+          getMockRequest({resourceType: 'document'}),
+          getMockRequest({resourceType: 'font'}),
         ];
       };
       const result = await response.handle('test', context);
@@ -367,7 +367,7 @@ http://example.com GET [pending]`,
 describe('McpResponse network pagination', () => {
   it('returns all requests when pagination is not provided', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({ length: 5 }, () => getMockRequest());
+      const requests = Array.from({length: 5}, () => getMockRequest());
       context.getNetworkRequests = () => requests;
       response.setIncludeNetworkRequests(true);
       const result = await response.handle('test', context);
@@ -380,13 +380,13 @@ describe('McpResponse network pagination', () => {
 
   it('returns first page by default', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({ length: 30 }, (_, idx) =>
-        getMockRequest({ method: `GET-${idx}` }),
+      const requests = Array.from({length: 30}, (_, idx) =>
+        getMockRequest({method: `GET-${idx}`}),
       );
       context.getNetworkRequests = () => {
         return requests;
       };
-      response.setIncludeNetworkRequests(true, { pageSize: 10 });
+      response.setIncludeNetworkRequests(true, {pageSize: 10});
       const result = await response.handle('test', context);
       const text = (result[0].text as string).toString();
       assert.ok(text.includes('Showing 1-10 of 30 (Page 1 of 3).'));
@@ -397,8 +397,8 @@ describe('McpResponse network pagination', () => {
 
   it('returns subsequent page when pageIdx provided', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({ length: 25 }, (_, idx) =>
-        getMockRequest({ method: `GET-${idx}` }),
+      const requests = Array.from({length: 25}, (_, idx) =>
+        getMockRequest({method: `GET-${idx}`}),
       );
       context.getNetworkRequests = () => requests;
       response.setIncludeNetworkRequests(true, {
@@ -415,7 +415,7 @@ describe('McpResponse network pagination', () => {
 
   it('handles invalid page number by showing first page', async () => {
     await withBrowser(async (response, context) => {
-      const requests = Array.from({ length: 5 }, () => getMockRequest());
+      const requests = Array.from({length: 5}, () => getMockRequest());
       context.getNetworkRequests = () => requests;
       response.setIncludeNetworkRequests(true, {
         pageSize: 2,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -5,20 +5,20 @@
  */
 
 import logger from 'debug';
-import type {Browser} from 'puppeteer';
+import type { Browser } from 'puppeteer';
 import puppeteer from 'puppeteer';
-import type {HTTPRequest, HTTPResponse} from 'puppeteer-core';
+import type { HTTPRequest, HTTPResponse } from 'puppeteer-core';
 
-import {McpContext} from '../src/McpContext.js';
-import {McpResponse} from '../src/McpResponse.js';
+import { McpContext } from '../src/McpContext.js';
+import { McpResponse } from '../src/McpResponse.js';
 
 let browser: Browser | undefined;
 
 export async function withBrowser(
   cb: (response: McpResponse, context: McpContext) => Promise<void>,
-  options: {debug?: boolean} = {},
+  options: { debug?: boolean } = {},
 ) {
-  const {debug = false} = options;
+  const { debug = false } = options;
   if (!browser) {
     browser = await puppeteer.launch({
       executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
@@ -46,6 +46,7 @@ export function getMockRequest(
     method?: string;
     response?: HTTPResponse;
     failure?: HTTPRequest['failure'];
+    resourceType?: string;
   } = {},
 ): HTTPRequest {
   return {
@@ -60,6 +61,9 @@ export function getMockRequest(
     },
     failure() {
       return options.failure?.() ?? null;
+    },
+    resourceType() {
+      return options.resourceType ?? 'document';
     },
     headers(): Record<string, string> {
       return {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -5,20 +5,20 @@
  */
 
 import logger from 'debug';
-import type { Browser } from 'puppeteer';
+import type {Browser} from 'puppeteer';
 import puppeteer from 'puppeteer';
-import type { HTTPRequest, HTTPResponse } from 'puppeteer-core';
+import type {HTTPRequest, HTTPResponse} from 'puppeteer-core';
 
-import { McpContext } from '../src/McpContext.js';
-import { McpResponse } from '../src/McpResponse.js';
+import {McpContext} from '../src/McpContext.js';
+import {McpResponse} from '../src/McpResponse.js';
 
 let browser: Browser | undefined;
 
 export async function withBrowser(
   cb: (response: McpResponse, context: McpContext) => Promise<void>,
-  options: { debug?: boolean } = {},
+  options: {debug?: boolean} = {},
 ) {
-  const { debug = false } = options;
+  const {debug = false} = options;
   if (!browser) {
     browser = await puppeteer.launch({
       executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,


### PR DESCRIPTION
### Summary
This PR build upon #145 to also adds filtering by resource type to `list_network_requests` (Also see: #137 and #107).

### Motivation
Agents often need specific request types (e.g., scripts, stylesheets, images). Filtering reduces noise and improves performance.

### Changes
- **New parameter**: `resourceType` (array) to filter by resource types
- **Supported types**: all resource types supported by Puppeteer
- **Backward compatible**: when omitted, returns all requests

Filtering runs before pagination, so pagination applies to the filtered results.