### PR TITLE
fix: use 1-based line/column and fix wasm offsets in stack frames

### DIFF
--- a/src/formatters/ConsoleFormatter.ts
+++ b/src/formatters/ConsoleFormatter.ts
@@ -177,6 +177,7 @@ export class ConsoleFormatter {
       '### Stack trace',
       this.#formatFragment(stackTrace.syncFragment),
       ...stackTrace.asyncFragments.map(this.#formatAsyncFragment.bind(this)),
+      'Note: line and column numbers use 1-based indexing',
     ].join('\n');
   }
 
@@ -198,7 +199,8 @@ export class ConsoleFormatter {
   #formatFrame(frame: DevTools.DevTools.StackTrace.StackTrace.Frame): string {
     let result = `at ${frame.name ?? '<anonymous>'}`;
     if (frame.uiSourceCode) {
-      result += ` (${frame.uiSourceCode.displayName()}:${frame.line}:${frame.column})`;
+      const location = frame.uiSourceCode.uiLocation(frame.line, frame.column);
+      result += ` (${location.linkText(/* skipTrim */ false, /* showColumnNumber */ true)})`;
     } else if (frame.url) {
       result += ` (${frame.url}:${frame.line}:${frame.column})`;
     }

--- a/tests/formatters/ConsoleFormatter.test.js.snapshot
+++ b/tests/formatters/ConsoleFormatter.test.js.snapshot
@@ -22,6 +22,7 @@ at foo (foo.ts:10:2)
 at bar (foo.ts:20:2)
 --- setTimeout -------------------------
 at schedule (util.ts:5:2)
+Note: line and column numbers use 1-based indexing
 `;
 
 exports[`ConsoleFormatter > toStringDetailed > formats a console.error message 1`] = `
@@ -57,6 +58,7 @@ at foo (foo.ts:10:2)
 at bar (foo.ts:20:2)
 --- setTimeout -------------------------
 at schedule (util.ts:5:2)
+Note: line and column numbers use 1-based indexing
 `;
 
 exports[`ConsoleFormatter > toStringDetailed > handles \"Execution context is not available\" error in args 1`] = `

--- a/tests/tools/console.test.js.snapshot
+++ b/tests/tools/console.test.js.snapshot
@@ -5,10 +5,11 @@ Message: warn> hello world
 ### Arguments
 Arg #0: hello world
 ### Stack trace
-at bar (main.js:2:10)
-at foo (main.js:6:2)
-at Iife (main.js:10:2)
-at <anonymous> (main.js:9:0)
+at bar (main.js:3:11)
+at foo (main.js:7:3)
+at Iife (main.js:11:3)
+at <anonymous> (main.js:10:1)
+Note: line and column numbers use 1-based indexing
 `;
 
 exports[`console > get_console_message > applies source maps to stack traces of uncaught exceptions 1`] = `
@@ -16,10 +17,11 @@ exports[`console > get_console_message > applies source maps to stack traces of 
 ID: 1
 Message: error> Uncaught Error: b00m!
 ### Stack trace
-at bar (main.js:2:8)
-at foo (main.js:6:2)
-at Iife (main.js:10:2)
-at <anonymous> (main.js:9:0)
+at bar (main.js:3:9)
+at foo (main.js:7:3)
+at Iife (main.js:11:3)
+at <anonymous> (main.js:10:1)
+Note: line and column numbers use 1-based indexing
 `;
 
 exports[`console > get_console_message > issues type > gets issue details with node id parsing 1`] = `


### PR DESCRIPTION
`UILocation.linkText` does the right thing when formatting a location, e.g. a wasm location will be formatted as `foo.wasm:0x95`.