### PR TITLE
Add Dockerfile for Docker MCP registry support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use Node.js 20 with Puppeteer (includes Chrome)
+FROM ghcr.io/puppeteer/puppeteer:24.1.0
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the project
+RUN npm run build
+
+# Set user to non-root for security
+USER pptruser
+
+# Expose MCP port (stdio transport doesn't need exposed ports, but good practice)
+# MCP uses stdio by default when run with npx
+
+# Run the MCP server
+CMD ["node", "build/src/index.js"]


### PR DESCRIPTION
This PR adds a Dockerfile to enable chrome-devtools-mcp to be added to the Docker MCP registry.

## Changes
- Added Dockerfile using Puppeteer base image (includes Chrome)
- Configured for container deployment in Docker MCP toolkit
- Follows MCP server containerization best practices

## Motivation
This will allow chrome-devtools-mcp to be integrated into Docker Desktop's MCP Toolkit, providing a unified way to deploy and manage the server alongside other MCP servers.

## Testing
The Dockerfile can be tested by building and running it locally:
```bash
docker build -t chrome-devtools-mcp .
docker run --rm -i chrome-devtools-mcp
```