### PR TITLE
fix: use relative path for plugin source in marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,7 @@
   "plugins": [
     {
       "name": "chrome-devtools-mcp",
-      "source": {
-        "source": "github",
-        "repo": "ChromeDevTools/chrome-devtools-mcp"
-      },
+      "source": "./",
       "description": "Reliable automation, in-depth debugging, and performance analysis in Chrome using Chrome DevTools and Puppeteer"
     }
   ]


### PR DESCRIPTION
The previous GitHub self-reference format was not recognized by Claude Code when adding this repository as an external marketplace. Using a relative path `./` follows the pattern used by other official plugins like [Sentry](https://github.com/getsentry/sentry-for-claude/blob/main/.claude-plugin/marketplace.json) and ensures proper plugin discovery.

<img width="1824" height="1488" alt="image" src="https://github.com/user-attachments/assets/18e8767d-b362-4c08-a166-ae91ff9d2711" />
