### PR TITLE
chore: prevent dropping license notices on some files when publishing

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import {
   AggregatedIssue,
   Marked,

--- a/src/WaitForHelper.ts
+++ b/src/WaitForHelper.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import {logger} from './logger.js';
 import type {Page, Protocol, CdpPage} from './third_party/index.js';
 

--- a/src/formatters/snapshotFormatter.ts
+++ b/src/formatters/snapshotFormatter.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import type {TextSnapshot, TextSnapshotNode} from '../McpContext.js';
 
 export function formatSnapshotNode(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import fs from 'node:fs';
 
 import {debug} from './third_party/index.js';

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import 'core-js/modules/es.promise.with-resolvers.js';
 import 'core-js/proposals/iterator-helpers.js';
 

--- a/src/utils/keyboard.ts
+++ b/src/utils/keyboard.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import type {KeyInput} from '../third_party/index.js';
 
 // See the KeyInput type for the list of supported keys.

--- a/tests/DevtoolsUtils.test.ts
+++ b/tests/DevtoolsUtils.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {readFile, rm} from 'node:fs/promises';
 import {tmpdir} from 'node:os';

--- a/tests/PageCollector.test.ts
+++ b/tests/PageCollector.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {afterEach, beforeEach, describe, it} from 'node:test';
 

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import os from 'node:os';
 import path from 'node:path';

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import fs from 'node:fs';
 import {describe, it} from 'node:test';

--- a/tests/server.ts
+++ b/tests/server.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import http, {
   type IncomingMessage,
   type Server,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import '../src/polyfill.js';
 
 import path from 'node:path';

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {afterEach, before, beforeEach, describe, it} from 'node:test';
 

--- a/tests/tools/emulation.test.ts
+++ b/tests/tools/emulation.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/tests/tools/network.test.ts
+++ b/tests/tools/network.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 

--- a/tests/tools/performance.test.ts
+++ b/tests/tools/performance.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it, afterEach} from 'node:test';
 

--- a/tests/tools/screenshot.test.ts
+++ b/tests/tools/screenshot.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {rm, stat, mkdir, chmod, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 

--- a/tests/tools/snapshot.test.ts
+++ b/tests/tools/snapshot.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 

--- a/tests/trace-processing/parse.test.ts
+++ b/tests/trace-processing/parse.test.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import logger from 'debug';
 import type {Browser} from 'puppeteer';
 import puppeteer, {Locator} from 'puppeteer';


### PR DESCRIPTION
This PR prevents license notices being dropped when creating package for publication.

This can happen when first import in the file is type-only import that gets removed during build. When there is no empty line between the license block comment and such import, the comment is treated as related to the import and gets removed alongside it.
Adding an empty line between copyright notice and the import fixes the issue.