### PR TITLE
fix(emulation): Allow disabling CPU throttling

### DIFF
--- a/src/tools/emulation.ts
+++ b/src/tools/emulation.ts
@@ -60,17 +60,20 @@ export const emulateCpu = defineTool({
   schema: {
     throttlingRate: z
       .number()
-      .min(1)
+      .min(0)
       .max(20)
       .describe(
-        'The CPU throttling rate representing the slowdown factor 1-20x. Set the rate to 1 to disable throttling',
+        'The CPU throttling rate representing the slowdown factor 1-20x. Set the rate to 0 to disable throttling.',
       ),
   },
   handler: async (request, _response, context) => {
     const page = context.getSelectedPage();
     const {throttlingRate} = request.params;
 
-    await page.emulateCPUThrottling(throttlingRate);
+    await page.emulateCPUThrottling(
+      throttlingRate === 0 ? null : throttlingRate,
+    );
     context.setCpuThrottlingRate(throttlingRate);
   },
 });
+

--- a/tests/tools/emulation.test.ts
+++ b/tests/tools/emulation.test.ts
@@ -98,7 +98,7 @@ describe('emulation', () => {
       });
     });
 
-    it('disables cpu throttling', async () => {
+    it('disables cpu throttling when the rate is 1', async () => {
       await withBrowser(async (response, context) => {
         context.setCpuThrottlingRate(4); // Set it to something first.
         await emulateCpu.handler(
@@ -112,6 +112,23 @@ describe('emulation', () => {
         );
 
         assert.strictEqual(context.getCpuThrottlingRate(), 1);
+      });
+    });
+
+    it('disables cpu throttling when the rate is 0', async () => {
+      await withBrowser(async (response, context) => {
+        context.setCpuThrottlingRate(4); // Set it to something first.
+        await emulateCpu.handler(
+          {
+            params: {
+              throttlingRate: 0,
+            },
+          },
+          response,
+          context,
+        );
+
+        assert.strictEqual(context.getCpuThrottlingRate(), 0);
       });
     });
 
@@ -137,3 +154,4 @@ describe('emulation', () => {
     });
   });
 });
+


### PR DESCRIPTION
This PR Fixes #245 

The emulate_cpu tool did not provide a way to disable CPU emulation once it was enabled. This was because the throttlingRate parameter had a minimum value of 1, which only set the throttling to its lowest level but didn't turn off the emulation feature.

This change modifies the emulate_cpu tool to allow a throttlingRate of 0 to disable CPU emulation. The handler now passes null to Puppeteer's emulateCPUThrottling method when the rate is 0, which is the correct way to disable it.

A new test case has been added to verify that CPU throttling can be disabled by passing a throttlingRate of 0.
