### PR TITLE
revert: "chore(deps-dev): bump chrome-devtools-frontend from 1.0.1583146 to 1.0.1585538 in the bundled-devtools group"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/yargs": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
-        "chrome-devtools-frontend": "1.0.1585538",
+        "chrome-devtools-frontend": "1.0.1583146",
         "core-js": "3.48.0",
         "debug": "4.4.3",
         "eslint": "^9.35.0",
@@ -2550,9 +2550,9 @@
       }
     },
     "node_modules/chrome-devtools-frontend": {
-      "version": "1.0.1585538",
-      "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.1585538.tgz",
-      "integrity": "sha512-zSiEUA7wZYfqhh25U4kc0hbyAoiRHAi4fcKgFJPCIIfHDCiwebiQL/ke6TFCk7TNT3ooW0PLGAMeKrim/O656Q==",
+      "version": "1.0.1583146",
+      "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.1583146.tgz",
+      "integrity": "sha512-WfH6W0WY/WGJXWwOHTBTPldHM4hT+7ewDPu6zBgNjKxrU9jYjnwDMwX0WS94XuCo2ytBzvTrUOMeprHET/KSdg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
-    "chrome-devtools-frontend": "1.0.1585538",
+    "chrome-devtools-frontend": "1.0.1583146",
     "core-js": "3.48.0",
     "debug": "4.4.3",
     "eslint": "^9.35.0",


### PR DESCRIPTION
Reverts ChromeDevTools/chrome-devtools-mcp#984

might be related to flakiness on macos.