### PR TITLE
test: stabilize test locally

### DIFF
--- a/tests/tools/screenshot.test.ts
+++ b/tests/tools/screenshot.test.ts
@@ -74,7 +74,7 @@ describe('screenshot', () => {
       });
     });
 
-    it.only('with full page resulting in a large screenshot', async () => {
+    it('with full page resulting in a large screenshot', async () => {
       await withBrowser(async (response, context) => {
         const page = context.getSelectedPage();
 


### PR DESCRIPTION
Locally the test `with full page resulting in a large screenshot` would fail semi consistently.
With what I think is just things not getting loaded fully, so scroll to the bottom to fix that.