### PR TITLE
fix: guard error handler against non-object thrown values

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -225,8 +225,11 @@ function registerTool(tool: ToolDefinition): void {
         return result;
       } catch (err) {
         logger(`${tool.name} error:`, err, err?.stack);
-        let errorText = err && 'message' in err ? err.message : String(err);
-        if ('cause' in err && err.cause) {
+        let errorText =
+          err && typeof err === 'object' && 'message' in err
+            ? err.message
+            : String(err);
+        if (err && typeof err === 'object' && 'cause' in err && err.cause) {
           errorText += `\nCause: ${err.cause.message}`;
         }
         return {


### PR DESCRIPTION
## Summary
- The `in` operator throws a `TypeError` when its right-hand operand is not an object
- In the tool execution error handler, both `'message' in err` and `'cause' in err` crash if the caught value is a primitive (null, string, number, undefined)
- Added `typeof err === 'object'` checks before using the `in` operator to ensure primitive thrown values are safely converted to strings

## Reproduction
```js
try {
  throw null; // or throw "some string", throw 42
} catch (err) {
  'message' in err; // TypeError: Cannot use 'in' operator to search for 'message' in null
}
```

## Test plan
- [ ] Verify tool error handling with `throw null`
- [ ] Verify tool error handling with `throw "string"`
- [ ] Verify tool error handling with `throw 42`
- [ ] Verify tool error handling with standard `throw new Error("msg")` still works
- [ ] Verify error with `cause` property still includes cause message