### PR TITLE
Add WordPress debugging example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,21 @@ Your MCP client should open the browser and record a performance trace.
 
 > [!NOTE]  
 > The MCP server will start the browser automatically once the MCP client uses a tool that requires a running browser instance. Connecting to the Chrome DevTools MCP server on its own will not automatically start the browser.
+## Example: Debugging a WordPress Site Using MCP
+
+This example demonstrates how `chrome-devtools-mcp` can be used to debug
+and analyze a locally hosted WordPress site using Chrome DevTools automation.
+
+### Prerequisites
+- Local WordPress setup (XAMPP, LocalWP, Docker, etc.)
+- Google Chrome
+- Node.js installed
+
+### Steps
+
+1. Start Chrome with remote debugging enabled:
+```bash
+google-chrome --remote-debugging-port=9222
 
 ## Tools
 


### PR DESCRIPTION
### Problem
The README lacks real-world examples showing how chrome-devtools-mcp can
be used with popular CMS platforms like WordPress.

### Solution
Added a WordPress-focused example demonstrating debugging and performance
analysis using Chrome DevTools MCP.

### Impact
Helps developers understand practical MCP usage in production-like
WordPress environments.

### Testing
Verified the steps on a local WordPress setup.
