### PR TITLE
fix(cli): tolerate empty browser URLs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,10 @@ export const cliOptions = {
     description:
       'Connect to a running Chrome instance using port forwarding. For more details see: https://developer.chrome.com/docs/devtools/remote-debugging/local-server.',
     alias: 'u',
-    coerce: (url: string) => {
+    coerce: (url: string | undefined) => {
+      if (!url) {
+        return;
+      }
       try {
         new URL(url);
       } catch {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -38,6 +38,25 @@ describe('cli args parsing', () => {
     });
   });
 
+  it('parses an empty browser url', async () => {
+    const args = parseArguments('1.0.0', [
+      'node',
+      'main.js',
+      '--browserUrl',
+      '',
+    ]);
+    assert.deepStrictEqual(args, {
+      _: [],
+      headless: false,
+      isolated: false,
+      $0: 'npx chrome-devtools-mcp@latest',
+      'browser-url': undefined,
+      browserUrl: undefined,
+      u: undefined,
+      channel: 'stable',
+    });
+  });
+
   it('parses with executable path', async () => {
     const args = parseArguments('1.0.0', [
       'node',


### PR DESCRIPTION
it seems some clients default to empty default values for args. We can accept that and do not error for these.

Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/264