### PR TITLE
chore: support an html route in evals

### DIFF
--- a/scripts/eval_scenarios/snapshot_test.ts
+++ b/scripts/eval_scenarios/snapshot_test.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import assert from 'node:assert';
+
+import type {TestScenario} from '../eval_gemini.ts';
+
+export const scenario: TestScenario = {
+  prompt: 'Read the content of <TEST_URL>',
+  maxTurns: 3,
+  htmlRoute: {
+    path: '/test.html',
+    htmlContent: '<h1>Hello World</h1><p>This is a test.</p>',
+  },
+  expectations: calls => {
+    assert.strictEqual(calls.length, 2);
+    assert.ok(
+      calls[0].name === 'navigate_page' || calls[0].name === 'new_page',
+    );
+    assert.ok(calls[1].name === 'take_snapshot');
+  },
+};

--- a/tests/server.ts
+++ b/tests/server.ts
@@ -13,7 +13,7 @@ import {before, after, afterEach} from 'node:test';
 
 import {html} from './utils.js';
 
-class TestServer {
+export class TestServer {
   #port: number;
   #server: Server;
 


### PR DESCRIPTION
Allows using the server URL in the prompt.