### PR TITLE
chore: experimental vision mode

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -152,6 +152,11 @@ export const cliOptions = {
     describe: 'Whether to enable automation over DevTools targets',
     hidden: true,
   },
+  experimentalVision: {
+    type: 'boolean',
+    describe: 'Whether to enable vision tools',
+    hidden: true,
+  },
   experimentalIncludeAllPages: {
     type: 'boolean',
     describe:

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,6 +121,12 @@ function registerTool(tool: ToolDefinition): void {
   ) {
     return;
   }
+  if (
+    tool.annotations.conditions?.includes('computerVision') &&
+    !args.experimentalVision
+  ) {
+    return;
+  }
   server.registerTool(
     tool.name,
     {

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -24,6 +24,7 @@ export interface ToolDefinition<
      * If true, the tool does not modify its environment.
      */
     readOnlyHint: boolean;
+    conditions?: string[];
   };
   schema: Schema;
   handler: (

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -12,8 +12,13 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 import {executablePath} from 'puppeteer';
 
+import type {ToolDefinition} from '../src/tools/ToolDefinition';
+
 describe('e2e', () => {
-  async function withClient(cb: (client: Client) => Promise<void>) {
+  async function withClient(
+    cb: (client: Client) => Promise<void>,
+    extraArgs: string[] = [],
+  ) {
     const transport = new StdioClientTransport({
       command: 'node',
       args: [
@@ -22,6 +27,7 @@ describe('e2e', () => {
         '--isolated',
         '--executable-path',
         executablePath(),
+        ...extraArgs,
       ],
     });
     const client = new Client(
@@ -90,8 +96,11 @@ describe('e2e', () => {
           continue;
         }
         const fileTools = await import(`../src/tools/${file}`);
-        for (const maybeTool of Object.values<object>(fileTools)) {
+        for (const maybeTool of Object.values<ToolDefinition>(fileTools)) {
           if ('name' in maybeTool) {
+            if (maybeTool.annotations?.conditions?.includes('computerVision')) {
+              continue;
+            }
             definedNames.push(maybeTool.name);
           }
         }
@@ -99,5 +108,16 @@ describe('e2e', () => {
       definedNames.sort();
       assert.deepStrictEqual(exposedNames, definedNames);
     });
+  });
+
+  it('has experimental vision tools', async () => {
+    await withClient(
+      async client => {
+        const {tools} = await client.listTools();
+        const clickAt = tools.find(t => t.name === 'click_at');
+        assert.ok(clickAt);
+      },
+      ['--experimental-vision'],
+    );
   });
 });

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -17,6 +17,7 @@ import {
   fillForm,
   uploadFile,
   pressKey,
+  clickAt,
 } from '../../src/tools/input.js';
 import {parseKey} from '../../src/utils/keyboard.js';
 import {serverHooks} from '../server.js';
@@ -179,6 +180,67 @@ describe('input', () => {
         );
         assert.ok(response.includeSnapshot);
         assert.ok(await page.$('text/hovered'));
+      });
+    });
+  });
+
+  describe('click_at', () => {
+    it('clicks at coordinates', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPage();
+        await page.setContent(
+          html`<div
+            style="width: 100px; height: 100px; background: red;"
+            onclick="this.innerText = 'clicked'"
+          ></div>`,
+        );
+        await context.createTextSnapshot();
+        await clickAt.handler(
+          {
+            params: {
+              x: 50,
+              y: 50,
+            },
+          },
+          response,
+          context,
+        );
+        assert.strictEqual(
+          response.responseLines[0],
+          'Successfully clicked at the coordinates',
+        );
+        assert.ok(response.includeSnapshot);
+        assert.ok(await page.$('text/clicked'));
+      });
+    });
+
+    it('double clicks at coordinates', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPage();
+        await page.setContent(
+          html`<div
+            style="width: 100px; height: 100px; background: red;"
+            ondblclick="this.innerText = 'dblclicked'"
+          ></div>`,
+        );
+        await context.createTextSnapshot();
+        await clickAt.handler(
+          {
+            params: {
+              x: 50,
+              y: 50,
+              dblClick: true,
+            },
+          },
+          response,
+          context,
+        );
+        assert.strictEqual(
+          response.responseLines[0],
+          'Successfully double clicked at the coordinates',
+        );
+        assert.ok(response.includeSnapshot);
+        assert.ok(await page.$('text/dblclicked'));
       });
     });
   });


### PR DESCRIPTION
this PR adds the `--experimental-vision` argument that exposes additional tool for visual automation (currently, click_at(x, y)).