### PR TITLE
docs: add VS Code install badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,12 @@ Configure the following fields and press `CTRL+S` to save the configuration:
 **Or install manually:**
 
 Follow the MCP install <a href="https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server">guide</a>,
-  with the standard config from above. You can also install the Chrome DevTools MCP server using the VS Code CLI:
-  
-  ```bash
-  code --add-mcp '{"name":"io.github.ChromeDevTools/chrome-devtools-mcp","command":"npx","args":["-y","chrome-devtools-mcp"],"env":{}}'
-  ```
+with the standard config from above. You can also install the Chrome DevTools MCP server using the VS Code CLI:
+
+```bash
+code --add-mcp '{"name":"io.github.ChromeDevTools/chrome-devtools-mcp","command":"npx","args":["-y","chrome-devtools-mcp"],"env":{}}'
+```
+
 </details>
 
 <details>


### PR DESCRIPTION
Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/531

(Once https://github.com/mcp is the default GA registry in VS Code, the link can be updated to show the registry page)