### PR TITLE
chore: suppress DevTools CDP command errors

### DIFF
--- a/src/DevtoolsUtils.ts
+++ b/src/DevtoolsUtils.ts
@@ -10,6 +10,7 @@ import {
   type IssuesManagerEventTypes,
   MarkdownIssueDescription,
   Marked,
+  ProtocolClient,
   Common,
   I18n,
 } from '../node_modules/chrome-devtools-frontend/mcp/mcp.js';
@@ -124,6 +125,9 @@ export function mapIssueToMessageObject(issue: AggregatedIssue) {
     description: processedMarkdown,
   };
 }
+
+// DevTools CDP errors can get noisy.
+ProtocolClient.InspectorBackend.test.suppressRequestErrors = true;
 
 I18n.DevToolsLocale.DevToolsLocale.instance({
   create: true,


### PR DESCRIPTION
This PR suppresses all the CDP command errors that DevTools logs via `console.error`. (mostly `Storage.getStorageKey`  errors). These `console.error`s could also break MCP client that don't ignore invalid JSON on stdio.