### PR TITLE
chore: roll latest chrome-devtools-frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/yargs": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
-        "chrome-devtools-frontend": "1.0.1520139",
+        "chrome-devtools-frontend": "1.0.1520535",
         "eslint": "^9.35.0",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/chrome-devtools-frontend": {
-      "version": "1.0.1520139",
-      "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.1520139.tgz",
-      "integrity": "sha512-sebWwMkX6TZ/qa5R+1luGhjlUjbEBSm3jtmCPVTaXk8g3pY1ys8Rpb59FxKcmAKEDoaa0mIO4OAXLGR9GEyfhA==",
+      "version": "1.0.1520535",
+      "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.1520535.tgz",
+      "integrity": "sha512-kCjiu7ZQ3vLNQ5hmmQZRwwpGpQykJECWuDUc3nKjXOOsMEWgJJh+3OhG6vOrtEG5BxL9jWZoBvf1GG8ddNpkeg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
-    "chrome-devtools-frontend": "1.0.1520139",
+    "chrome-devtools-frontend": "1.0.1520535",
     "eslint": "^9.35.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/src/trace-processing/parse.ts
+++ b/src/trace-processing/parse.ts
@@ -75,10 +75,7 @@ export async function parseRawTraceBuffer(
 
 export function getTraceSummary(result: TraceResult): string {
   const focus = AgentFocus.fromParsedTrace(result.parsedTrace);
-  const formatter = new PerformanceTraceFormatter(
-    focus,
-    PerformanceInsightFormatter.create,
-  );
+  const formatter = new PerformanceTraceFormatter(focus);
   const output = formatter.formatTraceSummary();
   return output;
 }

--- a/tests/tools/performance.test.js.snapshot
+++ b/tests/tools/performance.test.js.snapshot
@@ -6,7 +6,7 @@ This insight is used to analyze the time spent that contributed to the final LCP
 
 ## Detailed analysis:
 The Largest Contentful Paint (LCP) time for this navigation was 129 ms.
-The LCP element is an image fetched from https://web-dev.imgix.net/image/kheDArv5csY6rvQUJDbWRscckLr1/4i7JstVZvgTFk9dxCe4a.svg (eventKey: s-1314).
+The LCP element is an image fetched from https://web-dev.imgix.net/image/kheDArv5csY6rvQUJDbWRscckLr1/4i7JstVZvgTFk9dxCe4a.svg (eventKey: s-1314, ts: 122411037986).
 ## LCP resource network request: https://web-dev.imgix.net/image/kheDArv5csY6rvQUJDbWRscckLr1/4i7JstVZvgTFk9dxCe4a.svg
 eventKey: s-1314
 Timings:


### PR DESCRIPTION
This includes a better fix for the circular dependency problem and makes
the changes in the MCP server based on the upstream DevTools
implementation changes.
