### PR TITLE
docs: Add note on node version when building

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ for PR and commit titles.
 
 ## Installation
 
+Check that you are using node version specified in .nvmrc, then run following commands:
+
 ```sh
 git clone https://github.com/ChromeDevTools/chrome-devtools-mcp.git
 cd chrome-devtools-mcp


### PR DESCRIPTION
I heard several people had issues installing the project locally due to not noticing the difference between node version required to run vs to build the project. This improvement aims at helping in those cases and hopefully preventing small waste of time.