### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ MCP clients.
 
 ## Requirements
 
-- [Node.js 20](https://nodejs.org/) or a newer [latest maintainance LTS](https://github.com/nodejs/Release#release-schedule) version.
+- [Node.js](https://nodejs.org/) v20.19 or a newer [latest maintenance LTS](https://github.com/nodejs/Release#release-schedule) version.
 - [Chrome](https://www.google.com/chrome/) current stable version or newer.
 - [npm](https://www.npmjs.com/).
 
@@ -280,7 +280,7 @@ The Chrome DevTools MCP server supports the following configuration option:
   - **Type:** string
 
 - **`--viewport`**
-  Initial viewport size for the Chromee instances started by the server. For example, `1280x720`
+  Initial viewport size for the Chrome instances started by the server. For example, `1280x720`
   - **Type:** string
 
 - **`--proxyServer`**

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -223,7 +223,7 @@
 
 ### `performance_analyze_insight`
 
-**Description:** Provides more detailed information on a specific Performance Insight that was highlighed in the results of a trace recording.
+**Description:** Provides more detailed information on a specific Performance Insight that was highlighted in the results of a trace recording.
 
 **Parameters:**
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -99,9 +99,9 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
   if (customDevTools) {
     args.push(`--custom-devtools-frontend=file://${customDevTools}`);
   }
-  let puppeterChannel: ChromeReleaseChannel | undefined;
+  let puppeteerChannel: ChromeReleaseChannel | undefined;
   if (!executablePath) {
-    puppeterChannel =
+    puppeteerChannel =
       channel && channel !== 'stable'
         ? (`chrome-${channel}` as ChromeReleaseChannel)
         : 'chrome';
@@ -110,7 +110,7 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
   try {
     const browser = await puppeteer.launch({
       ...connectOptions,
-      channel: puppeterChannel,
+      channel: puppeteerChannel,
       executablePath,
       defaultViewport: null,
       userDataDir,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ export const cliOptions = {
   viewport: {
     type: 'string',
     describe:
-      'Initial viewport size for the Chromee instances started by the server. For example, `1280x720`',
+      'Initial viewport size for the Chrome instances started by the server. For example, `1280x720`',
     coerce: (arg: string | undefined) => {
       if (arg === undefined) {
         return;

--- a/src/formatters/consoleFormatter.ts
+++ b/src/formatters/consoleFormatter.ts
@@ -42,7 +42,7 @@ async function formatConsoleMessage(msg: ConsoleMessage): Promise<string> {
           return error.toString();
         })
         .catch(() => {
-          return 'Error occured';
+          return 'Error occurred';
         });
       void errorHandle.dispose().catch();
 

--- a/src/tools/performance.ts
+++ b/src/tools/performance.ts
@@ -122,7 +122,7 @@ export const stopTrace = defineTool({
 export const analyzeInsight = defineTool({
   name: 'performance_analyze_insight',
   description:
-    'Provides more detailed information on a specific Performance Insight that was highlighed in the results of a trace recording.',
+    'Provides more detailed information on a specific Performance Insight that was highlighted in the results of a trace recording.',
   annotations: {
     category: ToolCategories.PERFORMANCE,
     readOnlyHint: true,
@@ -182,7 +182,7 @@ async function stopTracingAndAppendOutput(
     const errorText = e instanceof Error ? e.message : JSON.stringify(e);
     logger(`Error stopping performance trace: ${errorText}`);
     response.appendResponseLine(
-      'An error occured generating the response for this trace:',
+      'An error occurred generating the response for this trace:',
     );
     response.appendResponseLine(errorText);
   } finally {

--- a/src/trace-processing/parse.ts
+++ b/src/trace-processing/parse.ts
@@ -66,7 +66,7 @@ export async function parseRawTraceBuffer(
     };
   } catch (e) {
     const errorText = e instanceof Error ? e.message : JSON.stringify(e);
-    logger(`Unexpeced error parsing trace: ${errorText}`);
+    logger(`Unexpected error parsing trace: ${errorText}`);
     return {
       error: errorText,
     };

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -267,7 +267,7 @@ describe('pages', () => {
         );
       });
     });
-    it('can dismiss alread dismissed dialog dialogs', async () => {
+    it('can dismiss already dismissed dialog dialogs', async () => {
       await withBrowser(async (response, context) => {
         const page = context.getSelectedPage();
         const dialogPromise = new Promise<Dialog>(resolve => {


### PR DESCRIPTION
This also implements the suggestion from https://github.com/ChromeDevTools/chrome-devtools-mcp/pull/244
but that includes other parts that I am not sure we would want for now.
