### PR TITLE
ci: add rerun for publish

### DIFF
--- a/.github/workflows/publish-to-npm-on-tag.yml
+++ b/.github/workflows/publish-to-npm-on-tag.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - 'chrome-devtools-mcp-v*'
+  workflow_call:
+    inputs:
+      npm-publish:
+        default: false
+        type: boolean
+      mcp-publish:
+        default: true
+        type: boolean
 
 permissions:
   id-token: write # Required for OIDC
@@ -70,7 +78,9 @@ jobs:
 
       - name: Install MCP Publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          export VERSION="1.2.1"
+          export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v${VERSION}/mcp-publisher_${VERSION}_${OS}.tar.gz" | tar xz mcp-publisher
 
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
     "source": "github"
   },
-  "version": "0.2.5",
+  "version": "0.6.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "chrome-devtools-mcp",
-      "version": "0.2.5",
+      "version": "0.6.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
This will allow us to manually call the run so the latest GitHub Action config from main is picked up.
It also updates the Publisher to the latest version, and extracts the command in vars so its easier to
update and read.

Issue: https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/304