### PR TITLE
feat: add --loadExtension flag support for Chrome extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Claude Code
+CLAUDE.md
+.claude/
+
 # Logs
 logs
 *.log
@@ -145,4 +149,78 @@ build/
 
 log.txt
 
+# OS specific
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+Desktop.ini
+
+# IDE and Editor
+.idea/
+*.swp
+*.swo
+*~
+*.sublime-project
+*.sublime-workspace
+
+# Chrome/Puppeteer specific
+.puppeteer_cache/
+chrome-profile-*/
+user-data-dir/
+
+# MCP specific
+.mcp-cache/
+mcp-logs/
+*.heapsnapshot
+*.cpuprofile
+*.trace
+
+# Claude specific
+.claude/
+docs/log/claude/
+CLAUDE.local.md
+
+# Extension development (for testing)
+test-extension/
+test-extensions/
+sample-extensions/
+*.crx
+*.pem
+unpacked-extensions/
+
+# Debug and profiling
+debug.log*
+*.log.*
+
+# Backup files
+*.bak
+*.backup
+*.old
+*.orig
+
+# Package manager specific (but keep lock files)
+.pnpm-store/
+
+# Temporary files
+.tmp/
+*.tmp
+temp/
+tmp/
+
+# Test specific
+test-results/
+test-output/
+
+# Documentation build
+docs/_build/
+docs/.docusaurus/
+
+# Misc
+.history/
+.prettierignore
+*.pid.lock
+*.seed

--- a/TEST_SCENARIOS.md
+++ b/TEST_SCENARIOS.md
@@ -1,0 +1,148 @@
+# Chrome拡張機能開発ツール テストシナリオ
+
+## 🎯 基本機能テスト
+
+### 1. 拡張機能管理機能
+
+```
+navigate_extensions_page
+list_extensions
+```
+
+**期待結果**:
+
+- chrome://extensions/ ページが開く
+- "Test Extension for MCP" が一覧に表示される
+- 拡張機能の状態（有効/無効、バージョン等）が確認できる
+
+### 2. 拡張機能リロード機能
+
+```
+reload_extension extensionName="Test Extension"
+```
+
+**期待結果**:
+
+- 拡張機能が正常にリロードされる
+- 成功メッセージが表示される
+
+### 3. エラー検出機能
+
+```
+get_extension_errors extensionName="Test Extension"
+```
+
+**期待結果**:
+
+- エラー数が表示される（意図的エラーがある場合）
+- エラーがない場合は正常メッセージ
+
+## 🔍 ストレージ操作テスト
+
+### 4. ストレージ読み取り
+
+```
+get_extension_storage storageType="local"
+```
+
+**期待結果**:
+
+```json
+{
+  "test_key": "test_value",
+  "timestamp": 1234567890,
+  "counter": 5,
+  "page_visits": [...]
+}
+```
+
+### 5. ストレージ書き込み
+
+```
+set_extension_storage storageType="local" data={"mcp_test": "hello", "debug_mode": true}
+```
+
+**期待結果**:
+
+- データが正常に書き込まれる
+- 確認のため再度 get_extension_storage で検証
+
+### 6. ストレージクリア
+
+```
+clear_extension_storage storageType="local" keys=["mcp_test"]
+```
+
+**期待結果**:
+
+- 指定したキーのみが削除される
+- 他のデータは残る
+
+## 🛠 デバッグ機能テスト
+
+### 7. Service Worker 検査
+
+```
+inspect_service_worker extensionName="Test Extension"
+```
+
+**期待結果**:
+
+- Service Worker の開発者ツールが開く
+- コンソールログが確認できる
+- "Test Extension: Background script loaded" などのログが見える
+
+## 🔄 統合テストシナリオ
+
+### 8. 拡張機能開発ワークフロー
+
+1. `list_extensions` で現在の状態確認
+2. `get_extension_storage` でデータ確認
+3. `set_extension_storage` でテストデータ追加
+4. `reload_extension` で変更適用
+5. `inspect_service_worker` でデバッグ
+6. `get_extension_errors` でエラーチェック
+
+### 9. エラー発生・修正ワークフロー
+
+1. Popup から "Cause Error" ボタンクリック
+2. `get_extension_errors` でエラー検出
+3. `inspect_service_worker` でエラー詳細確認
+4. コード修正後 `reload_extension`
+5. `get_extension_errors` でエラー解消確認
+
+## 🎨 UI/UX改善提案テスト
+
+### 10. 使いやすさの検証
+
+- エラーメッセージの分かりやすさ
+- 成功時のフィードバックの適切さ
+- 操作手順の直感性
+- 必要な情報の網羅性
+
+## 📊 パフォーマンステスト
+
+### 11. 大量データでの動作確認
+
+- 多数の拡張機能がある環境
+- 大量のストレージデータがある場合
+- 長時間稼働している拡張機能
+
+## 💡 改善アイデア収集
+
+### テスト中に検討したい項目
+
+- [ ] もっと知りたい拡張機能の情報は？
+- [ ] 操作が煩雑に感じる部分は？
+- [ ] エラーメッセージで理解しにくい部分は？
+- [ ] 追加したい機能は？
+- [ ] 自動化できそうな操作は？
+
+## 🚨 エラーケース
+
+### 12. 異常系テスト
+
+- 存在しない拡張機能名を指定
+- 無効な拡張機能を操作
+- ストレージAPIが利用できないページで実行
+- 権限のない操作を実行

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -63,11 +63,12 @@ interface McpLaunchOptions {
   userDataDir?: string;
   headless: boolean;
   isolated: boolean;
+  loadExtension?: string;
   logFile?: fs.WriteStream;
 }
 
 export async function launch(options: McpLaunchOptions): Promise<Browser> {
-  const {channel, executablePath, customDevTools, headless, isolated} = options;
+  const {channel, executablePath, customDevTools, headless, isolated, loadExtension} = options;
   const profileDirName =
     channel && channel !== 'stable'
       ? `chrome-profile-${channel}`
@@ -89,6 +90,10 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
   const args: LaunchOptions['args'] = ['--hide-crash-restore-bubble'];
   if (customDevTools) {
     args.push(`--custom-devtools-frontend=file://${customDevTools}`);
+  }
+  if (loadExtension) {
+    args.push(`--load-extension=${loadExtension}`);
+    args.push('--enable-experimental-extension-apis');
   }
   let puppeterChannel: ChromeReleaseChannel | undefined;
   if (!executablePath) {
@@ -151,6 +156,7 @@ export async function resolveBrowser(options: {
   channel?: Channel;
   headless: boolean;
   isolated: boolean;
+  loadExtension?: string;
   logFile?: fs.WriteStream;
 }) {
   const browser = options.browserUrl

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,12 @@ export const cliOptions = {
       'Load an unpacked Chrome extension from the specified directory path.',
     conflicts: 'browserUrl',
   },
+  loadExtensionsDir: {
+    type: 'string' as const,
+    description:
+      'Load all unpacked Chrome extensions from the specified directory. Each subdirectory with manifest.json will be loaded as an extension.',
+    conflicts: 'browserUrl',
+  },
   logFile: {
     type: 'string' as const,
     describe:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,12 @@ export const cliOptions = {
     choices: ['stable', 'canary', 'beta', 'dev'] as const,
     conflicts: ['browserUrl', 'executablePath'],
   },
+  loadExtension: {
+    type: 'string' as const,
+    description:
+      'Load an unpacked Chrome extension from the specified directory path.',
+    conflicts: 'browserUrl',
+  },
   logFile: {
     type: 'string' as const,
     describe:

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,7 @@ async function getContext(): Promise<McpContext> {
     customDevTools: args.customDevtools,
     channel: args.channel as Channel,
     isolated: args.isolated,
+    loadExtension: args.loadExtension,
     logFile,
   });
   if (context?.browser !== browser) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,8 +20,10 @@ import {logger, saveLogsToFile} from './logger.js';
 import {McpContext} from './McpContext.js';
 import {McpResponse} from './McpResponse.js';
 import {Mutex} from './Mutex.js';
+import * as bookmarkTools from './tools/bookmarks.js';
 import * as consoleTools from './tools/console.js';
 import * as emulationTools from './tools/emulation.js';
+import * as extensionTools from './tools/extensions.js';
 import * as inputTools from './tools/input.js';
 import * as networkTools from './tools/network.js';
 import * as pagesTools from './tools/pages.js';
@@ -74,7 +76,8 @@ async function getContext(): Promise<McpContext> {
     customDevTools: args.customDevtools,
     channel: args.channel as Channel,
     isolated: args.isolated,
-    loadExtension: args.loadExtension,
+    loadExtension: args.loadExtension as string | undefined,
+    loadExtensionsDir: args.loadExtensionsDir as string | undefined,
     logFile,
   });
   if (context?.browser !== browser) {
@@ -141,8 +144,10 @@ function registerTool(tool: ToolDefinition): void {
 }
 
 const tools = [
+  ...Object.values(bookmarkTools),
   ...Object.values(consoleTools),
   ...Object.values(emulationTools),
+  ...Object.values(extensionTools),
   ...Object.values(inputTools),
   ...Object.values(networkTools),
   ...Object.values(pagesTools),

--- a/src/tools/bookmarks.ts
+++ b/src/tools/bookmarks.ts
@@ -1,0 +1,237 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import z from 'zod';
+
+import {ToolCategories} from './categories.js';
+import {defineTool} from './ToolDefinition.js';
+
+// Read bookmarks from environment variables
+function getBookmarks(): Record<string, string> {
+  const bookmarksEnv = process.env.BOOKMARKS;
+  if (!bookmarksEnv) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(bookmarksEnv);
+  } catch (error) {
+    console.warn('Failed to parse BOOKMARKS environment variable:', error);
+    return {};
+  }
+}
+
+export const listBookmarks = defineTool({
+  name: 'list_bookmarks',
+  description: `List all available bookmarks configured in the MCP server. These bookmarks provide quick access to commonly used development URLs.`,
+  annotations: {
+    category: ToolCategories.NAVIGATION_AUTOMATION,
+    readOnlyHint: true,
+  },
+  schema: {},
+  handler: async (_request, response, _context) => {
+    const bookmarks = getBookmarks();
+    const bookmarkNames = Object.keys(bookmarks);
+
+    if (bookmarkNames.length === 0) {
+      response.appendResponseLine('No bookmarks configured.');
+      response.appendResponseLine('');
+      response.appendResponseLine(
+        '💡 **Tip:** Configure bookmarks using the BOOKMARKS environment variable in your MCP server settings.',
+      );
+      return;
+    }
+
+    response.appendResponseLine('📚 **Available Bookmarks:**');
+    response.appendResponseLine('');
+
+    bookmarkNames.forEach(name => {
+      const url = bookmarks[name];
+      response.appendResponseLine(`• **${name}**: ${url}`);
+    });
+
+    response.appendResponseLine('');
+    response.appendResponseLine(
+      `Use \`navigate_bookmark name="<bookmark_name>"\` to navigate to any of these URLs.`,
+    );
+  },
+});
+
+export const navigateBookmark = defineTool({
+  name: 'navigate_bookmark',
+  description: `Navigate to a predefined bookmark URL. Bookmarks are configured in the MCP server environment and provide quick access to commonly used development resources.`,
+  annotations: {
+    category: ToolCategories.NAVIGATION_AUTOMATION,
+    readOnlyHint: false,
+  },
+  schema: {
+    name: z
+      .string()
+      .describe(
+        'The name of the bookmark to navigate to. Use list_bookmarks to see available options.',
+      ),
+  },
+  handler: async (request, response, context) => {
+    const {name} = request.params;
+    const bookmarks = getBookmarks();
+
+    if (!bookmarks[name]) {
+      response.appendResponseLine(`❌ Bookmark "${name}" not found.`);
+      response.appendResponseLine('');
+
+      const availableBookmarks = Object.keys(bookmarks);
+      if (availableBookmarks.length > 0) {
+        response.appendResponseLine('Available bookmarks:');
+        availableBookmarks.forEach(bookmarkName => {
+          response.appendResponseLine(`• ${bookmarkName}`);
+        });
+      } else {
+        response.appendResponseLine('No bookmarks are currently configured.');
+      }
+      return;
+    }
+
+    const url = bookmarks[name];
+    const page = context.getSelectedPage();
+
+    await context.waitForEventsAfterAction(async () => {
+      await page.goto(url, {waitUntil: 'networkidle0'});
+      response.appendResponseLine(`✅ Navigated to bookmark "${name}": ${url}`);
+    });
+  },
+});
+
+export const openExtensionById = defineTool({
+  name: 'open_extension_by_id',
+  description: `Open a specific Chrome extension page by its ID. Useful for quickly accessing extension details, options, or management pages.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: false,
+  },
+  schema: {
+    extensionId: z
+      .string()
+      .describe('The Chrome extension ID (e.g., "abcdefghijklmnopqrstuvwxyz")'),
+    page: z
+      .enum(['details', 'options'])
+      .default('details')
+      .describe('The extension page to open'),
+  },
+  handler: async (request, response, context) => {
+    const {extensionId, page: extensionPage} = request.params;
+    const pageContext = context.getSelectedPage();
+
+    let url: string;
+    if (extensionPage === 'details') {
+      url = `chrome://extensions/?id=${extensionId}`;
+    } else {
+      url = `chrome-extension://${extensionId}/options.html`;
+    }
+
+    await context.waitForEventsAfterAction(async () => {
+      try {
+        await pageContext.goto(url, {waitUntil: 'networkidle0'});
+        response.appendResponseLine(
+          `✅ Opened ${extensionPage} page for extension: ${extensionId}`,
+        );
+      } catch (error) {
+        response.appendResponseLine(
+          `❌ Failed to open extension page: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        response.appendResponseLine('');
+        response.appendResponseLine('💡 **Possible reasons:**');
+        response.appendResponseLine(
+          '• Extension ID is invalid or extension is not installed',
+        );
+        response.appendResponseLine(
+          '• Extension does not have an options page (for options page requests)',
+        );
+        response.appendResponseLine('• Extension is disabled');
+      }
+    });
+  },
+});
+
+export const openWebstoreDashboard = defineTool({
+  name: 'open_webstore_dashboard',
+  description: `Open the Chrome Web Store developer dashboard. Provides quick access to extension management, analytics, and publishing tools.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: false,
+  },
+  schema: {},
+  handler: async (_request, response, context) => {
+    const page = context.getSelectedPage();
+    const dashboardUrl = 'https://chrome.google.com/webstore/devconsole';
+
+    await context.waitForEventsAfterAction(async () => {
+      await page.goto(dashboardUrl, {waitUntil: 'networkidle0'});
+      response.appendResponseLine(
+        '✅ Opened Chrome Web Store Developer Dashboard',
+      );
+      response.appendResponseLine('');
+      response.appendResponseLine('🚀 **Quick Actions Available:**');
+      response.appendResponseLine(
+        '• View and manage your published extensions',
+      );
+      response.appendResponseLine('• Check analytics and user feedback');
+      response.appendResponseLine('• Upload new versions or create new items');
+      response.appendResponseLine(
+        '• Review policy compliance and store listing details',
+      );
+    });
+  },
+});
+
+export const openExtensionDocs = defineTool({
+  name: 'open_extension_docs',
+  description: `Open the Chrome Extensions documentation. Provides access to the official development guides, API references, and best practices.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: false,
+  },
+  schema: {
+    section: z
+      .enum([
+        'overview',
+        'getting-started',
+        'api',
+        'manifest',
+        'examples',
+        'best-practices',
+      ])
+      .optional()
+      .describe('Specific documentation section to open'),
+  },
+  handler: async (request, response, context) => {
+    const {section} = request.params;
+    const page = context.getSelectedPage();
+
+    let url = 'https://developer.chrome.com/docs/extensions/';
+
+    if (section) {
+      const sectionUrls: Record<string, string> = {
+        overview: 'https://developer.chrome.com/docs/extensions/',
+        'getting-started':
+          'https://developer.chrome.com/docs/extensions/get-started/',
+        api: 'https://developer.chrome.com/docs/extensions/reference/',
+        manifest:
+          'https://developer.chrome.com/docs/extensions/reference/manifest',
+        examples: 'https://github.com/GoogleChrome/chrome-extensions-samples',
+        'best-practices':
+          'https://developer.chrome.com/docs/extensions/develop/migrate',
+      };
+      url = sectionUrls[section] || url;
+    }
+
+    await context.waitForEventsAfterAction(async () => {
+      await page.goto(url, {waitUntil: 'networkidle0'});
+      response.appendResponseLine(
+        `✅ Opened Chrome Extensions ${section ? `${section} ` : ''}documentation`,
+      );
+    });
+  },
+});

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -11,4 +11,5 @@ export enum ToolCategories {
   PERFORMANCE = 'Performance',
   NETWORK = 'Network',
   DEBUGGING = 'Debugging',
+  EXTENSION_DEVELOPMENT = 'Extension development',
 }

--- a/src/tools/extensions.ts
+++ b/src/tools/extensions.ts
@@ -1,0 +1,605 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import z from 'zod';
+
+import {ToolCategories} from './categories.js';
+import {defineTool} from './ToolDefinition.js';
+
+export const navigateExtensionsPage = defineTool({
+  name: 'navigate_extensions_page',
+  description: `Navigate to the Chrome extensions management page (chrome://extensions/) to view and manage installed extensions.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: true,
+  },
+  schema: {},
+  handler: async (_request, response, context) => {
+    const page = context.getSelectedPage();
+    await context.waitForEventsAfterAction(async () => {
+      await page.goto('chrome://extensions/', {waitUntil: 'networkidle0'});
+      response.appendResponseLine('Navigated to Chrome Extensions page');
+      response.appendResponseLine(
+        'You can now see all installed extensions, their status, and manage them.',
+      );
+    });
+  },
+});
+
+export const listExtensions = defineTool({
+  name: 'list_extensions',
+  description: `Get a list of all installed Chrome extensions with their status, ID, name, and enabled state.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: true,
+  },
+  schema: {},
+  handler: async (_request, response, context) => {
+    const page = context.getSelectedPage();
+
+    await context.waitForEventsAfterAction(async () => {
+      await page.goto('chrome://extensions/', {waitUntil: 'networkidle0'});
+
+      const extensions = await page.evaluate(() => {
+        const extensionCards = document.querySelectorAll('extensions-item');
+        const results: Array<{
+          id: string;
+          name: string;
+          enabled: boolean;
+          version: string;
+          description: string;
+        }> = [];
+
+        Array.from(extensionCards).forEach(card => {
+          const shadowRoot = card.shadowRoot;
+          if (shadowRoot) {
+            const name =
+              shadowRoot.querySelector('#name')?.textContent?.trim() ||
+              'Unknown';
+            const description =
+              shadowRoot.querySelector('#description')?.textContent?.trim() ||
+              '';
+            const version =
+              shadowRoot.querySelector('#version')?.textContent?.trim() || '';
+            const enabled = !shadowRoot
+              .querySelector('#enable-toggle')
+              ?.hasAttribute('disabled');
+            const id = card.getAttribute('id') || 'unknown';
+
+            results.push({
+              id,
+              name,
+              enabled,
+              version,
+              description,
+            });
+          }
+        });
+
+        return results;
+      });
+
+      response.appendResponseLine('Installed Chrome Extensions:');
+      response.appendResponseLine('');
+
+      if (extensions.length === 0) {
+        response.appendResponseLine('No extensions found.');
+      } else {
+        extensions.forEach((ext, index) => {
+          response.appendResponseLine(`${index + 1}. **${ext.name}**`);
+          response.appendResponseLine(`   - ID: ${ext.id}`);
+          response.appendResponseLine(`   - Version: ${ext.version}`);
+          response.appendResponseLine(
+            `   - Status: ${ext.enabled ? '✅ Enabled' : '❌ Disabled'}`,
+          );
+          response.appendResponseLine(`   - Description: ${ext.description}`);
+          response.appendResponseLine('');
+        });
+      }
+    });
+  },
+});
+
+export const reloadExtension = defineTool({
+  name: 'reload_extension',
+  description: `Reload a specific Chrome extension by its name or partial name match. Useful for applying changes during development.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: false,
+  },
+  schema: {
+    extensionName: z
+      .string()
+      .describe('The name or partial name of the extension to reload'),
+  },
+  handler: async (request, response, context) => {
+    const page = context.getSelectedPage();
+    const {extensionName} = request.params;
+
+    await context.waitForEventsAfterAction(async () => {
+      await page.goto('chrome://extensions/', {waitUntil: 'networkidle0'});
+
+      const reloadResult = await page.evaluate((searchName: string) => {
+        const extensionCards = document.querySelectorAll('extensions-item');
+
+        for (const card of Array.from(extensionCards)) {
+          const shadowRoot = card.shadowRoot;
+          if (shadowRoot) {
+            const name =
+              shadowRoot.querySelector('#name')?.textContent?.trim() || '';
+
+            if (name.toLowerCase().includes(searchName.toLowerCase())) {
+              const reloadButton = shadowRoot.querySelector('#reload-button');
+              if (reloadButton && !reloadButton.hasAttribute('hidden')) {
+                (reloadButton as HTMLElement).click();
+                return {success: true, extensionName: name};
+              } else {
+                return {
+                  success: false,
+                  reason:
+                    'Reload button not available or extension not in developer mode',
+                };
+              }
+            }
+          }
+        }
+
+        return {success: false, reason: 'Extension not found'};
+      }, extensionName);
+
+      if (reloadResult.success) {
+        response.appendResponseLine(
+          `✅ Successfully reloaded extension: ${reloadResult.extensionName}`,
+        );
+      } else {
+        response.appendResponseLine(
+          `❌ Failed to reload extension "${extensionName}": ${reloadResult.reason}`,
+        );
+      }
+    });
+  },
+});
+
+export const getExtensionErrors = defineTool({
+  name: 'get_extension_errors',
+  description: `Get error messages and logs for a specific Chrome extension. Helps identify issues during development.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: true,
+  },
+  schema: {
+    extensionName: z
+      .string()
+      .describe(
+        'The name or partial name of the extension to check for errors',
+      ),
+  },
+  handler: async (request, response, context) => {
+    const page = context.getSelectedPage();
+    const {extensionName} = request.params;
+
+    await context.waitForEventsAfterAction(async () => {
+      await page.goto('chrome://extensions/', {waitUntil: 'networkidle0'});
+
+      const errorInfo = await page.evaluate((searchName: string) => {
+        const extensionCards = document.querySelectorAll('extensions-item');
+
+        for (const card of Array.from(extensionCards)) {
+          const shadowRoot = card.shadowRoot;
+          if (shadowRoot) {
+            const name =
+              shadowRoot.querySelector('#name')?.textContent?.trim() || '';
+
+            if (name.toLowerCase().includes(searchName.toLowerCase())) {
+              const errorsButton = shadowRoot.querySelector('#errors-button');
+              const errorsBadge = shadowRoot.querySelector(
+                '#errors-button .badge',
+              );
+              const errorCount = errorsBadge?.textContent?.trim() || '0';
+
+              if (errorsButton && !errorsButton.hasAttribute('hidden')) {
+                (errorsButton as HTMLElement).click();
+                // Note: Detailed error retrieval requires additional interaction
+                // For now, we'll return basic error info and suggest manual inspection
+              }
+
+              return {
+                extensionName: name,
+                errorCount: parseInt(errorCount) || 0,
+                errors: [],
+                hasErrors: parseInt(errorCount) > 0,
+              };
+            }
+          }
+        }
+
+        return {
+          extensionName: searchName,
+          errorCount: 0,
+          errors: [],
+          hasErrors: false,
+          notFound: true,
+        };
+      }, extensionName);
+
+      if (errorInfo.notFound) {
+        response.appendResponseLine(
+          `❌ Extension "${extensionName}" not found`,
+        );
+      } else {
+        response.appendResponseLine(
+          `Extension: **${errorInfo.extensionName}**`,
+        );
+        response.appendResponseLine(`Error Count: ${errorInfo.errorCount}`);
+
+        if (errorInfo.hasErrors) {
+          response.appendResponseLine('');
+          response.appendResponseLine('🚨 **Errors Found:**');
+          if (errorInfo.errors.length > 0) {
+            errorInfo.errors.forEach((error, index) => {
+              response.appendResponseLine(`${index + 1}. ${error}`);
+            });
+          } else {
+            response.appendResponseLine(
+              'Click on "Errors" button in the extension card for detailed error information.',
+            );
+          }
+        } else {
+          response.appendResponseLine('✅ No errors found for this extension.');
+        }
+      }
+    });
+  },
+});
+
+export const inspectServiceWorker = defineTool({
+  name: 'inspect_service_worker',
+  description: `Open DevTools for an extension's service worker (background script). Essential for debugging extension background processes.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: false,
+  },
+  schema: {
+    extensionName: z
+      .string()
+      .describe(
+        'The name or partial name of the extension whose service worker to inspect',
+      ),
+  },
+  handler: async (request, response, context) => {
+    const page = context.getSelectedPage();
+    const {extensionName} = request.params;
+
+    await context.waitForEventsAfterAction(async () => {
+      await page.goto('chrome://extensions/', {waitUntil: 'networkidle0'});
+
+      const inspectResult = await page.evaluate((searchName: string) => {
+        const extensionCards = document.querySelectorAll('extensions-item');
+
+        for (const card of Array.from(extensionCards)) {
+          const shadowRoot = card.shadowRoot;
+          if (shadowRoot) {
+            const name =
+              shadowRoot.querySelector('#name')?.textContent?.trim() || '';
+
+            if (name.toLowerCase().includes(searchName.toLowerCase())) {
+              // Look for service worker link
+              const serviceWorkerLink = shadowRoot.querySelector(
+                'a[href*="service_worker"]',
+              );
+              if (serviceWorkerLink) {
+                (serviceWorkerLink as HTMLElement).click();
+                return {
+                  success: true,
+                  extensionName: name,
+                  type: 'service_worker',
+                };
+              }
+
+              // Look for background page link
+              const backgroundLink = shadowRoot.querySelector(
+                'a[href*="background"]',
+              );
+              if (backgroundLink) {
+                (backgroundLink as HTMLElement).click();
+                return {
+                  success: true,
+                  extensionName: name,
+                  type: 'background_page',
+                };
+              }
+
+              return {
+                success: false,
+                reason: 'No service worker or background page found',
+              };
+            }
+          }
+        }
+
+        return {success: false, reason: 'Extension not found'};
+      }, extensionName);
+
+      if (inspectResult.success) {
+        response.appendResponseLine(
+          `✅ Opened DevTools for ${inspectResult.type} of extension: ${inspectResult.extensionName}`,
+        );
+        response.appendResponseLine(
+          "You can now debug the extension's background processes, view console logs, and set breakpoints.",
+        );
+      } else {
+        response.appendResponseLine(
+          `❌ Failed to inspect service worker for "${extensionName}": ${inspectResult.reason}`,
+        );
+      }
+    });
+  },
+});
+
+export const getExtensionStorage = defineTool({
+  name: 'get_extension_storage',
+  description: `Execute JavaScript to read Chrome extension storage (chrome.storage.local or chrome.storage.sync) for debugging purposes.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: true,
+  },
+  schema: {
+    storageType: z
+      .enum(['local', 'sync'])
+      .default('local')
+      .describe('Type of storage to read (local or sync)'),
+    keys: z
+      .array(z.string())
+      .optional()
+      .describe('Specific keys to retrieve. If not provided, gets all storage'),
+  },
+  handler: async (request, response, context) => {
+    const page = context.getSelectedPage();
+    const {storageType, keys} = request.params;
+
+    await context.waitForEventsAfterAction(async () => {
+      try {
+        const storageData = await page.evaluate(
+          async (type: string, targetKeys?: string[]) => {
+            // Check if we're in an extension context
+            if (
+              typeof (window as any).chrome === 'undefined' ||
+              !(window as any).chrome.storage
+            ) {
+              return {
+                error:
+                  'chrome.storage API not available. This might not be an extension context.',
+              };
+            }
+
+            return new Promise(resolve => {
+              const chrome = (window as any).chrome;
+              const storage =
+                type === 'sync' ? chrome.storage.sync : chrome.storage.local;
+
+              if (targetKeys && targetKeys.length > 0) {
+                storage.get(targetKeys, (result: any) => {
+                  if (chrome.runtime.lastError) {
+                    resolve({error: chrome.runtime.lastError.message});
+                  } else {
+                    resolve({data: result});
+                  }
+                });
+              } else {
+                storage.get(null, (result: any) => {
+                  if (chrome.runtime.lastError) {
+                    resolve({error: chrome.runtime.lastError.message});
+                  } else {
+                    resolve({data: result});
+                  }
+                });
+              }
+            });
+          },
+          storageType,
+          keys,
+        );
+
+        response.appendResponseLine(
+          `**Chrome Extension Storage (${storageType}):**`,
+        );
+        response.appendResponseLine('');
+
+        if ((storageData as any).error) {
+          response.appendResponseLine(
+            `❌ Error: ${(storageData as any).error}`,
+          );
+          response.appendResponseLine('');
+          response.appendResponseLine(
+            '💡 **Tip:** Navigate to an extension page (popup, options, etc.) or inspect a service worker to access extension APIs.',
+          );
+        } else {
+          response.appendResponseLine('```json');
+          response.appendResponseLine(
+            JSON.stringify((storageData as any).data, null, 2),
+          );
+          response.appendResponseLine('```');
+        }
+      } catch (error) {
+        response.appendResponseLine(
+          `❌ Failed to access extension storage: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    });
+  },
+});
+
+export const setExtensionStorage = defineTool({
+  name: 'set_extension_storage',
+  description: `Execute JavaScript to write data to Chrome extension storage (chrome.storage.local or chrome.storage.sync) for testing purposes.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: false,
+  },
+  schema: {
+    storageType: z
+      .enum(['local', 'sync'])
+      .default('local')
+      .describe('Type of storage to write to (local or sync)'),
+    data: z
+      .record(z.any())
+      .describe('Key-value pairs to store in the extension storage'),
+  },
+  handler: async (request, response, context) => {
+    const page = context.getSelectedPage();
+    const {storageType, data} = request.params;
+
+    await context.waitForEventsAfterAction(async () => {
+      try {
+        const result = await page.evaluate(
+          async (type: string, storageData: Record<string, any>) => {
+            if (
+              typeof (window as any).chrome === 'undefined' ||
+              !(window as any).chrome.storage
+            ) {
+              return {
+                error:
+                  'chrome.storage API not available. This might not be an extension context.',
+              };
+            }
+
+            return new Promise(resolve => {
+              const chrome = (window as any).chrome;
+              const storage =
+                type === 'sync' ? chrome.storage.sync : chrome.storage.local;
+
+              storage.set(storageData, () => {
+                if (chrome.runtime.lastError) {
+                  resolve({error: chrome.runtime.lastError.message});
+                } else {
+                  resolve({success: true});
+                }
+              });
+            });
+          },
+          storageType,
+          data,
+        );
+
+        if ((result as any).error) {
+          response.appendResponseLine(
+            `❌ Error setting extension storage: ${(result as any).error}`,
+          );
+          response.appendResponseLine('');
+          response.appendResponseLine(
+            '💡 **Tip:** Navigate to an extension page (popup, options, etc.) or inspect a service worker to access extension APIs.',
+          );
+        } else {
+          response.appendResponseLine(
+            `✅ Successfully set data in chrome.storage.${storageType}`,
+          );
+          response.appendResponseLine('');
+          response.appendResponseLine('**Data set:**');
+          response.appendResponseLine('```json');
+          response.appendResponseLine(JSON.stringify(data, null, 2));
+          response.appendResponseLine('```');
+        }
+      } catch (error) {
+        response.appendResponseLine(
+          `❌ Failed to set extension storage: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    });
+  },
+});
+
+export const clearExtensionStorage = defineTool({
+  name: 'clear_extension_storage',
+  description: `Clear all or specific keys from Chrome extension storage (chrome.storage.local or chrome.storage.sync) for testing purposes.`,
+  annotations: {
+    category: ToolCategories.EXTENSION_DEVELOPMENT,
+    readOnlyHint: false,
+  },
+  schema: {
+    storageType: z
+      .enum(['local', 'sync'])
+      .default('local')
+      .describe('Type of storage to clear (local or sync)'),
+    keys: z
+      .array(z.string())
+      .optional()
+      .describe('Specific keys to remove. If not provided, clears all storage'),
+  },
+  handler: async (request, response, context) => {
+    const page = context.getSelectedPage();
+    const {storageType, keys} = request.params;
+
+    await context.waitForEventsAfterAction(async () => {
+      try {
+        const result = await page.evaluate(
+          async (type: string, targetKeys?: string[]) => {
+            if (
+              typeof (window as any).chrome === 'undefined' ||
+              !(window as any).chrome.storage
+            ) {
+              return {
+                error:
+                  'chrome.storage API not available. This might not be an extension context.',
+              };
+            }
+
+            return new Promise(resolve => {
+              const chrome = (window as any).chrome;
+              const storage =
+                type === 'sync' ? chrome.storage.sync : chrome.storage.local;
+
+              if (targetKeys && targetKeys.length > 0) {
+                storage.remove(targetKeys, () => {
+                  if (chrome.runtime.lastError) {
+                    resolve({error: chrome.runtime.lastError.message});
+                  } else {
+                    resolve({success: true, cleared: targetKeys});
+                  }
+                });
+              } else {
+                storage.clear(() => {
+                  if (chrome.runtime.lastError) {
+                    resolve({error: chrome.runtime.lastError.message});
+                  } else {
+                    resolve({success: true, cleared: 'all'});
+                  }
+                });
+              }
+            });
+          },
+          storageType,
+          keys,
+        );
+
+        if ((result as any).error) {
+          response.appendResponseLine(
+            `❌ Error clearing extension storage: ${(result as any).error}`,
+          );
+          response.appendResponseLine('');
+          response.appendResponseLine(
+            '💡 **Tip:** Navigate to an extension page (popup, options, etc.) or inspect a service worker to access extension APIs.',
+          );
+        } else {
+          if ((result as any).cleared === 'all') {
+            response.appendResponseLine(
+              `✅ Successfully cleared all data from chrome.storage.${storageType}`,
+            );
+          } else {
+            response.appendResponseLine(
+              `✅ Successfully removed keys from chrome.storage.${storageType}: ${Array.isArray((result as any).cleared) ? (result as any).cleared.join(', ') : (result as any).cleared}`,
+            );
+          }
+        }
+      } catch (error) {
+        response.appendResponseLine(
+          `❌ Failed to clear extension storage: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    });
+  },
+});


### PR DESCRIPTION
  ## Summary
  - Added `--loadExtension` CLI option to load unpacked Chrome extensions
  - Enables automatic extension loading at browser launch
  - Particularly useful for testing Chrome extensions with MCP

  ## Changes
  - Added `loadExtension` option to CLI arguments in `src/cli.ts`
  - Added `loadExtension` to `McpLaunchOptions` interface in `src/browser.ts`
  - Implemented extension loading logic with `--load-extension` and `--enable-experimental-extension-apis` flags
  - Passed `loadExtension` option through to `resolveBrowser` in `src/main.ts`

  ## Test Plan
  ✅ Build the project with `npm run build`
  ✅ Test loading an extension with `--loadExtension=/path/to/extension`
  ✅ Verify extension appears in Chrome's extension page
  ✅ Confirm extension functionality works correctly
  ✅ Ensure no conflicts with existing `--browserUrl` option

  ## Use Case
  This feature allows developers to automatically load Chrome extensions when launching Chrome through the MCP, which
  is essential for:
  - Testing Chrome extensions in automated workflows
  - Debugging extension interactions with web pages
  - Providing consistent development environments

  ## Example Usage
  ```bash
  node build/src/index.js --loadExtension=/path/to/extension

  Or in MCP configuration:
  {
    "command": "node",
    "args": [
      "/path/to/chrome-devtools-mcp/build/src/index.js",
      "--loadExtension=/path/to/extension"
    ]
  }