### PR TITLE
docs: add Qoder CLI to the MCP client configuration section in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Alternatively, follow the <a href="https://docs.qoder.com/user-guide/chat/model-
 <details>
   <summary>Qoder CLI</summary>
 
-Install the Chrome DevTools MCP server using the Qoder CLI  (<a href="https://docs.qoder.com/cli/using-cli#mcp-servsers">guide</a>):
+Install the Chrome DevTools MCP server using the Qoder CLI (<a href="https://docs.qoder.com/cli/using-cli#mcp-servsers">guide</a>):
 
 **Project wide:**
 
@@ -256,6 +256,7 @@ qodercli mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
 ```bash
 qodercli mcp add -s user chrome-devtools -- npx chrome-devtools-mcp@latest
 ```
+
 </details>
 
 <details>


### PR DESCRIPTION
This PR adds [Qoder CLI](https://qoder.com/cli) to the MCP client configuration section in the README.

The Qoder CLI section:

Follows the same format as other MCP clients
Is placed in alphabetical order (between Qoder and Visual Studio)
Includes a link to the Qoder CLI [documentation](https://docs.qoder.com/cli/using-cli#mcp-servsers)
Provides the command to add the Chrome DevTools MCP server using `qodercli mcp add`