### PR TITLE
docs: Update installation link for Cursor MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Configure the following fields and press `CTRL+S` to save the configuration:
 
 **Click the button to install:**
 
-[<img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install in Cursor">](https://cursor.com/en/install-mcp?name=chrome-devtools&config=eyJjb21tYW5kIjoibnB4IC15IGNocm9tZS1kZXZ0b29scy1tY3BAbGF0ZXN0In0%3D)
+[<img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install in Cursor">](https://cursor.com/en/install-mcp?name=chrome-devtools&config=eyJjb21tYW5kIjogIm5weCIsImFyZ3MiOiBbIi15IiwgImNocm9tZS1kZXZ0b29scy1tY3BAbGF0ZXN0Il19)
 
 **Or install manually:**
 


### PR DESCRIPTION
move args from `command` prop to `args`, which would be more standardized.

from `{"command":"npx -y chrome-devtools-mcp@latest"}` to  `{"command": "npx","args": ["-y", "chrome-devtools-mcp@latest"]}`