### PR TITLE
refactor: remove text from the status code for Network requests

### DIFF
--- a/src/formatters/NetworkFormatter.ts
+++ b/src/formatters/NetworkFormatter.ts
@@ -183,15 +183,11 @@ export class NetworkFormatter {
     const failure = request.failure();
     let status: string;
     if (httpResponse) {
-      const responseStatus = httpResponse.status();
-      status =
-        responseStatus >= 200 && responseStatus <= 299
-          ? `[success - ${responseStatus}]`
-          : `[failed - ${responseStatus}]`;
+      status = httpResponse.status().toString();
     } else if (failure) {
-      status = `[failed - ${failure.errorText}]`;
+      status = failure.errorText;
     } else {
-      status = '[pending]';
+      status = 'pending';
     }
     return status;
   }
@@ -231,7 +227,7 @@ function convertNetworkRequestConciseToString(
   data: NetworkRequestConcise,
 ): string {
   // TODO truncate the URL
-  return `reqid=${data.requestId} ${data.method} ${data.url} ${data.status}${data.selectedInDevToolsUI ? ` [selected in the DevTools Network panel]` : ''}`;
+  return `reqid=${data.requestId} ${data.method} ${data.url} [${data.status}]${data.selectedInDevToolsUI ? ` [selected in the DevTools Network panel]` : ''}`;
 }
 
 function formatHeadlers(headers: Record<string, string>): string[] {

--- a/tests/McpContext.test.js.snapshot
+++ b/tests/McpContext.test.js.snapshot
@@ -4,7 +4,7 @@ exports[`McpContext > should include detailed network request in structured cont
     "requestId": 456,
     "method": "GET",
     "url": "http://example.com/detail",
-    "status": "[pending]",
+    "status": "pending",
     "requestHeaders": {
       "content-size": "10"
     }
@@ -37,7 +37,7 @@ exports[`McpContext > should include network requests in structured content 1`] 
       "requestId": 123,
       "method": "GET",
       "url": "http://example.com/api",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]

--- a/tests/McpResponse.test.js.snapshot
+++ b/tests/McpResponse.test.js.snapshot
@@ -1,7 +1,7 @@
 exports[`McpResponse > add network request when attached 1`] = `
 # test response
 ## Request http://example.com
-Status: [pending]
+Status: pending
 ### Request Headers
 - content-size:10
 ## Network requests
@@ -15,7 +15,7 @@ exports[`McpResponse > add network request when attached 2`] = `
     "requestId": 1,
     "method": "GET",
     "url": "http://example.com",
-    "status": "[pending]",
+    "status": "pending",
     "requestHeaders": {
       "content-size": "10"
     }
@@ -34,7 +34,7 @@ exports[`McpResponse > add network request when attached 2`] = `
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]
@@ -44,7 +44,7 @@ exports[`McpResponse > add network request when attached 2`] = `
 exports[`McpResponse > add network request when attached with POST data 1`] = `
 # test response
 ## Request http://example.com
-Status: [success - 200]
+Status: 200
 ### Request Headers
 - content-size:10
 ### Request Body
@@ -55,7 +55,7 @@ Status: [success - 200]
 {"response":"body"}
 ## Network requests
 Showing 1-1 of 1 (Page 1 of 1).
-reqid=1 POST http://example.com [success - 200]
+reqid=1 POST http://example.com [200]
 `;
 
 exports[`McpResponse > add network request when attached with POST data 2`] = `
@@ -64,7 +64,7 @@ exports[`McpResponse > add network request when attached with POST data 2`] = `
     "requestId": 1,
     "method": "POST",
     "url": "http://example.com",
-    "status": "[success - 200]",
+    "status": "200",
     "requestHeaders": {
       "content-size": "10"
     },
@@ -88,7 +88,7 @@ exports[`McpResponse > add network request when attached with POST data 2`] = `
       "requestId": 1,
       "method": "POST",
       "url": "http://example.com",
-      "status": "[success - 200]",
+      "status": "200",
       "selectedInDevToolsUI": false
     }
   ]
@@ -119,14 +119,14 @@ exports[`McpResponse > add network requests when setting is true 2`] = `
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 2,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]
@@ -487,14 +487,14 @@ exports[`McpResponse network pagination > handles invalid page number by showing
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]
@@ -517,35 +517,35 @@ exports[`McpResponse network pagination > returns all requests when pagination i
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]
@@ -568,70 +568,70 @@ exports[`McpResponse network pagination > returns first page by default 1`] = `
       "requestId": 1,
       "method": "GET-0",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-1",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-2",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-3",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-4",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-5",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-6",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-7",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-8",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-9",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]
@@ -654,70 +654,70 @@ exports[`McpResponse network pagination > returns subsequent page when pageIdx p
       "requestId": 1,
       "method": "GET-10",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-11",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-12",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-13",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-14",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-15",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-16",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-17",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-18",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET-19",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]
@@ -1002,14 +1002,14 @@ exports[`McpResponse network request filtering > filters network requests by res
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]
@@ -1039,7 +1039,7 @@ exports[`McpResponse network request filtering > filters network requests by sin
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]
@@ -1073,35 +1073,35 @@ exports[`McpResponse network request filtering > shows all requests when empty r
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]
@@ -1135,35 +1135,35 @@ exports[`McpResponse network request filtering > shows all requests when no filt
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     },
     {
       "requestId": 1,
       "method": "GET",
       "url": "http://example.com",
-      "status": "[pending]",
+      "status": "pending",
       "selectedInDevToolsUI": false
     }
   ]

--- a/tests/formatters/NetworkFormatter.test.ts
+++ b/tests/formatters/NetworkFormatter.test.ts
@@ -60,7 +60,7 @@ describe('NetworkFormatter', () => {
 
       assert.equal(
         formatter.toString(),
-        'reqid=1 GET http://example.com [success - 200]',
+        'reqid=1 GET http://example.com [200]',
       );
     });
     it('shows correct status for request with response code in 100', async () => {
@@ -75,7 +75,7 @@ describe('NetworkFormatter', () => {
 
       assert.equal(
         formatter.toString(),
-        'reqid=1 GET http://example.com [failed - 199]',
+        'reqid=1 GET http://example.com [199]',
       );
     });
     it('shows correct status for request with response code above 200', async () => {
@@ -90,7 +90,7 @@ describe('NetworkFormatter', () => {
 
       assert.equal(
         formatter.toString(),
-        'reqid=1 GET http://example.com [failed - 300]',
+        'reqid=1 GET http://example.com [300]',
       );
     });
     it('shows correct status for request that failed', async () => {
@@ -108,7 +108,7 @@ describe('NetworkFormatter', () => {
 
       assert.equal(
         formatter.toString(),
-        'reqid=1 GET http://example.com [failed - Error in Network]',
+        'reqid=1 GET http://example.com [Error in Network]',
       );
     });
 
@@ -385,7 +385,7 @@ describe('NetworkFormatter', () => {
         requestId: 1,
         method: 'GET',
         url: 'http://example.com',
-        status: '[pending]',
+        status: 'pending',
         selectedInDevToolsUI: true,
       });
     });
@@ -410,7 +410,7 @@ describe('NetworkFormatter', () => {
         requestId: 1,
         method: 'GET',
         url: 'http://example.com',
-        status: '[success - 200]',
+        status: '200',
         selectedInDevToolsUI: undefined,
         requestHeaders: {
           'content-size': '10',

--- a/tests/tools/network.test.js.snapshot
+++ b/tests/tools/network.test.js.snapshot
@@ -1,7 +1,7 @@
 exports[`network > network_get_request > should get request from previous navigations 1`] = `
 # get_request response
 ## Request http://localhost:<port>/one
-Status: [success - 200]
+Status: 200
 ### Request Headers
 - accept-language:<lang>
 - upgrade-insecure-requests:1
@@ -31,23 +31,23 @@ exports[`network > network_list_requests > list requests form current navigation
 # list_request response
 ## Network requests
 Showing 1-1 of 1 (Page 1 of 1).
-reqid=3 GET http://localhost:<port>/three [success - 200]
+reqid=3 GET http://localhost:<port>/three [200]
 `;
 
 exports[`network > network_list_requests > list requests from previous navigations 1`] = `
 # list_request response
 ## Network requests
 Showing 1-3 of 3 (Page 1 of 1).
-reqid=1 GET http://localhost:<port>/one [success - 200]
-reqid=2 GET http://localhost:<port>/two [success - 200]
-reqid=3 GET http://localhost:<port>/three [success - 200]
+reqid=1 GET http://localhost:<port>/one [200]
+reqid=2 GET http://localhost:<port>/two [200]
+reqid=3 GET http://localhost:<port>/three [200]
 `;
 
 exports[`network > network_list_requests > list requests from previous navigations from redirects 1`] = `
 # list_request response
 ## Network requests
 Showing 1-3 of 3 (Page 1 of 1).
-reqid=1 GET http://localhost:<port>/redirect [failed - 302]
-reqid=2 GET http://localhost:<port>/redirected [success - 200]
-reqid=3 GET http://localhost:<port>/redirected-page [success - 200]
+reqid=1 GET http://localhost:<port>/redirect [302]
+reqid=2 GET http://localhost:<port>/redirected [200]
+reqid=3 GET http://localhost:<port>/redirected-page [200]
 `;


### PR DESCRIPTION
LLM are trained to know the common status code so we can rely on that when displaying the status code and fall back to text in case of errors or pending reponse.