### PR TITLE
fix: use page.setViewport instead of page.resize

### DIFF
--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -207,10 +207,9 @@ export const resizePage = defineTool({
   handler: async (request, response, context) => {
     const page = context.getSelectedPage();
 
-    // @ts-expect-error internal API for now.
-    await page.resize({
-      contentWidth: request.params.width,
-      contentHeight: request.params.height,
+    await page.setViewport({
+      width: request.params.width,
+      height: request.params.height,
     });
 
     response.setIncludePages(true);


### PR DESCRIPTION
## Description
Fixes #645.

The `resize_page` tool was failing with a `Protocol error (Browser.setContentsSize): 'Browser.setContentsSize' wasn't found` when running against certain Chrome environments (e.g., remote debugging). This was because it relied on an internal `page.resize` method that uses `Browser.setContentsSize`, which is not universally supported.

This PR replaces the internal `page.resize` call with the standard Puppeteer `page.setViewport` method. This uses `Emulation.setDeviceMetricsOverride` under the hood, which is the standard and supported way to resize the viewport for testing and emulation.

## Changes
- Replaced `page.resize` with `page.setViewport` in [src/tools/pages.ts](cci:7://file:///c:/Users/Home/Desktop/code/Chrom-dev-tools/src/tools/pages.ts:0:0-0:0).

## Verification
- Verified that `resize_page` now correctly calls `page.setViewport` with the provided dimensions.