### PR TITLE
feat: include source-mapped stack trace for uncaught errors

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -14,7 +14,7 @@ import {
   UniverseManager,
   urlsEqual,
 } from './DevtoolsUtils.js';
-import type {ListenerMap} from './PageCollector.js';
+import type {ListenerMap, UncaughtError} from './PageCollector.js';
 import {NetworkCollector, ConsoleCollector} from './PageCollector.js';
 import {Locator} from './third_party/index.js';
 import type {DevTools} from './third_party/index.js';
@@ -156,14 +156,8 @@ export class McpContext implements Context {
         console: event => {
           collect(event);
         },
-        pageerror: event => {
-          if (event instanceof Error) {
-            collect(event);
-          } else {
-            const error = new Error(`${event}`);
-            error.stack = undefined;
-            collect(error);
-          }
+        uncaughtError: event => {
+          collect(event);
         },
         issue: event => {
           collect(event);
@@ -245,7 +239,7 @@ export class McpContext implements Context {
 
   getConsoleData(
     includePreservedMessages?: boolean,
-  ): Array<ConsoleMessage | Error | DevTools.AggregatedIssue> {
+  ): Array<ConsoleMessage | Error | DevTools.AggregatedIssue | UncaughtError> {
     const page = this.getSelectedPage();
     return this.#consoleCollector.getData(page, includePreservedMessages);
   }
@@ -255,14 +249,14 @@ export class McpContext implements Context {
   }
 
   getConsoleMessageStableId(
-    message: ConsoleMessage | Error | DevTools.AggregatedIssue,
+    message: ConsoleMessage | Error | DevTools.AggregatedIssue | UncaughtError,
   ): number {
     return this.#consoleCollector.getIdForResource(message);
   }
 
   getConsoleMessageById(
     id: number,
-  ): ConsoleMessage | Error | DevTools.AggregatedIssue {
+  ): ConsoleMessage | Error | DevTools.AggregatedIssue | UncaughtError {
     return this.#consoleCollector.getById(this.getSelectedPage(), id);
   }
 

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -9,6 +9,7 @@ import {IssueFormatter} from './formatters/IssueFormatter.js';
 import {NetworkFormatter} from './formatters/NetworkFormatter.js';
 import {SnapshotFormatter} from './formatters/SnapshotFormatter.js';
 import type {McpContext} from './McpContext.js';
+import {UncaughtError} from './PageCollector.js';
 import {DevTools} from './third_party/index.js';
 import type {
   ConsoleMessage,
@@ -276,8 +277,8 @@ export class McpResponse implements Response {
         this.#attachedConsoleMessageId,
       );
       const consoleMessageStableId = this.#attachedConsoleMessageId;
-      if ('args' in message) {
-        const consoleMessage = message as ConsoleMessage;
+      if ('args' in message || message instanceof UncaughtError) {
+        const consoleMessage = message as ConsoleMessage | UncaughtError;
         const devTools = context.getDevToolsUniverse();
         detailedConsoleMessage = await ConsoleFormatter.from(consoleMessage, {
           id: consoleMessageStableId,
@@ -332,8 +333,8 @@ export class McpResponse implements Response {
             async (item): Promise<ConsoleFormatter | IssueFormatter | null> => {
               const consoleMessageStableId =
                 context.getConsoleMessageStableId(item);
-              if ('args' in item) {
-                const consoleMessage = item as ConsoleMessage;
+              if ('args' in item || item instanceof UncaughtError) {
+                const consoleMessage = item as ConsoleMessage | UncaughtError;
                 const devTools = context.getDevToolsUniverse();
                 return await ConsoleFormatter.from(consoleMessage, {
                   id: consoleMessageStableId,

--- a/src/PageCollector.ts
+++ b/src/PageCollector.ts
@@ -236,7 +236,7 @@ export class PageCollector<T> {
 }
 
 export class ConsoleCollector extends PageCollector<
-  ConsoleMessage | Error | DevTools.AggregatedIssue
+  ConsoleMessage | Error | DevTools.AggregatedIssue | UncaughtError
 > {
   #subscribedPages = new WeakMap<Page, PageEventSubscriber>();
 

--- a/tests/tools/console.test.js.snapshot
+++ b/tests/tools/console.test.js.snapshot
@@ -11,6 +11,17 @@ at Iife (main.js:10:2)
 at <anonymous> (main.js:9:0)
 `;
 
+exports[`console > get_console_message > applies source maps to stack traces of uncaught exceptions 1`] = `
+# test response
+ID: 1
+Message: error> Uncaught Error: b00m!
+### Stack trace
+at bar (main.js:2:8)
+at foo (main.js:6:2)
+at Iife (main.js:10:2)
+at <anonymous> (main.js:9:0)
+`;
+
 exports[`console > get_console_message > issues type > gets issue details with node id parsing 1`] = `
 # test response
 ID: 1


### PR DESCRIPTION
Note that we replace the existing "pageerror" handler with our new `UncaughtError` handler. The latter has a structured stack trace attached which we can source map via DevTools.

This regresses the current functionality slightly, as we lose "pageerror"s for workers and oopif.