### PR TITLE
refactor: clear issue aggregator on page navigation

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -155,6 +155,11 @@ export class McpContext implements Context {
     await this.#consoleCollector.init();
   }
 
+  dispose() {
+    this.#networkCollector.dispose();
+    this.#consoleCollector.dispose();
+  }
+
   static async from(
     browser: Browser,
     logger: Debugger,

--- a/tests/PageCollector.test.ts
+++ b/tests/PageCollector.test.ts
@@ -12,7 +12,6 @@ import type {
   HTTPRequest,
   Page,
   Target,
-  CDPSession,
   Protocol,
 } from 'puppeteer-core';
 import sinon from 'sinon';
@@ -59,9 +58,6 @@ function getMockPage(): Page {
   return {
     mainFrame() {
       return mainFrame;
-    },
-    createCDPSession() {
-      return Promise.resolve(cdpSession as unknown as CDPSession);
     },
     ...mockListener(),
     // @ts-expect-error internal API.

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -18,6 +18,7 @@ import {McpResponse} from '../src/McpResponse.js';
 import {stableIdSymbol} from '../src/PageCollector.js';
 
 const browsers = new Map<string, Browser>();
+let context: McpContext | undefined;
 
 export async function withBrowser(
   cb: (response: McpResponse, context: McpContext) => Promise<void>,
@@ -48,7 +49,10 @@ export async function withBrowser(
     }),
   );
   const response = new McpResponse();
-  const context = await McpContext.from(
+  if (context) {
+    context.dispose();
+  }
+  context = await McpContext.from(
     browser,
     logger('test'),
     {


### PR DESCRIPTION
- fixes a memory leak introduced previously (I could not pinpoint it but McpContext was retained for subsequent tests).
- adds a test that issue continue being aggregated on reload.
- moves page-specific logic to a class.