### PR TITLE
docs: add OpenCode integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,25 @@ Or, from the IDE **Activity Bar** > `Kiro` > `MCP Servers` > `Click Open MCP Con
 </details>
 
 <details>
+  <summary>OpenCode</summary>
+
+Add the following configuration to your `opencode.json` (project-specific) or `~/.config/opencode/config.json` (global):
+
+```json
+{
+  "mcp": {
+    "chrome-devtools": {
+      "type": "local",
+      "command": ["npx", "-y", "chrome-devtools-mcp@latest"],
+      "enabled": true
+    }
+  }
+}
+```
+
+</details>
+
+<details>
   <summary>Qoder</summary>
 
 In **Qoder Settings**, go to `MCP Server` > `+ Add` > Use the configuration snippet provided above.


### PR DESCRIPTION
## Summary
This PR adds integration instructions for **OpenCode**, an open-source AI coding agent, to the `README.md`.

## Details
OpenCode supports MCP servers through its configuration file (`opencode.json` or global `config.json`). Adding these instructions helps OpenCode users quickly set up and use the Chrome DevTools MCP features within their agent sessions.

The instructions follow the alphabetical order of the existing client list (inserted between Kiro and Qoder).