### PR TITLE
fix: console formatter hides frames from ignored scripts

### DIFF
--- a/tests/formatters/ConsoleFormatter.test.js.snapshot
+++ b/tests/formatters/ConsoleFormatter.test.js.snapshot
@@ -14,6 +14,25 @@ exports[`ConsoleFormatter > toString > formats an UncaughtError 1`] = `
 msgid=4 [error] Uncaught TypeError: Cannot read properties of undefined (0 args)
 `;
 
+exports[`ConsoleFormatter > toStringDetailed > does not show call frames with ignore listed scripts 1`] = `
+ID: 12
+Message: log> Hello stack trace!
+### Stack trace
+at foo (foo.ts:10:2)
+at bar (foo.ts:20:2)
+Note: line and column numbers use 1-based indexing
+`;
+
+exports[`ConsoleFormatter > toStringDetailed > does not show fragments where all frames are ignore listed 1`] = `
+ID: 13
+Message: log> Hello stack trace!
+### Stack trace
+at foo (foo.ts:10:2)
+--- await ------------------------------
+at bar (foo.ts:20:2)
+Note: line and column numbers use 1-based indexing
+`;
+
 exports[`ConsoleFormatter > toStringDetailed > formats a console message with a stack trace 1`] = `
 ID: 5
 Message: log> Hello stack trace!

--- a/tests/formatters/ConsoleFormatter.test.ts
+++ b/tests/formatters/ConsoleFormatter.test.ts
@@ -479,6 +479,113 @@ describe('ConsoleFormatter', () => {
       ).toStringDetailed();
       t.assert.snapshot?.(result);
     });
+
+    it('does not show call frames with ignore listed scripts', async t => {
+      const message = createMockMessage({
+        type: () => 'log',
+        text: () => 'Hello stack trace!',
+      });
+      const stackTrace = {
+        syncFragment: {
+          frames: [
+            {
+              line: 10,
+              column: 2,
+              url: 'foo.ts',
+              name: 'foo',
+            },
+            {
+              line: 200,
+              column: 46,
+              url: './node_modules/some-third-party-package/lib/index.js',
+              name: 'doThings',
+            },
+            {
+              line: 250,
+              column: 12,
+              url: './node_modules/some-third-party-package/lib/index.js',
+              name: 'doThings2',
+            },
+            {
+              line: 20,
+              column: 2,
+              url: 'foo.ts',
+              name: 'bar',
+            },
+          ],
+        },
+        asyncFragments: [],
+      } as unknown as DevTools.StackTrace.StackTrace.StackTrace;
+
+      const result = (
+        await ConsoleFormatter.from(message, {
+          id: 12,
+          resolvedStackTraceForTesting: stackTrace,
+          isIgnoredForTesting: frame =>
+            Boolean(frame.url?.includes('node_modules')),
+        })
+      ).toStringDetailed();
+      t.assert.snapshot?.(result);
+    });
+
+    it('does not show fragments where all frames are ignore listed', async t => {
+      const message = createMockMessage({
+        type: () => 'log',
+        text: () => 'Hello stack trace!',
+      });
+      const stackTrace = {
+        syncFragment: {
+          frames: [
+            {
+              line: 10,
+              column: 2,
+              url: 'foo.ts',
+              name: 'foo',
+            },
+          ],
+        },
+        asyncFragments: [
+          {
+            description: 'setTimeout',
+            frames: [
+              {
+                line: 200,
+                column: 46,
+                url: './node_modules/some-third-party-package/lib/index.js',
+                name: 'doThings',
+              },
+              {
+                line: 250,
+                column: 12,
+                url: './node_modules/some-third-party-package/lib/index.js',
+                name: 'doThings2',
+              },
+            ],
+          },
+          {
+            description: 'await',
+            frames: [
+              {
+                line: 20,
+                column: 2,
+                url: 'foo.ts',
+                name: 'bar',
+              },
+            ],
+          },
+        ],
+      } as unknown as DevTools.StackTrace.StackTrace.StackTrace;
+
+      const result = (
+        await ConsoleFormatter.from(message, {
+          id: 13,
+          resolvedStackTraceForTesting: stackTrace,
+          isIgnoredForTesting: frame =>
+            Boolean(frame.url?.includes('node_modules')),
+        })
+      ).toStringDetailed();
+      t.assert.snapshot?.(result);
+    });
   });
   describe('toJSON', () => {
     it('formats a console.log message', async () => {

--- a/tests/tools/console.test.js.snapshot
+++ b/tests/tools/console.test.js.snapshot
@@ -83,6 +83,19 @@ at <anonymous> (main.js:14:1)
 Note: line and column numbers use 1-based indexing
 `;
 
+exports[`console > get_console_message > ignores frames from ignore listed URLs 1`] = `
+# test response
+ID: 1
+Message: log> hello from callback
+### Arguments
+Arg #0: hello from callback
+### Stack trace
+at callback ('main.js':3:21)
+at callIt ('main.js':7:13)
+at  ('main.js':8:13)
+Note: line and column numbers use 1-based indexing
+`;
+
 exports[`console > get_console_message > issues type > gets issue details with node id parsing 1`] = `
 # test response
 ID: 1


### PR DESCRIPTION
This PR wires up the default DevTools ignore listing to hide frames from third party scripts in stack traces. By default, we ignore:

* Scripts with `/node_modules/` in their URL or where the URL starts with `node:/`
* Scripts that are marked as ignore listed in the source map
* Content scripts from extensions

The PR adds both, unit tests and an e2e test. This is because we allow the unit test to pass a mocked ignore checker, where-as the e2e uses the real DevTools one.