### PR TITLE
chore: fix manual  workflow

### DIFF
--- a/.github/workflows/publish-to-npm-on-tag.yml
+++ b/.github/workflows/publish-to-npm-on-tag.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       npm-publish:
-        description: 'Whether or not to try to publish to NPM'
+        description: 'Try to publish to NPM'
         default: false
         type: boolean
       mcp-publish:
-        description: 'Whether or not to try to publish to MCP registry'
+        description: 'Try to publish to MCP registry'
         default: true
         type: boolean
 
@@ -22,7 +22,7 @@ permissions:
 jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.npm-publish }}
+    if: ${{ (github.event_name != 'workflow_dispatch') || (inputs.npm-publish && always()) }}
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -52,8 +52,8 @@ jobs:
 
   publish-to-mcp-registry:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mcp-publish }}
     needs: publish-to-npm
+    if: ${{ (github.event_name != 'workflow_dispatch' && needs.publish-to-npm.result == 'success') || (inputs.mcp-publish && always()) }}
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
The first job was skipped so the second one that was marked as `needs: npm-publish` was getting skipped as well
I think this should fix that.