### PR TITLE
Fix: update error message to use take_snapshot instead of browser_snapshot

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -261,7 +261,8 @@ export class McpContext implements Context {
 
   async getElementByUid(uid: string): Promise<ElementHandle<Element>> {
     if (!this.#textSnapshot?.idToNode.size) {
-      throw new Error('No snapshot found. Use browser_snapshot to capture one');
+      throw new Error('No snapshot found. Use take_snapshot to capture one');
+
     }
     const [snapshotId] = uid.split('_');
 


### PR DESCRIPTION
Updated error message to reflect correct tool name (take_snapshot) instead of outdated browser_snapshot.

Fixes confusion for clients like LangChain.