### PR TITLE
fix: avoid extension bootstrap hangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,21 @@ The Chrome DevTools MCP server supports the following configuration option:
   Additional arguments for Chrome. Only applies when Chrome is launched by chrome-devtools-mcp.
   - **Type:** array
 
+- **`--includeExtensionTargets`**
+  Include extension-related targets (service workers, background pages, offscreen documents) during bootstrap. Disabled by default to avoid long startup times with heavy extensions such as MetaMask.
+  - **Type:** boolean
+  - **Default:** `false`
+
+- **`--bootstrapTimeoutMs`**
+  Maximum time in milliseconds to wait for a first page to auto-attach during browser bootstrap before continuing.
+  - **Type:** number
+  - **Default:** `2000`
+
+- **`--verboseBootstrap`**
+  Enable verbose bootstrap logging (disable with `--no-verboseBootstrap`).
+  - **Type:** boolean
+  - **Default:** `true`
+
 - **`--categoryEmulation`**
   Set to false to exclude tools related to emulation.
   - **Type:** boolean

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -136,7 +136,9 @@
 
 ### `list_pages`
 
-**Description:** Get a list of pages open in the browser.
+**Description:** Get a list of pages open in the browser. The response includes a JSON array of objects with the fields `index`, `id`, `title`, `url`, and `selected`.
+
+Extension and DevTools targets are filtered out by default to keep bootstrap fast. Pass `--includeExtensionTargets` when starting the server to include them.
 
 **Parameters:** None
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -28,6 +28,15 @@ This indicates that the browser could not be started. Make sure that no Chrome
 instances are running or close them. Make sure you have the latest stable Chrome
 installed and that [your system is able to run Chrome](https://support.google.com/chrome/a/answer/7100626?hl=en).
 
+### Browser appears stuck when extensions like MetaMask are enabled
+
+Some extensions register background pages, service workers, offscreen documents, and iframes that keep Chrome busy during startup. To prevent hangs, the MCP server filters these extension targets during bootstrap and ignores them in the `list_pages` tool.
+
+- Leave the default behavior to get a responsive startup and see only regular web pages.
+- Launch the server with `--includeExtensionTargets` if you need to work with extension targets.
+- Adjust `--bootstrapTimeoutMs` to wait longer than the default 2000 ms before giving up on extension targets.
+- Enable `--verboseBootstrap` (default) to see detailed logs about the new filtered auto-attach loop, and use `--no-verboseBootstrap` to reduce logging noise.
+
 ### Remote debugging between virtual machine (VM) and host fails
 
 When connecting DevTools inside a VM to Chrome running on the host, any domain is rejected by Chrome because of host header validation. Tunneling the port over SSH bypasses this restriction. In the VM, run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1227,6 +1227,7 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -1702,6 +1703,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2576,7 +2578,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
       "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -2877,6 +2880,7 @@
       "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3047,6 +3051,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3317,6 +3322,7 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -5612,6 +5618,7 @@
       "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6617,6 +6624,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6692,6 +6700,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -6990,6 +6999,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:only": "npm run build && node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-reporter spec --test-force-exit --test --test-only \"build/tests/**/*.test.js\"",
     "test:only:no-build": "node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-reporter spec --test-force-exit --test --test-only \"build/tests/**/*.test.js\"",
     "test:update-snapshots": "npm run build && node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test-force-exit --test --test-update-snapshots \"build/tests/**/*.test.js\"",
+    "test:remote": "npm run build && node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/test-remote-bootstrap.ts",
     "prepare": "node --experimental-strip-types scripts/prepare.ts",
     "verify-server-json-version": "node --experimental-strip-types scripts/verify-server-json-version.ts"
   },

--- a/scripts/test-remote-bootstrap.ts
+++ b/scripts/test-remote-bootstrap.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const DEFAULT_BROWSER_URL = 'http://127.0.0.1:9222';
+const DEFAULT_FIRST_TOOL_TIMEOUT_MS = 10_000;
+const DEFAULT_LIST_PAGES_TIMEOUT_MS = 2_000;
+const REQUIRED_LOG_LINES = [
+  'bootstrap: setDiscoverTargets',
+  'bootstrap: setAutoAttach',
+  'bootstrap: waiting for first page or timeout',
+];
+
+function getElapsedMilliseconds(start: bigint): number {
+  const diff = process.hrtime.bigint() - start;
+  return Number(diff / BigInt(1_000_000));
+}
+
+async function wait(ms: number) {
+  await new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function main(): Promise<void> {
+  const browserUrl = process.env.REMOTE_CHROME_URL ?? DEFAULT_BROWSER_URL;
+  const bootstrapTimeoutMs = Number(
+    process.env.BOOTSTRAP_TIMEOUT_MS ?? 2_000,
+  );
+  const logDir =
+    process.env.MCP_LOG_DIR ?? path.join(process.cwd(), 'tmp', 'logs');
+  await fs.mkdir(logDir, {recursive: true});
+  const logFile = path.join(
+    logDir,
+    `remote-bootstrap-${Date.now()}.log`,
+  );
+
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: [
+      'build/src/index.js',
+      '--browserUrl',
+      browserUrl,
+      '--bootstrapTimeoutMs',
+      String(bootstrapTimeoutMs),
+      '--logFile',
+      logFile,
+    ],
+  });
+
+  const client = new Client(
+    {
+      name: 'remote-bootstrap-test',
+      version: '1.0.0',
+    },
+    {
+      capabilities: {},
+    },
+  );
+
+  try {
+    await assertBrowserReachable(browserUrl);
+    await client.connect(transport);
+
+    // First tool: select_page to avoid list_pages at startup.
+    const firstToolStart = process.hrtime.bigint();
+    await client.callTool({
+      name: 'select_page',
+      arguments: {pageIdx: 0},
+    });
+    const firstToolDuration = getElapsedMilliseconds(firstToolStart);
+    assert(
+      firstToolDuration <= DEFAULT_FIRST_TOOL_TIMEOUT_MS,
+      `First tool took ${firstToolDuration}ms (> ${DEFAULT_FIRST_TOOL_TIMEOUT_MS}ms).`,
+    );
+
+    // list_pages should complete quickly and exclude extension/devtools URLs.
+    const listPagesStart = process.hrtime.bigint();
+    const listPagesResult = await client.callTool({
+      name: 'list_pages',
+      arguments: {},
+    });
+    const listPagesDuration = getElapsedMilliseconds(listPagesStart);
+    assert(
+      listPagesDuration <= DEFAULT_LIST_PAGES_TIMEOUT_MS,
+      `list_pages took ${listPagesDuration}ms (> ${DEFAULT_LIST_PAGES_TIMEOUT_MS}ms).`,
+    );
+
+    const textContent = (listPagesResult.content ?? [])
+      .filter((entry): entry is {type: string; text: string} => {
+        return Boolean(entry && entry.type === 'text' && entry.text);
+      })
+      .map(entry => entry.text)
+      .join('\n');
+    if (!textContent) {
+      throw new Error('list_pages returned no textual content to inspect.');
+    }
+
+    const jsonStart = textContent.indexOf('[');
+    const jsonEnd = textContent.lastIndexOf(']');
+    assert(
+      jsonStart !== -1 && jsonEnd !== -1 && jsonEnd > jsonStart,
+      'Unable to locate pages JSON payload in list_pages response.',
+    );
+    const pagesJson = textContent.slice(jsonStart, jsonEnd + 1);
+    const pages = JSON.parse(pagesJson) as Array<{
+      index: number;
+      url: string;
+      title?: string;
+      selected?: boolean;
+    }>;
+    assert(Array.isArray(pages), 'list_pages payload is not an array.');
+    const forbidden = pages.filter(page => {
+      const lower = page.url.toLowerCase();
+      return (
+        lower.startsWith('chrome-extension://') ||
+        lower.startsWith('devtools://') ||
+        lower.includes('snaps/index.html') ||
+        lower.includes('offscreen.html')
+      );
+    });
+    assert(
+      forbidden.length === 0,
+      `list_pages included filtered URLs: ${forbidden.map(p => p.url).join(', ')}`,
+    );
+
+    await wait(250); // allow log stream to flush
+    const logContent = await fs.readFile(logFile, 'utf-8');
+    for (const line of REQUIRED_LOG_LINES) {
+      assert(
+        logContent.includes(line),
+        `Missing expected log line: "${line}"`,
+      );
+    }
+    assert(
+      /bootstrap: (first page attached|timed out, continuing)/.test(
+        logContent,
+      ),
+      'Missing bootstrap completion log (first page attached or timed out).',
+    );
+
+    console.log(
+      JSON.stringify(
+        {
+          browserUrl,
+          bootstrapTimeoutMs,
+          firstToolDurationMs: firstToolDuration,
+          listPagesDurationMs: listPagesDuration,
+          pagesCount: pages.length,
+          logFile,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await client.close();
+  }
+}
+
+async function assertBrowserReachable(browserUrl: string): Promise<void> {
+  const versionUrl = new URL('/json/version', browserUrl).toString();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, 3_000);
+  try {
+    const response = await fetch(versionUrl, {signal: controller.signal});
+    if (!response.ok) {
+      throw new Error(`Unexpected status ${response.status}`);
+    }
+    await response.json();
+  } catch (error) {
+    throw new Error(
+      `Unable to reach Chromium debugger at ${versionUrl}. ` +
+        `Ensure Chrome is running with --remote-debugging-port. Original error: ${
+          (error as Error).message
+        }`,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+main().catch(error => {
+  console.error('Remote bootstrap test failed:', error);
+  process.exitCode = 1;
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,6 +139,34 @@ export const cliOptions = {
     describe:
       'Additional arguments for Chrome. Only applies when Chrome is launched by chrome-devtools-mcp.',
   },
+  includeExtensionTargets: {
+    type: 'boolean',
+    default: false,
+    describe:
+      'Include extension-related targets (service workers, background pages, iframes) during bootstrap. Enable only if you need to interact with extension targets.',
+  },
+  bootstrapTimeoutMs: {
+    type: 'number',
+    default: 2_000,
+    describe:
+      'Maximum time in milliseconds to wait for the first page to auto-attach during bootstrap before continuing.',
+    coerce: (value: number | undefined) => {
+      if (value === undefined) {
+        return;
+      }
+      const numberValue = Number(value);
+      if (!Number.isFinite(numberValue) || numberValue < 0) {
+        throw new Error('bootstrapTimeoutMs must be a non-negative number.');
+      }
+      return numberValue;
+    },
+  },
+  verboseBootstrap: {
+    type: 'boolean',
+    default: true,
+    describe:
+      'Enable verbose logs for the browser bootstrap process. Disable with --no-verboseBootstrap.',
+  },
   categoryEmulation: {
     type: 'boolean',
     default: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,11 @@ async function getContext(): Promise<McpContext> {
     extraArgs.push(`--proxy-server=${args.proxyServer}`);
   }
   const devtools = args.experimentalDevtools ?? false;
+  const bootstrapOptions = {
+    includeExtensionTargets: args.includeExtensionTargets ?? false,
+    bootstrapTimeoutMs: args.bootstrapTimeoutMs ?? 2_000,
+    verboseBootstrap: args.verboseBootstrap ?? true,
+  };
   const browser =
     args.browserUrl || args.wsEndpoint
       ? await ensureBrowserConnected({
@@ -67,6 +72,7 @@ async function getContext(): Promise<McpContext> {
           wsEndpoint: args.wsEndpoint,
           wsHeaders: args.wsHeaders,
           devtools,
+          bootstrap: bootstrapOptions,
         })
       : await ensureBrowserLaunched({
           headless: args.headless,
@@ -78,11 +84,13 @@ async function getContext(): Promise<McpContext> {
           args: extraArgs,
           acceptInsecureCerts: args.acceptInsecureCerts,
           devtools,
+          bootstrap: bootstrapOptions,
         });
 
   if (context?.browser !== browser) {
     context = await McpContext.from(browser, logger, {
       experimentalDevToolsDebugging: devtools,
+      includeExtensionTargets: args.includeExtensionTargets ?? false,
     });
   }
   return context;

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {TextSnapshotNode} from '../McpContext.js';
+import type {TextSnapshotNode, VisiblePagesSummary} from '../McpContext.js';
 import {zod} from '../third_party/index.js';
 import type {Dialog, ElementHandle, Page} from '../third_party/index.js';
 import type {TraceResult} from '../trace-processing/parse.js';
@@ -119,6 +119,7 @@ export type Context = Readonly<{
    * Returns a reqid for a cdpRequestId.
    */
   resolveCdpElementId(cdpBackendNodeId: number): string | undefined;
+  getVisiblePagesSummary(): Promise<VisiblePagesSummary>;
 }>;
 
 export function defineTool<Schema extends zod.ZodRawShape>(

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -10,6 +10,12 @@ import {parseArguments} from '../src/cli.js';
 
 describe('cli args parsing', () => {
   const defaultArgs = {
+    'include-extension-targets': false,
+    includeExtensionTargets: false,
+    'bootstrap-timeout-ms': 2_000,
+    bootstrapTimeoutMs: 2_000,
+    'verbose-bootstrap': true,
+    verboseBootstrap: true,
     'category-emulation': true,
     categoryEmulation: true,
     'category-performance': true,
@@ -67,6 +73,37 @@ describe('cli args parsing', () => {
       u: undefined,
       channel: 'stable',
     });
+  });
+
+  it('parses includeExtensionTargets', async () => {
+    const args = parseArguments('1.0.0', [
+      'node',
+      'main.js',
+      '--includeExtensionTargets',
+    ]);
+    assert.equal(args.includeExtensionTargets, true);
+    assert.equal(args['include-extension-targets'], true);
+  });
+
+  it('parses bootstrapTimeoutMs', async () => {
+    const args = parseArguments('1.0.0', [
+      'node',
+      'main.js',
+      '--bootstrapTimeoutMs',
+      '4500',
+    ]);
+    assert.equal(args.bootstrapTimeoutMs, 4_500);
+    assert.equal(args['bootstrap-timeout-ms'], 4_500);
+  });
+
+  it('parses verboseBootstrap', async () => {
+    const args = parseArguments('1.0.0', [
+      'node',
+      'main.js',
+      '--no-verboseBootstrap',
+    ]);
+    assert.equal(args.verboseBootstrap, false);
+    assert.equal(args['verbose-bootstrap'], false);
   });
 
   it('parses with executable path', async () => {

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -24,7 +24,24 @@ describe('pages', () => {
     it('list pages', async () => {
       await withBrowser(async (response, context) => {
         await listPages.handler({params: {}}, response, context);
-        assert.ok(response.includePages);
+        assert.strictEqual(response.responseLines[0], 'pages:');
+        const serializedPages = response.responseLines.at(1);
+        assert.ok(serializedPages);
+        const pages = JSON.parse(serializedPages ?? '[]');
+        assert.equal(pages.length, 1);
+        const page = pages[0] as {
+          id: string;
+          index: number;
+          selected: boolean;
+          title: string;
+          url: string;
+        };
+        assert.equal(page.index, 0);
+        assert.equal(page.url, 'about:blank');
+        assert.equal(page.selected, true);
+        assert.equal(page.title, '');
+        assert.equal(typeof page.id, 'string');
+        assert.ok(!response.includePages);
       });
     });
   });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -53,6 +53,7 @@ export async function withBrowser(
     logger('test'),
     {
       experimentalDevToolsDebugging: false,
+      includeExtensionTargets: false,
     },
     Locator,
   );


### PR DESCRIPTION
## Summary
- add filtered `Target.setAutoAttach` setup with short “first page attached or timeout” race so MetaMask-heavy sessions no longer stall bootstrap
- filter extension/devtools URLs out of `list_pages` by default, expose stable JSON payload, and plumb new CLI flags (`--includeExtensionTargets`, `--bootstrapTimeoutMs`, `--verboseBootstrap`)
- add automation (`npm run test:remote`) + docs/tests updates and extra logging to keep behavior transparent and configurable

## Testing
- npm test
- npm run test:remote  # against Chromium w/ MetaMask at http://127.0.0.1:9222
