### PR TITLE
docs: improve autoConnect docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ The Chrome DevTools MCP server supports the following configuration option:
 <!-- BEGIN AUTO GENERATED OPTIONS -->
 
 - **`--autoConnect`**
-  If specified, automatically connects to a browser (Chrome 145+) running in the user data directory identified by the channel param.
+  If specified, automatically connects to a browser (Chrome 145+) running in the user data directory identified by the channel param. Requires remote debugging being enabled in Chrome here: chrome://inspect/#remote-debugging.
   - **Type:** boolean
   - **Default:** `false`
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -134,7 +134,7 @@ export async function ensureBrowserConnected(options: {
     browser = await puppeteer.connect(connectOptions);
   } catch (err) {
     throw new Error(
-      'Could not connect to Chrome. Check if Chrome is running and remote debugging is enabled.',
+      'Could not connect to Chrome. Check if Chrome is running and remote debugging is enabled by going to chrome://inspect/#remote-debugging.',
       {
         cause: err,
       },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ export const cliOptions = {
   autoConnect: {
     type: 'boolean',
     description:
-      'If specified, automatically connects to a browser (Chrome 145+) running in the user data directory identified by the channel param.',
+      'If specified, automatically connects to a browser (Chrome 145+) running in the user data directory identified by the channel param. Requires remote debugging being enabled in Chrome here: chrome://inspect/#remote-debugging.',
     conflicts: ['isolated', 'executablePath'],
     default: false,
     coerce: (value: boolean | undefined) => {


### PR DESCRIPTION
Mention chrome://inspect/#remote-debugging in CLI docs and error message.