### PR TITLE
docs: Update Copilot CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ Configure the following fields and press `CTRL+S` to save the configuration:
 
 - **Server name:** `chrome-devtools`
 - **Server Type:** `[1] Local`
-- **Command:** `npx`
-- **Arguments:** `-y, chrome-devtools-mcp@latest`
+- **Command:** `npx -y chrome-devtools-mcp@latest`
 
 </details>
 


### PR DESCRIPTION
This PR addresses issue #359  and updates instructions for Copilot CLI.  It removes the argument section and combines it with the command field.