### PR TITLE
feat: Add ability to inject script to run on page load

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -157,7 +157,7 @@
 
 - **handleBeforeUnload** (enum: "accept", "decline") _(optional)_: Whether to auto accept or beforeunload dialogs triggered by this navigation. Default is accept.
 - **ignoreCache** (boolean) _(optional)_: Whether to ignore cache on reload.
-- **initScript** (string) _(optional)_: (optional) A JavaScript function to be executed by the tool on new document for every page load before any other scripts.
+- **initScript** (string) _(optional)_: A JavaScript script to be executed on each new document before any other scripts for the next navigation.
 - **timeout** (integer) _(optional)_: Maximum wait time in milliseconds. If set to 0, the default timeout will be used.
 - **type** (enum: "url", "back", "forward", "reload") _(optional)_: Navigate the page by URL, back or forward in history, or reload.
 - **url** (string) _(optional)_: Target URL (only type=url)

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -298,7 +298,7 @@ describe('pages', () => {
       });
     });
     it('navigates to correct page with initScript', async () => {
-      await withBrowser(async (response, context) => {
+      await withMcpContext(async (response, context) => {
         await navigatePage.handler(
           {
             params: {


### PR DESCRIPTION
Adds a parameter "initScript" to be used to inject a script into the page load before other scripts execute.
[Page.evaluateOnNewDocument](https://pptr.dev/api/puppeteer.page.evaluateonnewdocument)

See #567