### PR TITLE
Add an option value to the snapshot

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -285,15 +285,14 @@ so returned values have to JSON-serializable.
 
 - **args** (array) _(optional)_: An optional list of arguments to pass to the function.
 - **function** (string) **(required)**: A JavaScript function to run in the currently selected page.
-Example without arguments: `() => {
+  Example without arguments: `() => {
   return document.title
 }` or `async () => {
   return await fetch("example.com")
 }`.
-Example with arguments: `(el) => {
+  Example with arguments: `(el) => {
   return el.innerText;
 }`
-
 
 ---
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -285,14 +285,15 @@ so returned values have to JSON-serializable.
 
 - **args** (array) _(optional)_: An optional list of arguments to pass to the function.
 - **function** (string) **(required)**: A JavaScript function to run in the currently selected page.
-  Example without arguments: `() => {
+Example without arguments: `() => {
   return document.title
 }` or `async () => {
   return await fetch("example.com")
 }`.
-  Example with arguments: `(el) => {
+Example with arguments: `(el) => {
   return el.innerText;
 }`
+
 
 ---
 

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -30,7 +30,7 @@ import {WaitForHelper} from './WaitForHelper.js';
 export interface TextSnapshotNode extends SerializedAXNode {
   id: string;
   children: TextSnapshotNode[];
-  value?: string | number;
+  value?: string;
 }
 
 export interface TextSnapshot {

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -33,6 +33,30 @@ describe('McpContext', () => {
     });
   });
 
+  it('should include the value of an option in the text snapshot', async () => {
+    await withBrowser(async (_response, context) => {
+      const page = context.getSelectedPage();
+      await page.setContent(`
+        <!DOCTYPE html>
+        <select>
+          <option value="1">One</option>
+          <option value="2">Two</option>
+        </select>
+      `);
+      await context.createTextSnapshot();
+      const snapshot = context.getTextSnapshot();
+      assert.ok(snapshot);
+
+      const option1 = snapshot.root.children[0]?.children[0];
+      assert.strictEqual(option1?.role, 'option');
+      assert.strictEqual(option1?.value, '1');
+
+      const option2 = snapshot.root.children[0]?.children[1];
+      assert.strictEqual(option2?.role, 'option');
+      assert.strictEqual(option2?.value, '2');
+    });
+  });
+
   it('can store and retrieve performance traces', async () => {
     await withBrowser(async (_response, context) => {
       const fakeTrace1 = {} as unknown as TraceResult;


### PR DESCRIPTION
Fixes #185

The standard selector <option> value is not included in the AXNode, so add it separately.