### PR TITLE
feat: add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "chrome-devtools-mcp",
+  "version": "latest",
+  "description": "Control and inspect a live Chrome browser through MCP - automate actions, debug, and analyze performance using Chrome DevTools",
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/plugin.json` to enable this MCP server as a Claude Code plugin
- Allows users to install and use chrome-devtools-mcp through Claude Code's plugin system

## What's Changed
This PR adds a Claude Code plugin manifest that enables chrome-devtools-mcp to be installed and used as a plugin in Claude Code (https://claude.ai/code).

## Benefits
- **Easier installation**: Users can install via `/plugin install chrome-devtools-mcp`
- **Better integration**: Seamless integration with Claude Code's plugin ecosystem
- **No breaking changes**: This is purely additive and doesn't affect existing MCP functionality

## Installation

```bash
# Add the pleaseai marketplace
/plugin marketplace add pleaseai/claude-code-plugins

# Install chrome-devtools-mcp plugin
/plugin install chrome-devtools-mcp@pleaseai
```

## File Added
- `.claude-plugin/plugin.json` - Plugin manifest with MCP server configuration

## Test Plan
- [x] Plugin manifest follows Claude Code plugin specification
- [x] MCP server configuration matches existing setup
- [x] No changes to existing functionality

This change is part of making chrome-devtools-mcp more accessible through the Claude Code plugin marketplace.