### PR TITLE
fix: apply pagination to network request output

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -589,36 +589,21 @@ Call ${handleDialog.name} to handle it before continuing.`);
     }
 
     if (this.#networkRequestsOptions?.include) {
-      let requests = context.getNetworkRequests(
-        this.#networkRequestsOptions?.includePreservedRequests,
-      );
-
-      // Apply resource type filtering if specified
-      if (this.#networkRequestsOptions.resourceTypes?.length) {
-        const normalizedTypes = new Set(
-          this.#networkRequestsOptions.resourceTypes,
-        );
-        requests = requests.filter(request => {
-          const type = request.resourceType();
-          return normalizedTypes.has(type);
-        });
-      }
-
       response.push('## Network requests');
-      if (requests.length) {
+      const networkFormatters = data.networkRequests ?? [];
+      if (networkFormatters.length) {
         const paginationData = this.#dataWithPagination(
-          requests,
+          networkFormatters,
           this.#networkRequestsOptions.pagination,
         );
         structuredContent.pagination = paginationData.pagination;
         response.push(...paginationData.info);
-        if (data.networkRequests) {
-          structuredContent.networkRequests = [];
-          for (const formatter of data.networkRequests) {
-            response.push(formatter.toString());
-            structuredContent.networkRequests.push(formatter.toJSON());
-          }
-        }
+        structuredContent.networkRequests = paginationData.items.map(
+          formatter => formatter.toJSON(),
+        );
+        response.push(
+          ...paginationData.items.map(formatter => formatter.toString()),
+        );
       } else {
         response.push('No requests found.');
       }

--- a/tests/McpResponse.test.js.snapshot
+++ b/tests/McpResponse.test.js.snapshot
@@ -496,27 +496,6 @@ exports[`McpResponse network pagination > handles invalid page number by showing
       "url": "http://example.com",
       "status": "[pending]",
       "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
     }
   ]
 }
@@ -654,146 +633,6 @@ exports[`McpResponse network pagination > returns first page by default 1`] = `
       "url": "http://example.com",
       "status": "[pending]",
       "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-10",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-11",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-12",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-13",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-14",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-15",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-16",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-17",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-18",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-19",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-20",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-21",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-22",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-23",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-24",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-25",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-26",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-27",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-28",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-29",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
     }
   ]
 }
@@ -813,76 +652,6 @@ exports[`McpResponse network pagination > returns subsequent page when pageIdx p
   "networkRequests": [
     {
       "requestId": 1,
-      "method": "GET-0",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-1",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-2",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-3",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-4",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-5",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-6",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-7",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-8",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-9",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
       "method": "GET-10",
       "url": "http://example.com",
       "status": "[pending]",
@@ -947,41 +716,6 @@ exports[`McpResponse network pagination > returns subsequent page when pageIdx p
     {
       "requestId": 1,
       "method": "GET-19",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-20",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-21",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-22",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-23",
-      "url": "http://example.com",
-      "status": "[pending]",
-      "selectedInDevToolsUI": false
-    },
-    {
-      "requestId": 1,
-      "method": "GET-24",
       "url": "http://example.com",
       "status": "[pending]",
       "selectedInDevToolsUI": false
@@ -1444,32 +1178,4 @@ No requests found.
 
 exports[`McpResponse network request filtering > shows no requests when filter matches nothing 2`] = `
 {}
-`;
-
-exports[`extensions > lists extensions 1`] = `
-# test response
-## Extensions
-id=id1 "Extension 1" v1.0 Enabled
-id=id2 "Extension 2" v2.0 Disabled
-`;
-
-exports[`extensions > lists extensions 2`] = `
-{
-  "extensions": [
-    {
-      "id": "id1",
-      "name": "Extension 1",
-      "version": "1.0",
-      "isEnabled": true,
-      "path": "/path/to/ext1"
-    },
-    {
-      "id": "id2",
-      "name": "Extension 2",
-      "version": "2.0",
-      "isEnabled": false,
-      "path": "/path/to/ext2"
-    }
-  ]
-}
 `;


### PR DESCRIPTION
## Summary
- Network request pagination was cosmetic-only: the header showed "Showing 1-10 of 30" but all requests were rendered in both text and structured content
- The `format()` method computed pagination on raw requests but then iterated over all pre-built `NetworkFormatter` instances from `handle()`, ignoring the paginated subset
- Fixed by applying pagination to the formatter array directly, matching the pattern already used correctly by console message pagination
- Also removed a redundant re-fetch of raw network requests in `format()` since the formatters from `handle()` already contain the filtered data

## Test plan
- [x] Existing pagination tests updated to verify correct paginated output
- [x] `returns first page by default` - now only includes 10 of 30 requests
- [x] `returns subsequent page when pageIdx provided` - shows correct page slice
- [x] `handles invalid page number by showing first page` - shows first page subset
- [x] All other McpResponse tests continue to pass