### PR TITLE
fix: secure cookie handling for multi-level subdomains

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -111,6 +111,9 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
   const args: LaunchOptions['args'] = [
     ...(options.args ?? []),
     '--hide-crash-restore-bubble',
+    // Fix cookie handling for subdomain patterns (e.g., dev.app.example.com)
+    // Disable third-party cookie partitioning which can interfere with secure cookies
+    '--disable-features=ThirdPartyStoragePartitioning,PartitionedCookies',
   ];
   if (headless) {
     args.push('--screen-info={3840x2160}');


### PR DESCRIPTION
## Problem

Session cookies with `Domain=.example.com; Secure` flag are not persisting when accessed from multi-level subdomains like `dev.app.example.com`, despite working correctly on single-level subdomains like `app.example.com`.

## Root Cause

Chrome's third-party storage partitioning features (`ThirdPartyStoragePartitioning` and `PartitionedCookies`) interfere with the proper handling of secure domain cookies on multi-level subdomains. This causes Chrome to create non-secure, host-specific cookies instead of respecting the server's secure domain cookies.

## Evidence

SQLite cookie database analysis showed:
```sql
-- Server sends: Domain=.example.com; Secure
-- Chrome stores:
.example.com | connect.sid | is_secure=1  ✓ (domain cookie)
dev.app.example.com | connect.sid | is_secure=0  ✗ (overrides with non-secure)
```

The host-specific non-secure cookie overrides the domain-wide secure cookie, preventing cookie transmission on HTTPS requests.

## Solution

Disable `ThirdPartyStoragePartitioning` and `PartitionedCookies` features via Chrome launch args to restore correct cookie handling behavior.

## Testing

Verified that this fix resolves the issue documented in #421 where:
- **Before**: `dev.app.example.com` - cookies not sent (401 errors)
- **After**: `dev.app.example.com` - cookies sent correctly (200 OK)

## Impact

- Fixes session persistence issues for applications using multi-level subdomain environments
- No breaking changes - only adds Chrome feature flags to disable problematic behavior
- Cookie storage and transmission now matches regular Chrome behavior

Fixes #421