### PR TITLE
docs: add Factory CLI configuration to MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ Go to `Cursor Settings` -> `MCP` -> `New MCP Server`. Use the config provided ab
 </details>
 
 <details>
+  <summary>Factory CLI</summary>
+Use the Factory CLI to add the Chrome DevTools MCP server (<a href="https://docs.factory.ai/cli/configuration/mcp">guide</a>):
+
+```bash
+droid mcp add chrome-devtools "npx -y chrome-devtools-mcp@latest"
+```
+
+</details>
+
+<details>
   <summary>Gemini CLI</summary>
 Install the Chrome DevTools MCP server using the Gemini CLI.
 


### PR DESCRIPTION
This PR adds Factory CLI to the MCP client configuration section in the README.

The Factory CLI section:
- Follows the same format as other MCP clients
- Is placed in alphabetical order (between Cursor and Gemini CLI)
- Includes a link to the Factory documentation
- Provides the command to add the Chrome DevTools MCP server using `droid mcp add`
