### PR TITLE
docs: fix typos and improve clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ amp mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
 <details>
   <summary>Antigravity</summary>
 
-To use the Chrome DevTools MCP server follow the instructions from <a href="https://antigravity.google/docs/mcp">Antigravity's docs<a/> to install a custom MCP server. Add the following config to the MCP servers config:
+To use the Chrome DevTools MCP server follow the instructions from <a href="https://antigravity.google/docs/mcp">Antigravity's docs</a> to install a custom MCP server. Add the following config to the MCP servers config:
 
-```bash
+```json
 {
   "mcpServers": {
     "chrome-devtools": {
@@ -85,7 +85,7 @@ To use the Chrome DevTools MCP server follow the instructions from <a href="http
 
 This will make the Chrome DevTools MCP server automatically connect to the browser that Antigravity is using. If you are not using port 9222, make sure to adjust accordingly.
 
-Chrome DevTools MCP will not start the browser instance automatically using this approach as as the Chrome DevTools MCP server runs in Antigravity's built-in browser. If the browser is not already running, you have to start it first by clicking the Chrome icon at the top right corner.
+Chrome DevTools MCP will not start the browser instance automatically using this approach as the Chrome DevTools MCP server runs in Antigravity's built-in browser. If the browser is not already running, you have to start it first by clicking the Chrome icon at the top right corner.
 
 </details>
 

--- a/docs/debugging-android.md
+++ b/docs/debugging-android.md
@@ -2,7 +2,7 @@
 
 This is an experimental feature as Puppeteer does not officially support Chrome on Android as a target.
 
-The workflow below works for most users. See [Troubleshooting: DevTools is not detecting the Android device for more help](https://developer.chrome.com/docs/devtools/remote-debugging#troubleshooting) for more help.
+The workflow below works for most users. See [Troubleshooting: DevTools is not detecting the Android device](https://developer.chrome.com/docs/devtools/remote-debugging#troubleshooting) if you encounter any issues.
 
 1. Open the Developer Options screen on your Android. See [Configure on-device developer Options](https://developer.android.com/studio/debug/dev-options.html).
 2. Select Enable USB Debugging.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,8 +4,8 @@
 
 - Run `npx chrome-devtools-mcp@latest --help` to test if the MCP server runs on your machine.
 - Make sure that your MCP client uses the same npm and node version as your terminal.
-- When configuring your MCP client, try using the `--yes` argument to `npx` to
-  auto-accept installation prompt.
+- When configuring your MCP client, try using the `-y` argument to `npx` to
+  auto-accept installation prompts (e.g., `npx -y chrome-devtools-mcp@latest`).
 - Find a specific error in the output of the `chrome-devtools-mcp` server.
   Usually, if your client is an IDE, logs would be in the Output pane.
 


### PR DESCRIPTION
## Summary
This PR fixes several minor documentation issues to improve readability and correctness:

- Fixed duplicate "as as" typo in Antigravity section
- Fixed malformed closing HTML tag in Antigravity docs link
- Changed `bash` code block to `json` for proper syntax highlighting of Antigravity config
- Improved clarity around using the `-y` flag with npx in troubleshooting guide
- Removed redundant "for more help" phrase in Android debugging documentation

## Changes
All changes are documentation-only and do not affect any code:
- `/tmp/chrome-mcp/README.md` - Fixed typos and code block syntax
- `/tmp/chrome-mcp/docs/troubleshooting.md` - Improved npx flag documentation  
- `/tmp/chrome-mcp/docs/debugging-android.md` - Removed redundant wording

These are small fixes that improve documentation quality for end users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)