### PR TITLE
fix: guard performance_stop_trace when tracing inactive

### DIFF
--- a/src/tools/performance.ts
+++ b/src/tools/performance.ts
@@ -111,7 +111,7 @@ export const stopTrace = defineTool({
   },
   schema: {},
   handler: async (_request, response, context) => {
-    if (!context.isRunningPerformanceTrace) {
+    if (!context.isRunningPerformanceTrace()) {
       return;
     }
     const page = context.getSelectedPage();

--- a/tests/tools/performance.test.ts
+++ b/tests/tools/performance.test.ts
@@ -218,7 +218,11 @@ describe('performance', () => {
     it('does nothing if the trace is not running and does not error', async () => {
       await withBrowser(async (response, context) => {
         context.setIsRunningPerformanceTrace(false);
+        const selectedPage = context.getSelectedPage();
+        const stopTracingStub = sinon.stub(selectedPage.tracing, 'stop');
         await stopTrace.handler({params: {}}, response, context);
+        sinon.assert.notCalled(stopTracingStub);
+        assert.strictEqual(context.isRunningPerformanceTrace(), false);
       });
     });
 


### PR DESCRIPTION
  PR Description

  - Fix the stop-trace guard to call context.isRunningPerformanceTrace() so we skip page.tracing.stop() when nothing is recording, avoiding the Puppeteer error that bubbled up
    to users.
  - Extend the “does nothing” test to stub tracing.stop() and assert it stays untouched, guaranteeing the guard path is covered.

  Testing

  - npm run build
  - node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-force-exit --test-reporter spec --test build/tests/tools/performance.test.js