### PR TITLE
chore: introduce SymbolizedError class

### DIFF
--- a/src/PageCollector.ts
+++ b/src/PageCollector.ts
@@ -23,17 +23,11 @@ import {
 } from './third_party/index.js';
 
 export class UncaughtError {
-  readonly message: string;
-  readonly stackTrace?: Protocol.Runtime.StackTrace;
+  readonly details: Protocol.Runtime.ExceptionDetails;
   readonly targetId: string;
 
-  constructor(
-    message: string,
-    stackTrace: Protocol.Runtime.StackTrace | undefined,
-    targetId: string,
-  ) {
-    this.message = message;
-    this.stackTrace = stackTrace;
+  constructor(details: Protocol.Runtime.ExceptionDetails, targetId: string) {
+    this.details = details;
     this.targetId = targetId;
   }
 }
@@ -328,13 +322,9 @@ class PageEventSubscriber {
   };
 
   #onExceptionThrown = (event: Protocol.Runtime.ExceptionThrownEvent) => {
-    const {exception, text, stackTrace} = event.exceptionDetails;
-    const messageWithRest = exception?.description?.split('\n    at ', 2) ?? [];
-    const message = text + ' ' + (messageWithRest[0] ?? '');
-
     this.#page.emit(
       'uncaughtError',
-      new UncaughtError(message, stackTrace, this.#targetId),
+      new UncaughtError(event.exceptionDetails, this.#targetId),
     );
   };
 

--- a/tests/PageCollector.test.ts
+++ b/tests/PageCollector.test.ts
@@ -408,8 +408,9 @@ describe('ConsoleCollector', () => {
       onUncaughtErrorListener,
       sinon.match(e => {
         return (
-          e.message === 'Uncaught SyntaxError: Expected {' &&
-          e.stackTrace.callFrames.length === 0
+          e.details.exception.description === 'SyntaxError: Expected {',
+          e.details.text === 'Uncaught',
+          e.details.stackTrace.callFrames.length === 0
         );
       }),
     );

--- a/tests/formatters/ConsoleFormatter.test.ts
+++ b/tests/formatters/ConsoleFormatter.test.ts
@@ -70,8 +70,16 @@ describe('ConsoleFormatter', () => {
 
     it('formats an UncaughtError', async t => {
       const error = new UncaughtError(
-        'Uncaught TypeError: Cannot read properties of undefined',
-        undefined,
+        {
+          exceptionId: 1,
+          lineNumber: 0,
+          columnNumber: 5,
+          exception: {
+            type: 'object',
+            description: 'TypeError: Cannot read properties of undefined',
+          },
+          text: 'Uncaught',
+        },
         '<mock target ID>',
       );
       const result = (
@@ -231,8 +239,16 @@ describe('ConsoleFormatter', () => {
         ],
       } as unknown as DevTools.StackTrace.StackTrace.StackTrace;
       const error = new UncaughtError(
-        'Uncaught TypeError: Cannot read properties of undefined',
-        undefined,
+        {
+          exceptionId: 1,
+          lineNumber: 0,
+          columnNumber: 5,
+          exception: {
+            type: 'object',
+            description: 'TypeError: Cannot read properties of undefined',
+          },
+          text: 'Uncaught',
+        },
         '<mock target ID>',
       );
 


### PR DESCRIPTION
The "SymbolizedError" class represents a fully resolved error: The stack trace is fully resolved and (in the future), the full `Error.cause` chain is also fully resolved.

We'll use the `SymbolizedError` for both "uncaught exceptions" as well as when logging `Error` objects to the console (e.g. `console.log(new Error())`. This means the `resolvedArgs` array in `ConsoleFormatter` will contain one `SymbolizedError` instance for every `Error` object logged.