### PR TITLE
Update McpContext.ts

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -261,7 +261,7 @@ export class McpContext implements Context {
 
   async getElementByUid(uid: string): Promise<ElementHandle<Element>> {
     if (!this.#textSnapshot?.idToNode.size) {
-      throw new Error('No snapshot found. Use browser_snapshot to capture one');
+      throw new Error('No snapshot found. Use take_snapshot to capture one');
     }
     const [snapshotId] = uid.split('_');
 


### PR DESCRIPTION
on the line **273** i have changed  error message . where using  langchain user navigating to wrong commentword

async getElementByUid(uid: string): Promise<ElementHandle<Element>> {
  if (!this.#textSnapshot?.idToNode.size) {
    throw new Error('No snapshot found. Use browser_snapshot to capture one'); // <-- THIS LINE
  }
  // ... rest of the method
}
........the above error message to : throw new Error('No snapshot found. Use take_snapshot to capture one'); ...............as new crome changes to browse_snapshot >> take_snapshot