### PR TITLE
fix: avoid mutating redirect chain array when formatting

### DIFF
--- a/src/formatters/NetworkFormatter.ts
+++ b/src/formatters/NetworkFormatter.ts
@@ -163,7 +163,7 @@ export class NetworkFormatter {
     if (redirectChain.length) {
       response.push(`### Redirect chain`);
       let indent = 0;
-      for (const request of redirectChain.reverse()) {
+      for (const request of [...redirectChain].reverse()) {
         const id = this.#options.requestIdResolver
           ? this.#options.requestIdResolver(request)
           : undefined;
@@ -191,7 +191,7 @@ export class NetworkFormatter {
 
   toJSONDetailed(): object {
     const redirectChain = this.#request.redirectChain();
-    const formattedRedirectChain = redirectChain.reverse().map(request => {
+    const formattedRedirectChain = [...redirectChain].reverse().map(request => {
       const id = this.#options.requestIdResolver
         ? this.#options.requestIdResolver(request)
         : undefined;


### PR DESCRIPTION
## Summary
- `toStringDetailed()` and `toJSONDetailed()` call `.reverse()` on the array returned by `request.redirectChain()`, which mutates the original array in-place
- Subsequent calls to these methods or any code that reads the redirect chain will see the reversed (incorrect) order
- Fixed by copying the array with spread syntax before reversing: `[...redirectChain].reverse()`

## Reproduction
```ts
const formatter = new NetworkFormatter(request, options);

// First call: redirect chain is [A -> B -> C], reversed to [C, B, A] ✓
formatter.toStringDetailed();

// Second call: chain is now [C, B, A] (mutated), reversed again to [A, B, C] ✗
formatter.toStringDetailed(); // Shows wrong order
```

## Test plan
- [ ] Verify redirect chain displays in correct order on first call
- [ ] Verify redirect chain displays in correct order on repeated calls
- [ ] Verify both `toStringDetailed()` and `toJSONDetailed()` produce consistent output