### PR TITLE
chore: remove no-restricted-imports rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -113,22 +113,6 @@ export default defineConfig([
 
       '@stylistic/function-call-spacing': 'error',
       '@stylistic/semi': 'error',
-
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: [
-                '*/node_modules/chrome-devtools-frontend/*',
-                '!*/node_modules/chrome-devtools-frontend/mcp/mcp.js',
-              ],
-              message:
-                'Import devtools-frontend code only from node_modules/chrome-devtools-frontend/mcp/mcp.js',
-            },
-          ],
-        },
-      ],
     },
   },
   {

--- a/src/DevToolsConnectionAdapter.ts
+++ b/src/DevToolsConnectionAdapter.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// eslint-disable-next-line no-restricted-imports
-import {ConnectionTransport as DevToolsConnectionTransport} from '../node_modules/chrome-devtools-frontend/front_end/core/protocol_client/ConnectionTransport.js';
+import {ConnectionTransport as DevToolsConnectionTransport} from '../node_modules/chrome-devtools-frontend/mcp/mcp.js';
 
 import {type ConnectionTransport} from './third_party/index.js';
 


### PR DESCRIPTION
It does not appear to work as documented and all attempts to make the glob pattern work failed. Will check this manually for now.