### PR TITLE
docs: remove outdated --channel=beta note

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,14 +563,11 @@ The following code snippet is an example configuration for gemini-cli:
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["chrome-devtools-mcp@latest", "--autoConnect", "--channel=beta"]
+      "args": ["chrome-devtools-mcp@latest", "--autoConnect"]
     }
   }
 }
 ```
-
-Note: you have to specify `--channel=beta` until Chrome M144 has reached the
-stable channel.
 
 **Step 3:** Test your setup
 


### PR DESCRIPTION
## Summary
Chrome M144 is now in the stable channel, so the note about requiring `--channel=beta` and the example configuration using it are outdated.

## Prompt
Remove outdated documentation about --channel=beta since Chrome M144 is now in stable channel.

## Changes
- Removed `--channel=beta` from the `--autoConnect` example configuration
- Removed the note: "Note: you have to specify `--channel=beta` until Chrome M144 has reached the stable channel."

## Test plan
- [x] Verified the documentation now reflects the current stable Chrome version

🤖 Generated with [Claude Code](https://claude.com/claude-code)