### PR TITLE
ci: fix Dependabot and Puppeteer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
         patterns:
           - '*'
       puppeteer:
-        dependency-type: development
         patterns:
           - 'puppeteer*'
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,20 @@ updates:
     groups:
       dependencies:
         dependency-type: production
+        exclude-patterns:
+          - 'puppeteer*'
         patterns:
           - '*'
       dev-dependencies:
         dependency-type: development
+        exclude-patterns:
+          - 'puppeteer*'
         patterns:
           - '*'
+      puppeteer:
+        dependency-type: development
+        patterns:
+          - 'puppeteer*'
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
We use both Puppeteer and Puppeteer-Core so we need to keep them in sync else their types will have issue and not work correctly.