### PR TITLE
chore: switch to issue type in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,8 +1,7 @@
 name: Bug report
 description: File a bug report for chrome-devtools-mcp
 title: '<short description of the bug>'
-labels:
-  - 'bug'
+type: 'Bug'
 body:
   - id: description
     type: textarea


### PR DESCRIPTION
Use the native issue time that was recently added.