### PR TITLE
chore: add UniverseManager to create DevTools Universes for each Page

### DIFF
--- a/scripts/post-build.ts
+++ b/scripts/post-build.ts
@@ -88,6 +88,13 @@ export const LOCAL_FETCH_PATTERN = './locales/@LOCALE@.json';`;
   const runtimeContent = `
 export function getChromeVersion() { return ''; };
 export const hostConfig = {};
+export const Runtime = {
+  isDescriptorEnabled: () => true,
+  queryParam: () => null,
+}
+export const experiments = {
+  isEnabled: () => false,
+}
   `;
   writeFile(runtimeFile, runtimeContent);
 


### PR DESCRIPTION
A follow-up PR will add a single instance of the `UniverseManager` to `McpContext` similarly to the *Collectors. We don't do that in this PR yet, as we need to wait for some chrome-devtools-frontend changes to roll.