### PR TITLE
build: do not bundle by default

### DIFF
--- a/.github/workflows/publish-to-npm-on-tag.yml
+++ b/.github/workflows/publish-to-npm-on-tag.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Build and bundle
+        run: npm run bundle
         env:
           NODE_ENV: 'production'
 
@@ -76,8 +76,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Build and bundle
+        run: npm run bundle
         env:
           NODE_ENV: 'production'
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npm run build
+        run: npm run bundle
 
       - name: Set up Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "index.js",
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('build', {recursive: true, force: true})\"",
-    "build": "npm run clean && tsc && node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/post-build.ts && rollup -c rollup.config.mjs",
+    "bundle": "npm run clean && npm run build && rollup -c rollup.config.mjs",
+    "build": "tsc && node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/post-build.ts",
     "typecheck": "tsc --noEmit",
     "format": "eslint --cache --fix . && prettier --write --cache .",
     "check-format": "eslint --cache . && prettier --check --cache .;",

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -9,7 +9,7 @@ import 'core-js/proposals/iterator-helpers.js';
 export type {Options as YargsOptions} from 'yargs';
 export {default as yargs} from 'yargs';
 export {hideBin} from 'yargs/helpers';
-export {debug} from 'debug';
+export {default as debug} from 'debug';
 export type {Debugger} from 'debug';
 export {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 export {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';


### PR DESCRIPTION
The CI jobs will still bundle by default but I think the risk of the differences between the bundled and unbundled version is fairly low for local development.