### PR TITLE
refactor: simplify snapshot generation

### DIFF
--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -89,7 +89,7 @@ uid=1_0 RootWebArea ""
 ## Page content
 uid=1_0 RootWebArea "My test page"
   uid=1_1 StaticText "username"
-  uid=1_2 textbox "username" value="mcp" focusable focused
+  uid=1_2 textbox "username" focusable focused value="mcp"
 `,
       );
     });

--- a/tests/formatters/snapshotFormatter.test.ts
+++ b/tests/formatters/snapshotFormatter.test.ts
@@ -100,7 +100,7 @@ describe('snapshotFormatter', () => {
     const formatted = formatA11ySnapshot(snapshot);
     assert.strictEqual(
       formatted,
-      `uid=1_1 checkbox "checkbox" checked checked="true"
+      `uid=1_1 checkbox "checkbox" checked
   uid=1_2 statictext "text"
 `,
     );


### PR DESCRIPTION
the only difference is that checked/pressed are only included if the element was checked/pressed.

Refs: https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/363