### PR TITLE
docs(getting-started): add `npx -y` to mcpServers args to auto-confirm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ startup_timeout_ms = 20_000
 
 **Click the button to install:**
 
-[<img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install in Cursor">](https://cursor.com/en/install-mcp?name=chrome-devtools&config=eyJjb21tYW5kIjoibnB4IGNocm9tZS1kZXZ0b29scy1tY3BAbGF0ZXN0In0%3D)
+[<img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install in Cursor">](https://cursor.com/en/install-mcp?name=chrome-devtools&config=eyJjb21tYW5kIjoibnB4IC15IGNocm9tZS1kZXZ0b29scy1tY3BAbGF0ZXN0In0%3D)
 
 **Or install manually:**
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add the following config to your MCP client:
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["chrome-devtools-mcp@latest"]
+      "args": ["-y", "chrome-devtools-mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
Avoids the "Need to install ... Ok to proceed?" interaction so the setup is non-interactive
for CI and first-time runs. (`-y` == `--yes`)