### PR TITLE
fix: change default screen size in headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ The Chrome DevTools MCP server supports the following configuration option:
   - **Type:** string
 
 - **`--viewport`**
-  Initial viewport size for the Chrome instances started by the server. For example, `1280x720`
+  Initial viewport size for the Chrome instances started by the server. For example, `1280x720`. In headless mode, max size is 3840x2160px.
   - **Type:** string
 
 - **`--proxyServer`**

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -99,6 +99,9 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
   if (customDevTools) {
     args.push(`--custom-devtools-frontend=file://${customDevTools}`);
   }
+  if (headless) {
+    args.push('--screen-info={3840x2160}');
+  }
   let puppeteerChannel: ChromeReleaseChannel | undefined;
   if (!executablePath) {
     puppeteerChannel =

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,7 +65,7 @@ export const cliOptions = {
   viewport: {
     type: 'string',
     describe:
-      'Initial viewport size for the Chrome instances started by the server. For example, `1280x720`',
+      'Initial viewport size for the Chrome instances started by the server. For example, `1280x720`. In headless mode, max size is 3840x2160px.',
     coerce: (arg: string | undefined) => {
       if (arg === undefined) {
         return;

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -52,8 +52,8 @@ describe('browser', () => {
       userDataDir: folderPath,
       executablePath: executablePath(),
       viewport: {
-        width: 700,
-        height: 500,
+        width: 1501,
+        height: 801,
       },
     });
     try {
@@ -62,8 +62,8 @@ describe('browser', () => {
         return {width: window.innerWidth, height: window.innerHeight};
       });
       assert.deepStrictEqual(result, {
-        width: 700,
-        height: 500,
+        width: 1501,
+        height: 801,
       });
     } finally {
       await browser.close();


### PR DESCRIPTION
Sets the screen size in headless to be 3840x2160px to allow resize tool to work correctly for most use cases.

Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/294