### PR TITLE
chore: implement stack trace formatting for console messages

### DIFF
--- a/src/third_party/devtools.ts
+++ b/src/third_party/devtools.ts
@@ -7,6 +7,7 @@
 export type {
   IssuesManagerEventTypes,
   CDPConnection,
+  StackTrace,
 } from '../../node_modules/chrome-devtools-frontend/mcp/mcp.js';
 export {
   AgentFocus,

--- a/tests/formatters/consoleFormatter.test.js.snapshot
+++ b/tests/formatters/consoleFormatter.test.js.snapshot
@@ -10,6 +10,16 @@ exports[`consoleFormatter > formatConsoleEventShort > formats a console.log mess
 msgid=2 [log] Processing file: (1 args)
 `;
 
+exports[`consoleFormatter > formatConsoleEventVerbose > formats a console message with a stack trace 1`] = `
+ID: 5
+Message: log> Hello stack trace!
+### Stack trace
+at foo (foo.ts:10:2)
+at bar (foo.ts:20:2)
+--- setTimeout -------------------------
+at schedule (util.ts:5:2)
+`;
+
 exports[`consoleFormatter > formatConsoleEventVerbose > formats a console.error message 1`] = `
 ID: 4
 Message: error> Something went wrong

--- a/tests/formatters/consoleFormatter.test.ts
+++ b/tests/formatters/consoleFormatter.test.ts
@@ -11,6 +11,7 @@ import {
   formatConsoleEventShort,
   formatConsoleEventVerbose,
 } from '../../src/formatters/consoleFormatter.js';
+import type {DevTools} from '../../src/third_party/index.js';
 import {getMockAggregatedIssue} from '../utils.js';
 
 describe('consoleFormatter', () => {
@@ -88,6 +89,48 @@ describe('consoleFormatter', () => {
         consoleMessageStableId: 4,
         type: 'error',
         message: 'Something went wrong',
+      };
+      const result = formatConsoleEventVerbose(message);
+      t.assert.snapshot?.(result);
+    });
+
+    it('formats a console message with a stack trace', t => {
+      const message: ConsoleMessageData = {
+        consoleMessageStableId: 5,
+        type: 'log',
+        message: 'Hello stack trace!',
+        args: [],
+        stackTrace: {
+          syncFragment: {
+            frames: [
+              {
+                line: 10,
+                column: 2,
+                url: 'foo.ts',
+                name: 'foo',
+              },
+              {
+                line: 20,
+                column: 2,
+                url: 'foo.ts',
+                name: 'bar',
+              },
+            ],
+          },
+          asyncFragments: [
+            {
+              description: 'setTimeout',
+              frames: [
+                {
+                  line: 5,
+                  column: 2,
+                  url: 'util.ts',
+                  name: 'schedule',
+                },
+              ],
+            },
+          ],
+        } as unknown as DevTools.StackTrace.StackTrace.StackTrace,
       };
       const result = formatConsoleEventVerbose(message);
       t.assert.snapshot?.(result);


### PR DESCRIPTION
The PR only implements the formatting, we don't create `DevTools.StackTrace` instances from puppeteer console message stack traces yet.