### PR TITLE
fix: Augment fix to prevent stray OGS frames in NTP from causing hangs.

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -30,7 +30,7 @@ function makeTargetFilter() {
     if (target.url() === 'chrome://newtab/') {
       return true;
     }
-    if (target.url().startsWith('https://ogs.google.com/widget/app/so')) {
+    if (target.url().startsWith('https://ogs.google.com/')) {
       // Some special frame on the NTP that is not picked up by CDP-auto-attach.
       return false;
     }


### PR DESCRIPTION
(original fix: https://github.com/ChromeDevTools/chrome-devtools-mcp/pull/504)