### PR TITLE
feat(cli): allow enabling and disabling categories of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,22 +230,24 @@ If you run into any issues, checkout our [troubleshooting guide](./docs/troubles
 
 <!-- BEGIN AUTO GENERATED TOOLS -->
 
-- **Input automation** (7 tools)
-  - [`click`](docs/tool-reference.md#click)
-  - [`drag`](docs/tool-reference.md#drag)
-  - [`fill`](docs/tool-reference.md#fill)
-  - [`fill_form`](docs/tool-reference.md#fill_form)
-  - [`handle_dialog`](docs/tool-reference.md#handle_dialog)
-  - [`hover`](docs/tool-reference.md#hover)
-  - [`upload_file`](docs/tool-reference.md#upload_file)
-- **Navigation automation** (7 tools)
+- **Core automation** (10 tools)
   - [`close_page`](docs/tool-reference.md#close_page)
+  - [`handle_dialog`](docs/tool-reference.md#handle_dialog)
   - [`list_pages`](docs/tool-reference.md#list_pages)
   - [`navigate_page`](docs/tool-reference.md#navigate_page)
   - [`navigate_page_history`](docs/tool-reference.md#navigate_page_history)
   - [`new_page`](docs/tool-reference.md#new_page)
   - [`select_page`](docs/tool-reference.md#select_page)
+  - [`take_screenshot`](docs/tool-reference.md#take_screenshot)
+  - [`take_snapshot`](docs/tool-reference.md#take_snapshot)
   - [`wait_for`](docs/tool-reference.md#wait_for)
+- **Input automation** (6 tools)
+  - [`click`](docs/tool-reference.md#click)
+  - [`drag`](docs/tool-reference.md#drag)
+  - [`fill`](docs/tool-reference.md#fill)
+  - [`fill_form`](docs/tool-reference.md#fill_form)
+  - [`hover`](docs/tool-reference.md#hover)
+  - [`upload_file`](docs/tool-reference.md#upload_file)
 - **Emulation** (3 tools)
   - [`emulate_cpu`](docs/tool-reference.md#emulate_cpu)
   - [`emulate_network`](docs/tool-reference.md#emulate_network)
@@ -257,11 +259,9 @@ If you run into any issues, checkout our [troubleshooting guide](./docs/troubles
 - **Network** (2 tools)
   - [`get_network_request`](docs/tool-reference.md#get_network_request)
   - [`list_network_requests`](docs/tool-reference.md#list_network_requests)
-- **Debugging** (4 tools)
+- **Debugging** (2 tools)
   - [`evaluate_script`](docs/tool-reference.md#evaluate_script)
   - [`list_console_messages`](docs/tool-reference.md#list_console_messages)
-  - [`take_screenshot`](docs/tool-reference.md#take_screenshot)
-  - [`take_snapshot`](docs/tool-reference.md#take_snapshot)
 
 <!-- END AUTO GENERATED TOOLS -->
 
@@ -313,6 +313,11 @@ The Chrome DevTools MCP server supports the following configuration option:
 - **`--chromeArg`**
   Additional arguments for Chrome. Only applies when Chrome is launched by chrome-devtools-mcp.
   - **Type:** array
+
+- **`--categories`**
+  Categories of tools to expose. The `core` category cannot be disabled.
+  - **Type:** string
+  - **Default:** `core,input,emulation,performance,network,debugging`
 
 <!-- END AUTO GENERATED OPTIONS -->
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -2,22 +2,24 @@
 
 # Chrome DevTools MCP Tool Reference
 
-- **[Input automation](#input-automation)** (7 tools)
-  - [`click`](#click)
-  - [`drag`](#drag)
-  - [`fill`](#fill)
-  - [`fill_form`](#fill_form)
-  - [`handle_dialog`](#handle_dialog)
-  - [`hover`](#hover)
-  - [`upload_file`](#upload_file)
-- **[Navigation automation](#navigation-automation)** (7 tools)
+- **[Core automation](#core-automation)** (10 tools)
   - [`close_page`](#close_page)
+  - [`handle_dialog`](#handle_dialog)
   - [`list_pages`](#list_pages)
   - [`navigate_page`](#navigate_page)
   - [`navigate_page_history`](#navigate_page_history)
   - [`new_page`](#new_page)
   - [`select_page`](#select_page)
+  - [`take_screenshot`](#take_screenshot)
+  - [`take_snapshot`](#take_snapshot)
   - [`wait_for`](#wait_for)
+- **[Input automation](#input-automation)** (6 tools)
+  - [`click`](#click)
+  - [`drag`](#drag)
+  - [`fill`](#fill)
+  - [`fill_form`](#fill_form)
+  - [`hover`](#hover)
+  - [`upload_file`](#upload_file)
 - **[Emulation](#emulation)** (3 tools)
   - [`emulate_cpu`](#emulate_cpu)
   - [`emulate_network`](#emulate_network)
@@ -29,54 +31,19 @@
 - **[Network](#network)** (2 tools)
   - [`get_network_request`](#get_network_request)
   - [`list_network_requests`](#list_network_requests)
-- **[Debugging](#debugging)** (4 tools)
+- **[Debugging](#debugging)** (2 tools)
   - [`evaluate_script`](#evaluate_script)
   - [`list_console_messages`](#list_console_messages)
-  - [`take_screenshot`](#take_screenshot)
-  - [`take_snapshot`](#take_snapshot)
 
-## Input automation
+## Core automation
 
-### `click`
+### `close_page`
 
-**Description:** Clicks on the provided element
+**Description:** Closes the page by its index. The last open page cannot be closed.
 
 **Parameters:**
 
-- **dblClick** (boolean) _(optional)_: Set to true for double clicks. Default is false.
-- **uid** (string) **(required)**: The uid of an element on the page from the page content snapshot
-
----
-
-### `drag`
-
-**Description:** [`Drag`](#drag) an element onto another element
-
-**Parameters:**
-
-- **from_uid** (string) **(required)**: The uid of the element to [`drag`](#drag)
-- **to_uid** (string) **(required)**: The uid of the element to drop into
-
----
-
-### `fill`
-
-**Description:** Type text into a input, text area or select an option from a &lt;select&gt; element.
-
-**Parameters:**
-
-- **uid** (string) **(required)**: The uid of an element on the page from the page content snapshot
-- **value** (string) **(required)**: The value to [`fill`](#fill) in
-
----
-
-### `fill_form`
-
-**Description:** [`Fill`](#fill) out multiple form elements at once
-
-**Parameters:**
-
-- **elements** (array) **(required)**: Elements from snapshot to [`fill`](#fill) out.
+- **pageIdx** (number) **(required)**: The index of the page to close. Call [`list_pages`](#list_pages) to list pages.
 
 ---
 
@@ -88,39 +55,6 @@
 
 - **action** (enum: "accept", "dismiss") **(required)**: Whether to dismiss or accept the dialog
 - **promptText** (string) _(optional)_: Optional prompt text to enter into the dialog.
-
----
-
-### `hover`
-
-**Description:** [`Hover`](#hover) over the provided element
-
-**Parameters:**
-
-- **uid** (string) **(required)**: The uid of an element on the page from the page content snapshot
-
----
-
-### `upload_file`
-
-**Description:** Upload a file through a provided element.
-
-**Parameters:**
-
-- **filePath** (string) **(required)**: The local path of the file to upload
-- **uid** (string) **(required)**: The uid of the file input element or an element that will open file chooser on the page from the page content snapshot
-
----
-
-## Navigation automation
-
-### `close_page`
-
-**Description:** Closes the page by its index. The last open page cannot be closed.
-
-**Parameters:**
-
-- **pageIdx** (number) **(required)**: The index of the page to close. Call [`list_pages`](#list_pages) to list pages.
 
 ---
 
@@ -175,6 +109,31 @@
 
 ---
 
+### `take_screenshot`
+
+**Description:** Take a screenshot of the page or element.
+
+**Parameters:**
+
+- **filePath** (string) _(optional)_: The absolute path, or a path relative to the current working directory, to save the screenshot to instead of attaching it to the response.
+- **format** (enum: "png", "jpeg", "webp") _(optional)_: Type of format to save the screenshot as. Default is "png"
+- **fullPage** (boolean) _(optional)_: If set to true takes a screenshot of the full page instead of the currently visible viewport. Incompatible with uid.
+- **quality** (number) _(optional)_: Compression quality for JPEG and WebP formats (0-100). Higher values mean better quality but larger file sizes. Ignored for PNG format.
+- **uid** (string) _(optional)_: The uid of an element on the page from the page content snapshot. If omitted takes a pages screenshot.
+
+---
+
+### `take_snapshot`
+
+**Description:** Take a text snapshot of the currently selected page based on the a11y tree. The snapshot lists page elements along with a unique
+identifier (uid). Always use the latest snapshot. Prefer taking a snapshot over taking a screenshot.
+
+**Parameters:**
+
+- **verbose** (boolean) _(optional)_: Whether to include all possible information available in the full a11y tree. Default is false.
+
+---
+
 ### `wait_for`
 
 **Description:** Wait for the specified text to appear on the selected page.
@@ -183,6 +142,72 @@
 
 - **text** (string) **(required)**: Text to appear on the page
 - **timeout** (integer) _(optional)_: Maximum wait time in milliseconds. If set to 0, the default timeout will be used.
+
+---
+
+## Input automation
+
+### `click`
+
+**Description:** Clicks on the provided element
+
+**Parameters:**
+
+- **dblClick** (boolean) _(optional)_: Set to true for double clicks. Default is false.
+- **uid** (string) **(required)**: The uid of an element on the page from the page content snapshot
+
+---
+
+### `drag`
+
+**Description:** [`Drag`](#drag) an element onto another element
+
+**Parameters:**
+
+- **from_uid** (string) **(required)**: The uid of the element to [`drag`](#drag)
+- **to_uid** (string) **(required)**: The uid of the element to drop into
+
+---
+
+### `fill`
+
+**Description:** Type text into a input, text area or select an option from a &lt;select&gt; element.
+
+**Parameters:**
+
+- **uid** (string) **(required)**: The uid of an element on the page from the page content snapshot
+- **value** (string) **(required)**: The value to [`fill`](#fill) in
+
+---
+
+### `fill_form`
+
+**Description:** [`Fill`](#fill) out multiple form elements at once
+
+**Parameters:**
+
+- **elements** (array) **(required)**: Elements from snapshot to [`fill`](#fill) out.
+
+---
+
+### `hover`
+
+**Description:** [`Hover`](#hover) over the provided element
+
+**Parameters:**
+
+- **uid** (string) **(required)**: The uid of an element on the page from the page content snapshot
+
+---
+
+### `upload_file`
+
+**Description:** Upload a file through a provided element.
+
+**Parameters:**
+
+- **filePath** (string) **(required)**: The local path of the file to upload
+- **uid** (string) **(required)**: The uid of the file input element or an element that will open file chooser on the page from the page content snapshot
 
 ---
 
@@ -301,30 +326,5 @@ so returned values have to JSON-serializable.
 **Description:** List all console messages for the currently selected page since the last navigation.
 
 **Parameters:** None
-
----
-
-### `take_screenshot`
-
-**Description:** Take a screenshot of the page or element.
-
-**Parameters:**
-
-- **filePath** (string) _(optional)_: The absolute path, or a path relative to the current working directory, to save the screenshot to instead of attaching it to the response.
-- **format** (enum: "png", "jpeg", "webp") _(optional)_: Type of format to save the screenshot as. Default is "png"
-- **fullPage** (boolean) _(optional)_: If set to true takes a screenshot of the full page instead of the currently visible viewport. Incompatible with uid.
-- **quality** (number) _(optional)_: Compression quality for JPEG and WebP formats (0-100). Higher values mean better quality but larger file sizes. Ignored for PNG format.
-- **uid** (string) _(optional)_: The uid of an element on the page from the page content snapshot. If omitted takes a pages screenshot.
-
----
-
-### `take_snapshot`
-
-**Description:** Take a text snapshot of the currently selected page based on the a11y tree. The snapshot lists page elements along with a unique
-identifier (uid). Always use the latest snapshot. Prefer taking a snapshot over taking a screenshot.
-
-**Parameters:**
-
-- **verbose** (boolean) _(optional)_: Whether to include all possible information available in the full a11y tree. Default is false.
 
 ---

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -11,7 +11,7 @@ import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 import type {Tool} from '@modelcontextprotocol/sdk/types.js';
 
 import {cliOptions} from '../build/src/cli.js';
-import {ToolCategories} from '../build/src/tools/categories.js';
+import {ToolCategory, labels} from '../build/src/tools/categories.js';
 
 const MCP_SERVER_PATH = 'build/src/index.js';
 const OUTPUT_PATH = './docs/tool-reference.md';
@@ -21,7 +21,7 @@ const README_PATH = './README.md';
 interface ToolWithAnnotations extends Tool {
   annotations?: {
     title?: string;
-    category?: ToolCategories;
+    category?: typeof ToolCategory;
   };
 }
 
@@ -67,7 +67,7 @@ function generateToolsTOC(
 
   for (const category of sortedCategories) {
     const categoryTools = categories[category];
-    const categoryName = category;
+    const categoryName = labels[category];
     toc += `- **${categoryName}** (${categoryTools.length} tools)\n`;
 
     // Sort tools within category for TOC
@@ -209,7 +209,7 @@ async function generateToolDocumentation(): Promise<void> {
     });
 
     // Sort categories using the enum order
-    const categoryOrder = Object.values(ToolCategories);
+    const categoryOrder = Object.values(ToolCategory);
     const sortedCategories = Object.keys(categories).sort((a, b) => {
       const aIndex = categoryOrder.indexOf(a);
       const bIndex = categoryOrder.indexOf(b);
@@ -223,8 +223,8 @@ async function generateToolDocumentation(): Promise<void> {
     // Generate table of contents
     for (const category of sortedCategories) {
       const categoryTools = categories[category];
-      const categoryName = category;
-      const anchorName = category.toLowerCase().replace(/\s+/g, '-');
+      const categoryName = labels[category];
+      const anchorName = categoryName.toLowerCase().replace(/\s+/g, '-');
       markdown += `- **[${categoryName}](#${anchorName})** (${categoryTools.length} tools)\n`;
 
       // Sort tools within category for TOC
@@ -239,8 +239,9 @@ async function generateToolDocumentation(): Promise<void> {
 
     for (const category of sortedCategories) {
       const categoryTools = categories[category];
+      const categoryName = labels[category];
 
-      markdown += `## ${category}\n\n`;
+      markdown += `## ${categoryName}\n\n`;
 
       // Sort tools within category
       categoryTools.sort((a: Tool, b: Tool) => a.name.localeCompare(b.name));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,8 @@ import type {Options as YargsOptions} from 'yargs';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
 
+import {ToolCategory} from './tools/categories.js';
+
 export const cliOptions = {
   browserUrl: {
     type: 'string',
@@ -90,6 +92,27 @@ export const cliOptions = {
     type: 'array',
     describe:
       'Additional arguments for Chrome. Only applies when Chrome is launched by chrome-devtools-mcp.',
+  },
+  categories: {
+    type: 'string',
+    describe:
+      'Categories of tools to expose. The `core` category cannot be disabled.',
+    default: Object.keys(ToolCategory)
+      .map(item => item.toLowerCase())
+      .join(','),
+    coerce: (arg: string) => {
+      if (!arg) {
+        return [ToolCategory.CORE];
+      }
+      const catgories = arg
+        .split(',')
+        .map(cat => cat.trim())
+        .filter(cat => cat !== '');
+      if (!catgories.length) {
+        return [ToolCategory.CORE];
+      }
+      return catgories;
+    },
   },
 } satisfies Record<string, YargsOptions>;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,10 +88,13 @@ debug, and modify any data in the browser or DevTools.
 Avoid sharing sensitive or personal information that you do not want to share with MCP clients.`,
   );
 };
-
+const enabledCategories = new Set(args.categories);
 const toolMutex = new Mutex();
 
 function registerTool(tool: ToolDefinition): void {
+  if (!enabledCategories.has(tool.annotations.category.toLowerCase())) {
+    return;
+  }
   server.registerTool(
     tool.name,
     {

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -10,14 +10,14 @@ import z from 'zod';
 import type {TextSnapshotNode} from '../McpContext.js';
 import type {TraceResult} from '../trace-processing/parse.js';
 
-import type {ToolCategories} from './categories.js';
+import type {ToolCategory} from './categories.js';
 
 export interface ToolDefinition<Schema extends z.ZodRawShape = z.ZodRawShape> {
   name: string;
   description: string;
   annotations: {
     title?: string;
-    category: ToolCategories;
+    category: ToolCategory;
     /**
      * If true, the tool does not modify its environment.
      */

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -4,11 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export enum ToolCategories {
-  INPUT_AUTOMATION = 'Input automation',
-  NAVIGATION_AUTOMATION = 'Navigation automation',
-  EMULATION = 'Emulation',
-  PERFORMANCE = 'Performance',
-  NETWORK = 'Network',
-  DEBUGGING = 'Debugging',
+export enum ToolCategory {
+  CORE = 'core',
+  INPUT = 'input',
+  EMULATION = 'emulation',
+  PERFORMANCE = 'performance',
+  NETWORK = 'network',
+  DEBUGGING = 'debugging',
 }
+
+export const labels = {
+  [ToolCategory.CORE]: 'Core automation',
+  [ToolCategory.INPUT]: 'Input automation',
+  [ToolCategory.EMULATION]: 'Emulation',
+  [ToolCategory.PERFORMANCE]: 'Performance',
+  [ToolCategory.NETWORK]: 'Network',
+  [ToolCategory.DEBUGGING]: 'Debugging',
+};

--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {ToolCategories} from './categories.js';
+import {ToolCategory} from './categories.js';
 import {defineTool} from './ToolDefinition.js';
 
 export const consoleTool = defineTool({
@@ -12,7 +12,7 @@ export const consoleTool = defineTool({
   description:
     'List all console messages for the currently selected page since the last navigation.',
   annotations: {
-    category: ToolCategories.DEBUGGING,
+    category: ToolCategory.DEBUGGING,
     readOnlyHint: true,
   },
   schema: {},

--- a/src/tools/emulation.ts
+++ b/src/tools/emulation.ts
@@ -7,7 +7,7 @@
 import {PredefinedNetworkConditions} from 'puppeteer-core';
 import z from 'zod';
 
-import {ToolCategories} from './categories.js';
+import {ToolCategory} from './categories.js';
 import {defineTool} from './ToolDefinition.js';
 
 const throttlingOptions: [string, ...string[]] = [
@@ -20,7 +20,7 @@ export const emulateNetwork = defineTool({
   name: 'emulate_network',
   description: `Emulates network conditions such as throttling or offline mode on the selected page.`,
   annotations: {
-    category: ToolCategories.EMULATION,
+    category: ToolCategory.EMULATION,
     readOnlyHint: false,
   },
   schema: {
@@ -66,7 +66,7 @@ export const emulateCpu = defineTool({
   name: 'emulate_cpu',
   description: `Emulates CPU throttling by slowing down the selected page's execution.`,
   annotations: {
-    category: ToolCategories.EMULATION,
+    category: ToolCategory.EMULATION,
     readOnlyHint: false,
   },
   schema: {

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -9,14 +9,14 @@ import z from 'zod';
 
 import type {McpContext, TextSnapshotNode} from '../McpContext.js';
 
-import {ToolCategories} from './categories.js';
+import {ToolCategory} from './categories.js';
 import {defineTool} from './ToolDefinition.js';
 
 export const click = defineTool({
   name: 'click',
   description: `Clicks on the provided element`,
   annotations: {
-    category: ToolCategories.INPUT_AUTOMATION,
+    category: ToolCategory.INPUT,
     readOnlyHint: false,
   },
   schema: {
@@ -55,7 +55,7 @@ export const hover = defineTool({
   name: 'hover',
   description: `Hover over the provided element`,
   annotations: {
-    category: ToolCategories.INPUT_AUTOMATION,
+    category: ToolCategory.INPUT,
     readOnlyHint: false,
   },
   schema: {
@@ -139,7 +139,7 @@ export const fill = defineTool({
   name: 'fill',
   description: `Type text into a input, text area or select an option from a <select> element.`,
   annotations: {
-    category: ToolCategories.INPUT_AUTOMATION,
+    category: ToolCategory.INPUT,
     readOnlyHint: false,
   },
   schema: {
@@ -167,7 +167,7 @@ export const drag = defineTool({
   name: 'drag',
   description: `Drag an element onto another element`,
   annotations: {
-    category: ToolCategories.INPUT_AUTOMATION,
+    category: ToolCategory.INPUT,
     readOnlyHint: false,
   },
   schema: {
@@ -196,7 +196,7 @@ export const fillForm = defineTool({
   name: 'fill_form',
   description: `Fill out multiple form elements at once`,
   annotations: {
-    category: ToolCategories.INPUT_AUTOMATION,
+    category: ToolCategory.INPUT,
     readOnlyHint: false,
   },
   schema: {
@@ -228,7 +228,7 @@ export const uploadFile = defineTool({
   name: 'upload_file',
   description: 'Upload a file through a provided element.',
   annotations: {
-    category: ToolCategories.INPUT_AUTOMATION,
+    category: ToolCategory.INPUT,
     readOnlyHint: false,
   },
   schema: {

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -7,7 +7,7 @@
 import type {ResourceType} from 'puppeteer-core';
 import z from 'zod';
 
-import {ToolCategories} from './categories.js';
+import {ToolCategory} from './categories.js';
 import {defineTool} from './ToolDefinition.js';
 
 const FILTERABLE_RESOURCE_TYPES: readonly [ResourceType, ...ResourceType[]] = [
@@ -36,7 +36,7 @@ export const listNetworkRequests = defineTool({
   name: 'list_network_requests',
   description: `List all requests for the currently selected page since the last navigation.`,
   annotations: {
-    category: ToolCategories.NETWORK,
+    category: ToolCategory.NETWORK,
     readOnlyHint: true,
   },
   schema: {
@@ -76,7 +76,7 @@ export const getNetworkRequest = defineTool({
   name: 'get_network_request',
   description: `Gets a network request by URL. You can get all requests by calling ${listNetworkRequests.name}.`,
   annotations: {
-    category: ToolCategories.NETWORK,
+    category: ToolCategory.NETWORK,
     readOnlyHint: true,
   },
   schema: {

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -8,14 +8,14 @@ import z from 'zod';
 
 import {logger} from '../logger.js';
 
-import {ToolCategories} from './categories.js';
+import {ToolCategory} from './categories.js';
 import {CLOSE_PAGE_ERROR, defineTool, timeoutSchema} from './ToolDefinition.js';
 
 export const listPages = defineTool({
   name: 'list_pages',
   description: `Get a list of pages open in the browser.`,
   annotations: {
-    category: ToolCategories.NAVIGATION_AUTOMATION,
+    category: ToolCategory.CORE,
     readOnlyHint: true,
   },
   schema: {},
@@ -28,7 +28,7 @@ export const selectPage = defineTool({
   name: 'select_page',
   description: `Select a page as a context for future tool calls.`,
   annotations: {
-    category: ToolCategories.NAVIGATION_AUTOMATION,
+    category: ToolCategory.CORE,
     readOnlyHint: true,
   },
   schema: {
@@ -50,7 +50,7 @@ export const closePage = defineTool({
   name: 'close_page',
   description: `Closes the page by its index. The last open page cannot be closed.`,
   annotations: {
-    category: ToolCategories.NAVIGATION_AUTOMATION,
+    category: ToolCategory.CORE,
     readOnlyHint: false,
   },
   schema: {
@@ -78,7 +78,7 @@ export const newPage = defineTool({
   name: 'new_page',
   description: `Creates a new page`,
   annotations: {
-    category: ToolCategories.NAVIGATION_AUTOMATION,
+    category: ToolCategory.CORE,
     readOnlyHint: false,
   },
   schema: {
@@ -102,7 +102,7 @@ export const navigatePage = defineTool({
   name: 'navigate_page',
   description: `Navigates the currently selected page to a URL.`,
   annotations: {
-    category: ToolCategories.NAVIGATION_AUTOMATION,
+    category: ToolCategory.CORE,
     readOnlyHint: false,
   },
   schema: {
@@ -126,7 +126,7 @@ export const navigatePageHistory = defineTool({
   name: 'navigate_page_history',
   description: `Navigates the currently selected page.`,
   annotations: {
-    category: ToolCategories.NAVIGATION_AUTOMATION,
+    category: ToolCategory.CORE,
     readOnlyHint: false,
   },
   schema: {
@@ -163,7 +163,7 @@ export const resizePage = defineTool({
   name: 'resize_page',
   description: `Resizes the selected page's window so that the page has specified dimension`,
   annotations: {
-    category: ToolCategories.EMULATION,
+    category: ToolCategory.EMULATION,
     readOnlyHint: false,
   },
   schema: {
@@ -187,7 +187,7 @@ export const handleDialog = defineTool({
   name: 'handle_dialog',
   description: `If a browser dialog was opened, use this command to handle it`,
   annotations: {
-    category: ToolCategories.INPUT_AUTOMATION,
+    category: ToolCategory.CORE,
     readOnlyHint: false,
   },
   schema: {

--- a/src/tools/performance.ts
+++ b/src/tools/performance.ts
@@ -16,7 +16,7 @@ import {
   traceResultIsSuccess,
 } from '../trace-processing/parse.js';
 
-import {ToolCategories} from './categories.js';
+import {ToolCategory} from './categories.js';
 import type {Context, Response} from './ToolDefinition.js';
 import {defineTool} from './ToolDefinition.js';
 
@@ -25,7 +25,7 @@ export const startTrace = defineTool({
   description:
     'Starts a performance trace recording on the selected page. This can be used to look for performance problems and insights to improve the performance of the page. It will also report Core Web Vital (CWV) scores for the page.',
   annotations: {
-    category: ToolCategories.PERFORMANCE,
+    category: ToolCategory.PERFORMANCE,
     readOnlyHint: true,
   },
   schema: {
@@ -106,7 +106,7 @@ export const stopTrace = defineTool({
   description:
     'Stops the active performance trace recording on the selected page.',
   annotations: {
-    category: ToolCategories.PERFORMANCE,
+    category: ToolCategory.PERFORMANCE,
     readOnlyHint: true,
   },
   schema: {},
@@ -124,7 +124,7 @@ export const analyzeInsight = defineTool({
   description:
     'Provides more detailed information on a specific Performance Insight that was highlighted in the results of a trace recording.',
   annotations: {
-    category: ToolCategories.PERFORMANCE,
+    category: ToolCategory.PERFORMANCE,
     readOnlyHint: true,
   },
   schema: {

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -7,14 +7,14 @@
 import type {ElementHandle, Page} from 'puppeteer-core';
 import z from 'zod';
 
-import {ToolCategories} from './categories.js';
+import {ToolCategory} from './categories.js';
 import {defineTool} from './ToolDefinition.js';
 
 export const screenshot = defineTool({
   name: 'take_screenshot',
   description: `Take a screenshot of the page or element.`,
   annotations: {
-    category: ToolCategories.DEBUGGING,
+    category: ToolCategory.CORE,
     readOnlyHint: true,
   },
   schema: {

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -6,7 +6,7 @@
 import type {JSHandle} from 'puppeteer-core';
 import z from 'zod';
 
-import {ToolCategories} from './categories.js';
+import {ToolCategory} from './categories.js';
 import {defineTool} from './ToolDefinition.js';
 
 export const evaluateScript = defineTool({
@@ -14,7 +14,7 @@ export const evaluateScript = defineTool({
   description: `Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON
 so returned values have to JSON-serializable.`,
   annotations: {
-    category: ToolCategories.DEBUGGING,
+    category: ToolCategory.DEBUGGING,
     readOnlyHint: false,
   },
   schema: {

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -7,7 +7,7 @@
 import {Locator} from 'puppeteer-core';
 import z from 'zod';
 
-import {ToolCategories} from './categories.js';
+import {ToolCategory} from './categories.js';
 import {defineTool, timeoutSchema} from './ToolDefinition.js';
 
 export const takeSnapshot = defineTool({
@@ -15,7 +15,7 @@ export const takeSnapshot = defineTool({
   description: `Take a text snapshot of the currently selected page based on the a11y tree. The snapshot lists page elements along with a unique
 identifier (uid). Always use the latest snapshot. Prefer taking a snapshot over taking a screenshot.`,
   annotations: {
-    category: ToolCategories.DEBUGGING,
+    category: ToolCategory.CORE,
     readOnlyHint: true,
   },
   schema: {
@@ -35,7 +35,7 @@ export const waitFor = defineTool({
   name: 'wait_for',
   description: `Wait for the specified text to appear on the selected page.`,
   annotations: {
-    category: ToolCategories.NAVIGATION_AUTOMATION,
+    category: ToolCategory.CORE,
     readOnlyHint: true,
   },
   schema: {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -8,7 +8,15 @@ import {describe, it} from 'node:test';
 
 import {parseArguments} from '../src/cli.js';
 
-describe('cli args parsing', () => {
+describe.only('cli args parsing', () => {
+  const defaultCategories = [
+    'core',
+    'input',
+    'emulation',
+    'performance',
+    'network',
+    'debugging',
+  ];
   it('parses with default args', async () => {
     const args = parseArguments('1.0.0', ['node', 'main.js']);
     assert.deepStrictEqual(args, {
@@ -17,6 +25,7 @@ describe('cli args parsing', () => {
       isolated: false,
       $0: 'npx chrome-devtools-mcp@latest',
       channel: 'stable',
+      categories: defaultCategories,
     });
   });
 
@@ -35,6 +44,7 @@ describe('cli args parsing', () => {
       'browser-url': 'http://localhost:3000',
       browserUrl: 'http://localhost:3000',
       u: 'http://localhost:3000',
+      categories: defaultCategories,
     });
   });
 
@@ -54,6 +64,7 @@ describe('cli args parsing', () => {
       browserUrl: undefined,
       u: undefined,
       channel: 'stable',
+      categories: defaultCategories,
     });
   });
 
@@ -72,6 +83,7 @@ describe('cli args parsing', () => {
       'executable-path': '/tmp/test 123/chrome',
       e: '/tmp/test 123/chrome',
       executablePath: '/tmp/test 123/chrome',
+      categories: defaultCategories,
     });
   });
 
@@ -92,6 +104,7 @@ describe('cli args parsing', () => {
         width: 888,
         height: 777,
       },
+      categories: defaultCategories,
     });
   });
 
@@ -110,6 +123,24 @@ describe('cli args parsing', () => {
       channel: 'stable',
       'chrome-arg': ['--no-sandbox', '--disable-setuid-sandbox'],
       chromeArg: ['--no-sandbox', '--disable-setuid-sandbox'],
+      categories: defaultCategories,
+    });
+  });
+
+  it('parses custom categories', async () => {
+    const args = parseArguments('1.0.0', [
+      'node',
+      'main.js',
+      '--categories',
+      'core,input',
+    ]);
+    assert.deepStrictEqual(args, {
+      _: [],
+      headless: false,
+      isolated: false,
+      $0: 'npx chrome-devtools-mcp@latest',
+      channel: 'stable',
+      categories: ['core', 'input'],
     });
   });
 });


### PR DESCRIPTION
This PR changes tool categories introducing a category called `Core automation` to indicate tools that are essential for browser automation. This PR also adds a CLI argument to configure which categories of tools are enabled to allow fine-tuning the token consumption for specific use cases. 