### PR TITLE
feat: support --user-data-dir with --auto-connect

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ export const cliOptions = {
     type: 'boolean',
     description:
       'If specified, automatically connects to a browser (Chrome 145+) running in the user data directory identified by the channel param.',
-    conflicts: ['isolated', 'executablePath', 'userDataDir'],
+    conflicts: ['isolated', 'executablePath'],
     default: false,
     coerce: (value: boolean | undefined) => {
       if (!value) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,7 @@ async function getContext(): Promise<McpContext> {
           wsHeaders: args.wsHeaders,
           // Important: only pass channel, if autoConnect is true.
           channel: args.autoConnect ? (args.channel as Channel) : undefined,
+          userDataDir: args.userDataDir,
           devtools,
         })
       : await ensureBrowserLaunched({

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -29,3 +29,9 @@ export {
 export {default as puppeteer} from 'puppeteer-core';
 export type * from 'puppeteer-core';
 export type {CdpPage} from 'puppeteer-core/internal/cdp/Page.js';
+export {
+  resolveDefaultUserDataDir,
+  detectBrowserPlatform,
+  Browser as BrowserEnum,
+  type ChromeReleaseChannel as BrowsersChromeReleaseChannel,
+} from '@puppeteer/browsers';

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -11,7 +11,7 @@ import {describe, it} from 'node:test';
 
 import {executablePath} from 'puppeteer';
 
-import {launch} from '../src/browser.js';
+import {ensureBrowserConnected, launch} from '../src/browser.js';
 
 describe('browser', () => {
   it('cannot launch multiple times with the same profile', async () => {
@@ -69,6 +69,29 @@ describe('browser', () => {
         width: 1501,
         height: 801,
       });
+    } finally {
+      await browser.close();
+    }
+  });
+  it('connects to an existing browser with userDataDir', async () => {
+    const tmpDir = os.tmpdir();
+    const folderPath = path.join(tmpDir, `temp-folder-${crypto.randomUUID()}`);
+    const browser = await launch({
+      headless: true,
+      isolated: false,
+      userDataDir: folderPath,
+      executablePath: executablePath(),
+      devtools: false,
+      args: ['--remote-debugging-port=0'],
+    });
+    try {
+      const connectedBrowser = await ensureBrowserConnected({
+        userDataDir: folderPath,
+        devtools: false,
+      });
+      assert.ok(connectedBrowser);
+      assert.ok(connectedBrowser.isConnected());
+      connectedBrowser.disconnect();
     } finally {
       await browser.close();
     }


### PR DESCRIPTION
This PR integrates `--user-data-dir` with the `--auto-connect` feature. If `--user-data-dir` is provided as well `--auto-connect`, the specified dir is used to locate a running browser server.