### PR TITLE
feat: add WebSocket endpoint and custom headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,14 @@ The Chrome DevTools MCP server supports the following configuration option:
   Connect to a running Chrome instance using port forwarding. For more details see: https://developer.chrome.com/docs/devtools/remote-debugging/local-server.
   - **Type:** string
 
+- **`--wsEndpoint`, `-w`**
+  WebSocket endpoint to connect to a running Chrome instance (e.g., ws://127.0.0.1:9222/devtools/browser/<id>). Alternative to --browserUrl.
+  - **Type:** string
+
+- **`--wsHeaders`**
+  Custom headers for WebSocket connection in JSON format (e.g., '{"Authorization":"Bearer token"}'). Only works with --wsEndpoint.
+  - **Type:** string
+
 - **`--headless`**
   Whether to run in headless (no UI) mode.
   - **Type:** boolean
@@ -342,6 +350,27 @@ Pass them via the `args` property in the JSON configuration. For example:
   }
 }
 ```
+
+### Connecting via WebSocket with custom headers
+
+You can connect directly to a Chrome WebSocket endpoint and include custom headers (e.g., for authentication):
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "chrome-devtools-mcp@latest",
+        "--wsEndpoint=ws://127.0.0.1:9222/devtools/browser/<id>",
+        "--wsHeaders={\"Authorization\":\"Bearer YOUR_TOKEN\"}"
+      ]
+    }
+  }
+}
+```
+
+To get the WebSocket endpoint from a running Chrome instance, visit `http://127.0.0.1:9222/json/version` and look for the `webSocketDebuggerUrl` field.
 
 You can also run `npx chrome-devtools-mcp@latest --help` to see all available configuration options.
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -42,18 +42,33 @@ function makeTargetFilter(devtools: boolean) {
 }
 
 export async function ensureBrowserConnected(options: {
-  browserURL: string;
+  browserURL?: string;
+  wsEndpoint?: string;
+  wsHeaders?: Record<string, string>;
   devtools: boolean;
 }) {
   if (browser?.connected) {
     return browser;
   }
-  browser = await puppeteer.connect({
+
+  const connectOptions: Parameters<typeof puppeteer.connect>[0] = {
     targetFilter: makeTargetFilter(options.devtools),
-    browserURL: options.browserURL,
     defaultViewport: null,
     handleDevToolsAsPage: options.devtools,
-  });
+  };
+
+  if (options.wsEndpoint) {
+    connectOptions.browserWSEndpoint = options.wsEndpoint;
+    if (options.wsHeaders) {
+      connectOptions.headers = options.wsHeaders;
+    }
+  } else if (options.browserURL) {
+    connectOptions.browserURL = options.browserURL;
+  } else {
+    throw new Error('Either browserURL or wsEndpoint must be provided');
+  }
+
+  browser = await puppeteer.connect(connectOptions);
   return browser;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,22 +58,25 @@ async function getContext(): Promise<McpContext> {
     extraArgs.push(`--proxy-server=${args.proxyServer}`);
   }
   const devtools = args.experimentalDevtools ?? false;
-  const browser = args.browserUrl
-    ? await ensureBrowserConnected({
-        browserURL: args.browserUrl,
-        devtools,
-      })
-    : await ensureBrowserLaunched({
-        headless: args.headless,
-        executablePath: args.executablePath,
-        channel: args.channel as Channel,
-        isolated: args.isolated,
-        logFile,
-        viewport: args.viewport,
-        args: extraArgs,
-        acceptInsecureCerts: args.acceptInsecureCerts,
-        devtools,
-      });
+  const browser =
+    args.browserUrl || args.wsEndpoint
+      ? await ensureBrowserConnected({
+          browserURL: args.browserUrl,
+          wsEndpoint: args.wsEndpoint,
+          wsHeaders: args.wsHeaders,
+          devtools,
+        })
+      : await ensureBrowserLaunched({
+          headless: args.headless,
+          executablePath: args.executablePath,
+          channel: args.channel as Channel,
+          isolated: args.isolated,
+          logFile,
+          viewport: args.viewport,
+          args: extraArgs,
+          acceptInsecureCerts: args.acceptInsecureCerts,
+          devtools,
+        });
 
   if (context?.browser !== browser) {
     context = await McpContext.from(browser, logger);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -112,4 +112,55 @@ describe('cli args parsing', () => {
       chromeArg: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
   });
+
+  it('parses wsEndpoint with ws:// protocol', async () => {
+    const args = parseArguments('1.0.0', [
+      'node',
+      'main.js',
+      '--wsEndpoint',
+      'ws://127.0.0.1:9222/devtools/browser/abc123',
+    ]);
+    assert.deepStrictEqual(args, {
+      _: [],
+      headless: false,
+      isolated: false,
+      $0: 'npx chrome-devtools-mcp@latest',
+      'ws-endpoint': 'ws://127.0.0.1:9222/devtools/browser/abc123',
+      wsEndpoint: 'ws://127.0.0.1:9222/devtools/browser/abc123',
+      w: 'ws://127.0.0.1:9222/devtools/browser/abc123',
+    });
+  });
+
+  it('parses wsEndpoint with wss:// protocol', async () => {
+    const args = parseArguments('1.0.0', [
+      'node',
+      'main.js',
+      '--wsEndpoint',
+      'wss://example.com:9222/devtools/browser/abc123',
+    ]);
+    assert.deepStrictEqual(args, {
+      _: [],
+      headless: false,
+      isolated: false,
+      $0: 'npx chrome-devtools-mcp@latest',
+      'ws-endpoint': 'wss://example.com:9222/devtools/browser/abc123',
+      wsEndpoint: 'wss://example.com:9222/devtools/browser/abc123',
+      w: 'wss://example.com:9222/devtools/browser/abc123',
+    });
+  });
+
+  it('parses wsHeaders with valid JSON', async () => {
+    const args = parseArguments('1.0.0', [
+      'node',
+      'main.js',
+      '--wsEndpoint',
+      'ws://127.0.0.1:9222/devtools/browser/abc123',
+      '--wsHeaders',
+      '{"Authorization":"Bearer token","X-Custom":"value"}',
+    ]);
+    assert.deepStrictEqual(args.wsHeaders, {
+      Authorization: 'Bearer token',
+      'X-Custom': 'value',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Add support for connecting to Chrome via WebSocket endpoint with custom headers, enabling authenticated remote debugging scenarios and providing an alternative to the HTTP-based connection method.

## What's New
This PR introduces two new CLI arguments:

- **`--wsEndpoint` / `-w`**: Connect directly to Chrome using a WebSocket URL
  - Example: `ws://127.0.0.1:9222/devtools/browser/<id>`
  - Alternative to `--browserUrl` (mutually exclusive)
  
- **`--wsHeaders`**: Pass custom headers for WebSocket connections (JSON format)
  - Example: `'{"Authorization":"Bearer token"}'`
  - Only works with `--wsEndpoint`

## Use Cases
- **Authenticated remote debugging**: Use API keys, tokens, or custom auth headers
- **Secured instances**: Connect to browser instances requiring authentication
