### PR TITLE
feat: support device viewport and user agent emulation

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -200,6 +200,8 @@
 - **cpuThrottlingRate** (number) _(optional)_: Represents the CPU slowdown factor. Set the rate to 1 to disable throttling. If omitted, throttling remains unchanged.
 - **geolocation** (unknown) _(optional)_: Geolocation to [`emulate`](#emulate). Set to null to clear the geolocation override.
 - **networkConditions** (enum: "No emulation", "Offline", "Slow 3G", "Fast 3G", "Slow 4G", "Fast 4G") _(optional)_: Throttle network. Set to "No emulation" to disable. If omitted, conditions remain unchanged.
+- **userAgent** (unknown) _(optional)_: User agent to [`emulate`](#emulate). Set to null to clear the user agent override.
+- **viewport** (unknown) _(optional)_: Viewport to [`emulate`](#emulate). Set to null to reset to the default viewport.
 
 ---
 

--- a/scripts/eval_scenarios/emulation_userAgent_test.ts
+++ b/scripts/eval_scenarios/emulation_userAgent_test.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+
+import type {TestScenario} from '../eval_gemini.ts';
+
+export const scenario: TestScenario = {
+  prompt: 'Emulate iPhone 14 user agent',
+  maxTurns: 2,
+  expectations: calls => {
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].name, 'emulate');
+    assert.deepStrictEqual(
+      calls[0].args.userAgent,
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+    );
+  },
+};

--- a/scripts/eval_scenarios/emulation_viewport_test.ts
+++ b/scripts/eval_scenarios/emulation_viewport_test.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+
+import {KnownDevices} from 'puppeteer';
+
+import type {TestScenario} from '../eval_gemini.ts';
+
+export const scenario: TestScenario = {
+  prompt: 'Emulate iPhone 14 viewport',
+  maxTurns: 2,
+  expectations: calls => {
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].name, 'emulate');
+    assert.deepStrictEqual(
+      {
+        ...(calls[0].args.viewport as object),
+        // models might not send defaults.
+        isLandscape: KnownDevices['iPhone 14'].viewport.isLandscape ?? false,
+      },
+      {
+        ...KnownDevices['iPhone 14'].viewport,
+        height: 844, // Puppeteer is wrong about the expected height.
+      },
+    );
+  },
+};

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -28,6 +28,7 @@ import type {
   Page,
   SerializedAXNode,
   PredefinedNetworkConditions,
+  Viewport,
 } from './third_party/index.js';
 import {listPages} from './tools/pages.js';
 import {takeSnapshot} from './tools/snapshot.js';
@@ -115,6 +116,8 @@ export class McpContext implements Context {
   #networkConditionsMap = new WeakMap<Page, string>();
   #cpuThrottlingRateMap = new WeakMap<Page, number>();
   #geolocationMap = new WeakMap<Page, GeolocationOptions>();
+  #viewportMap = new WeakMap<Page, Viewport>();
+  #userAgentMap = new WeakMap<Page, string>();
   #dialog?: Dialog;
 
   #pageIdMap = new WeakMap<Page, number>();
@@ -312,6 +315,34 @@ export class McpContext implements Context {
   getGeolocation(): GeolocationOptions | null {
     const page = this.getSelectedPage();
     return this.#geolocationMap.get(page) ?? null;
+  }
+
+  setViewport(viewport: Viewport | null): void {
+    const page = this.getSelectedPage();
+    if (viewport === null) {
+      this.#viewportMap.delete(page);
+    } else {
+      this.#viewportMap.set(page, viewport);
+    }
+  }
+
+  getViewport(): Viewport | null {
+    const page = this.getSelectedPage();
+    return this.#viewportMap.get(page) ?? null;
+  }
+
+  setUserAgent(userAgent: string | null): void {
+    const page = this.getSelectedPage();
+    if (userAgent === null) {
+      this.#userAgentMap.delete(page);
+    } else {
+      this.#userAgentMap.set(page, userAgent);
+    }
+  }
+
+  getUserAgent(): string | null {
+    const page = this.getSelectedPage();
+    return this.#userAgentMap.get(page) ?? null;
   }
 
   setIsRunningPerformanceTrace(x: boolean): void {

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -432,6 +432,18 @@ export class McpResponse implements Response {
       );
     }
 
+    const viewport = context.getViewport();
+    if (viewport) {
+      response.push(`## Viewport emulation`);
+      response.push(`Emulating viewport: ${JSON.stringify(viewport)}`);
+    }
+
+    const userAgent = context.getUserAgent();
+    if (userAgent) {
+      response.push(`## UserAgent emulation`);
+      response.push(`Emulating userAgent: ${userAgent}`);
+    }
+
     const cpuThrottlingRate = context.getCpuThrottlingRate();
     if (cpuThrottlingRate > 1) {
       response.push(`## CPU emulation`);

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -25,6 +25,7 @@ export {z as zod} from 'zod';
 export {
   Locator,
   PredefinedNetworkConditions,
+  KnownDevices,
   CDPSessionEvent,
 } from 'puppeteer-core';
 export {default as puppeteer} from 'puppeteer-core';

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -6,7 +6,12 @@
 
 import type {TextSnapshotNode, GeolocationOptions} from '../McpContext.js';
 import {zod} from '../third_party/index.js';
-import type {Dialog, ElementHandle, Page} from '../third_party/index.js';
+import type {
+  Dialog,
+  ElementHandle,
+  Page,
+  Viewport,
+} from '../third_party/index.js';
 import type {TraceResult} from '../trace-processing/parse.js';
 import type {PaginationOptions} from '../utils/types.js';
 
@@ -105,6 +110,10 @@ export type Context = Readonly<{
   setNetworkConditions(conditions: string | null): void;
   setCpuThrottlingRate(rate: number): void;
   setGeolocation(geolocation: GeolocationOptions | null): void;
+  setViewport(viewport: Viewport | null): void;
+  getViewport(): Viewport | null;
+  setUserAgent(userAgent: string | null): void;
+  getUserAgent(): string | null;
   saveTemporaryFile(
     data: Uint8Array<ArrayBufferLike>,
     mimeType: 'image/png' | 'image/jpeg' | 'image/webp',

--- a/tests/McpResponse.test.js.snapshot
+++ b/tests/McpResponse.test.js.snapshot
@@ -74,6 +74,18 @@ Emulating: Slow 3G
 Default navigation timeout set to 100000 ms
 `;
 
+exports[`McpResponse > adds userAgent emulation setting when it is set 1`] = `
+# test response
+## UserAgent emulation
+Emulating userAgent: MyUA
+`;
+
+exports[`McpResponse > adds viewport emulation setting when it is set 1`] = `
+# test response
+## Viewport emulation
+Emulating viewport: {"width":400,"height":400,"deviceScaleFactor":1}
+`;
+
 exports[`McpResponse > allows response text lines to be added 1`] = `
 # test response
 Testing 1

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -182,6 +182,22 @@ describe('McpResponse', () => {
     });
   });
 
+  it('adds viewport emulation setting when it is set', async t => {
+    await withMcpContext(async (response, context) => {
+      context.setViewport({width: 400, height: 400, deviceScaleFactor: 1});
+      const {content} = await response.handle('test', context);
+      t.assert.snapshot?.(getTextContent(content[0]));
+    });
+  });
+
+  it('adds userAgent emulation setting when it is set', async t => {
+    await withMcpContext(async (response, context) => {
+      context.setUserAgent('MyUA');
+      const {content} = await response.handle('test', context);
+      t.assert.snapshot?.(getTextContent(content[0]));
+    });
+  });
+
   it('adds a prompt dialog', async t => {
     await withMcpContext(async (response, context) => {
       const page = context.getSelectedPage();


### PR DESCRIPTION
This PR adds two emulation attributes `viewport` and `userAgent` that allow emulating a mobile or a different desktop device.

Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/pull/272
Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/619
Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/410
Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/280 (the recommended way is to emulate via the MCP server instead of a parallel DevTools session)