### PR TITLE
docs: add instructions for Kiro

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ The same way chrome-devtools-mcp can be configured for JetBrains Junie in `Setti
 </details>
 
 <details>
+  <summary>Kiro</summary>
+
+In **Kiro Settings**, go to `Configure MCP` > `Open Workspace or User MCP Config` > Use the configuration snippet provided above.
+
+Or, from the IDE **Activity Bar** > `Kiro` > `MCP Servers` > `Click Open MCP Config`. Use the configuration snippet provided above.
+
+</details>
+
+<details>
   <summary>Visual Studio</summary>
   
   **Click the button to install:**


### PR DESCRIPTION
Adds instructions on how to add Chrome DevTools MCP to [Kiro](https://kiro.dev).

<img width="706" height="449" alt="image" src="https://github.com/user-attachments/assets/dab524b9-e684-4726-8f80-bffdfb3197cf" />
