### PR TITLE
feat: Add Node.js v21 version check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,13 @@ if (major === 22 && minor < 12) {
   process.exit(1);
 }
 
+if (major === 21) {
+  console.error(
+    `ERROR: \`chrome-devtools-mcp\` does not support Node ${process.version}. Please upgrade to Node 20.19.0 LTS or a newer LTS.`,
+  );
+  process.exit(1);
+}
+
 if (major < 20) {
   console.error(
     `ERROR: \`chrome-devtools-mcp\` does not support Node ${process.version}. Please upgrade to Node 20.19.0 LTS or a newer LTS.`,

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, it, afterEach} from 'node:test';
+import assert from 'node:assert';
+import sinon from 'sinon';
+
+describe('version check', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should exit if node version is not supported', async (t) => {
+    const processExit = sinon.stub(process, 'exit');
+    const consoleError = sinon.stub(console, 'error');
+
+    await t.test('v21.0.0', async () => {
+      Object.defineProperty(process, 'version', {
+        value: 'v21.0.0',
+        writable: true,
+        configurable: true,
+      });
+
+      // We need to dynamically import the index with a random query string
+      // to bypass the module cache and re-evaluate the version check.
+      await import(`../src/index.js?r=${Math.random()}`);
+
+      assert.strictEqual(processExit.callCount, 1);
+      assert.strictEqual(processExit.getCall(0).args[0], 1);
+      assert.deepStrictEqual(consoleError.getCall(0).args, [
+        'ERROR: `chrome-devtools-mcp` does not support Node v21.0.0. Please upgrade to Node 20.19.0 LTS or a newer LTS.',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
The entrypoint script `src/index.ts` was missing a check for Node.js version 21. Although the `package.json` `engines` field specifies supported versions, this check provides a more user-friendly error message.

This change adds a condition to exit with an error if the major version of Node.js is 21, consistent with other version checks in the file.

A new test file, `tests/version.test.ts`, is added to verify this behavior in isolation, ensuring that the script exits as expected when an unsupported version is used.