### PR TITLE
chore: implement formatting for Error.cause messages

### DIFF
--- a/src/DevtoolsUtils.ts
+++ b/src/DevtoolsUtils.ts
@@ -255,10 +255,15 @@ export class SymbolizedError {
     targetId: string;
     includeStackAndCause?: boolean;
     resolvedStackTraceForTesting?: DevTools.StackTrace.StackTrace.StackTrace;
+    resolvedCauseForTesting?: SymbolizedError;
   }): Promise<SymbolizedError> {
     const message = SymbolizedError.#getMessage(opts.details);
     if (!opts.includeStackAndCause || !opts.devTools) {
-      return new SymbolizedError(message, opts.resolvedStackTraceForTesting);
+      return new SymbolizedError(
+        message,
+        opts.resolvedStackTraceForTesting,
+        opts.resolvedCauseForTesting,
+      );
     }
 
     let stackTrace: DevTools.StackTrace.StackTrace.StackTrace | undefined;
@@ -278,7 +283,11 @@ export class SymbolizedError {
 
     // TODO: Turn opts.details.exception into a JSHandle and retrieve the 'cause' property.
     //       If its an Error, recursively create a SymbolizedError.
-    return new SymbolizedError(message, stackTrace);
+    let cause: SymbolizedError | undefined;
+    if (opts.resolvedCauseForTesting) {
+      cause = opts.resolvedCauseForTesting;
+    }
+    return new SymbolizedError(message, stackTrace, cause);
   }
 
   static async fromError(opts: {

--- a/tests/formatters/ConsoleFormatter.test.js.snapshot
+++ b/tests/formatters/ConsoleFormatter.test.js.snapshot
@@ -35,6 +35,18 @@ at bar (foo.ts:20:2)
 Note: line and column numbers use 1-based indexing
 `;
 
+exports[`ConsoleFormatter > toStringDetailed > formats a console message with an Error object with cause 1`] = `
+ID: 9
+Message: log> JSHandle@error
+### Arguments
+Arg #0: AppError: Compute failed
+at foo (foo.ts:10:2)
+at bar (foo.ts:20:2)
+Caused by: TypeError: Cannot read properties of undefined
+at compute (library.js:5:10)
+Note: line and column numbers use 1-based indexing
+`;
+
 exports[`ConsoleFormatter > toStringDetailed > formats a console.error message 1`] = `
 ID: 4
 Message: error> Something went wrong
@@ -68,6 +80,19 @@ at foo (foo.ts:10:2)
 at bar (foo.ts:20:2)
 --- setTimeout -------------------------
 at schedule (util.ts:5:2)
+Note: line and column numbers use 1-based indexing
+`;
+
+exports[`ConsoleFormatter > toStringDetailed > formats an UncaughtError with a stack trace and a cause 1`] = `
+ID: 10
+Message: error> Uncaught TypeError: Cannot read properties of undefined
+### Stack trace
+at foo (foo.ts:10:2)
+at bar (foo.ts:20:2)
+--- setTimeout -------------------------
+at schedule (util.ts:5:2)
+Caused by: TypeError: Cannot read properties of undefined
+at compute (library.js:5:8)
 Note: line and column numbers use 1-based indexing
 `;
 


### PR DESCRIPTION
A follow-up PR will add actual `cause` property resolving of remote `Error` objects.