### PR TITLE
fix: handle the case when all pages are filtered out

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -407,7 +407,10 @@ export class McpContext implements Context {
       );
     });
 
-    if (!this.#selectedPage || this.#pages.indexOf(this.#selectedPage) === -1) {
+    if (
+      (!this.#selectedPage || this.#pages.indexOf(this.#selectedPage) === -1) &&
+      this.#pages[0]
+    ) {
       this.selectPage(this.#pages[0]);
     }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -30,6 +30,10 @@ function makeTargetFilter() {
     if (target.url() === 'chrome://newtab/') {
       return true;
     }
+    // Could be the only page opened in the browser.
+    if (target.url().startsWith('chrome://inspect')) {
+      return true;
+    }
     for (const prefix of ignoredPrefixes) {
       if (target.url().startsWith(prefix)) {
         return false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -148,6 +148,7 @@ function registerTool(tool: ToolDefinition): void {
             content,
           };
         } catch (error) {
+          logger(`${tool.name} response handling error:`, error, error.stack);
           const errorText =
             error instanceof Error ? error.message : String(error);
 
@@ -162,7 +163,7 @@ function registerTool(tool: ToolDefinition): void {
           };
         }
       } catch (err) {
-        logger(`${tool.name} error: ${err.message}`);
+        logger(`${tool.name} error:`, err, err.stack);
         throw err;
       } finally {
         guard.dispose();


### PR DESCRIPTION
Drive-by: allow attaching to chrome://inspect pages