### PR TITLE
feat: an option to ignore cache on reload

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -149,6 +149,7 @@
 
 **Parameters:**
 
+- **ignoreCache** (boolean) _(optional)_: Whether to ignore cache on reload.
 - **timeout** (integer) _(optional)_: Maximum wait time in milliseconds. If set to 0, the default timeout will be used.
 - **type** (enum: "url", "back", "forward", "reload") _(optional)_: Navigate the page by URL, back or forward in history, or reload.
 - **url** (string) _(optional)_: Target URL (only type=url)

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -112,6 +112,10 @@ export const navigatePage = defineTool({
         'Navigate the page by URL, back or forward in history, or reload.',
       ),
     url: zod.string().optional().describe('Target URL (only type=url)'),
+    ignoreCache: zod
+      .boolean()
+      .optional()
+      .describe('Whether to ignore cache on reload.'),
     ...timeoutSchema,
   },
   handler: async (request, response, context) => {
@@ -171,7 +175,10 @@ export const navigatePage = defineTool({
           break;
         case 'reload':
           try {
-            await page.reload(options);
+            await page.reload({
+              ...options,
+              ignoreCache: request.params.ignoreCache,
+            });
             response.appendResponseLine(`Successfully reloaded the page.`);
           } catch (error) {
             response.appendResponseLine(


### PR DESCRIPTION
This CL implements an option to ignore cache on reload. Since the configuration is passed as-is we rely on tests in Puppeteer to verify the cache behavior. 

Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/374