### PR TITLE
(do not merge): exposing additional performance functions

### DIFF
--- a/scripts/post-build.ts
+++ b/scripts/post-build.ts
@@ -149,6 +149,9 @@ export const ByteUtilities = {
   const runtimeContent = `
 export function getChromeVersion() { return ''; };
 export const hostConfig = {};
+export const experiments = {
+  isEnabled() { return false; },
+}
   `;
   writeFile(runtimeFile, runtimeContent);
 


### PR DESCRIPTION
This PR is so we have a branch that has the bigger set of performance
functions available to it that are equivalent to the ones the DevTools
Performance Agent has.

If we decide we want to expose these functions, we will do so via
reusing the implementation from upstream, not via the copy/paste of this
PR, but this is the quickest way to get them available to test.
