### PR TITLE
fix: validate file paths in saveFile to prevent path traversal

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -701,11 +701,17 @@ export class McpContext implements Context {
   ): Promise<{filename: string}> {
     try {
       const filePath = path.resolve(filename);
+      const cwd = process.cwd();
+      if (!filePath.startsWith(cwd + path.sep) && filePath !== cwd) {
+        throw new Error(
+          `File path must be within the current working directory: ${cwd}`,
+        );
+      }
       await fs.writeFile(filePath, data);
       return {filename};
     } catch (err) {
       this.logger(err);
-      throw new Error('Could not save a screenshot to a file', {cause: err});
+      throw new Error('Could not save a file', {cause: err});
     }
   }
 


### PR DESCRIPTION
## Summary
- `saveFile()` accepts user-provided filenames and resolves them with `path.resolve()`, but does not validate the resulting path
- This allows writing files to arbitrary locations outside the working directory via absolute paths (e.g., `/etc/passwd`) or `../` sequences
- Added validation to ensure the resolved path stays within `process.cwd()` before writing

## Reproduction
```ts
// These would previously succeed:
await context.saveFile(data, '/tmp/arbitrary-file.txt');
await context.saveFile(data, '../../outside-cwd/file.txt');

// After fix, both throw:
// "File path must be within the current working directory: /path/to/cwd"
```

## Test plan
- [ ] Verify relative paths within CWD still work (e.g., `output/file.txt`)
- [ ] Verify absolute paths outside CWD are rejected
- [ ] Verify `../` path traversal sequences are rejected
- [ ] Verify screenshot saving (uses `saveScreenshot`, not affected) still works