### PR TITLE
refactor: types for JSON output of IssueFormatter

### DIFF
--- a/tests/formatters/IssueFormatter.test.js.snapshot
+++ b/tests/formatters/IssueFormatter.test.js.snapshot
@@ -1,9 +1,58 @@
-exports[`IssueFormatter > formats an issue message 1`] = `
+exports[`IssueFormatter > formats a detailed issue toJSONDetailed 1`] = `
+{
+  "id": 5,
+  "type": "issue",
+  "title": "Mock Issue Title",
+  "description": "# Mock Issue Title\\n\\nThis is a mock issue description sub value",
+  "links": [
+    {
+      "link": "http://example.com",
+      "linkTitle": "Link 1"
+    }
+  ],
+  "affectedResources": [
+    {
+      "uid": "1_1",
+      "data": {
+        "violatingNodeAttribute": "test"
+      }
+    }
+  ]
+}
+`;
+
+exports[`IssueFormatter > formats a detailed issue toStringDetailed 1`] = `
 ID: 5
 Message: issue> Mock Issue Title
 
-This is a mock issue description
+This is a mock issue description sub value
 Learn more:
-[Learn more](http://example.com/learnmore)
-[Learn more 2](http://example.com/another-learnmore)
+[Link 1](http://example.com)
+### Affected resources
+uid=1_1 data={"violatingNodeAttribute":"test"}
+`;
+
+exports[`IssueFormatter > formats a simplified issue toJSON 1`] = `
+{
+  "type": "issue",
+  "title": "Issue Title",
+  "count": 5,
+  "id": 1
+}
+`;
+
+exports[`IssueFormatter > formats a simplified issue toString 1`] = `
+msgid=1 [issue] Issue Title (count: 5)
+`;
+
+exports[`IssueFormatter > formats an issue message toJSON 1`] = `
+{
+  "type": "issue",
+  "title": "Mock Issue Title",
+  "id": 5
+}
+`;
+
+exports[`IssueFormatter > formats an issue message toString 1`] = `
+msgid=5 [issue] Mock Issue Title (count: undefined)
 `;

--- a/tests/formatters/IssueFormatter.test.ts
+++ b/tests/formatters/IssueFormatter.test.ts
@@ -24,7 +24,35 @@ describe('IssueFormatter', () => {
     sinon.restore();
   });
 
-  it('formats an issue message', t => {
+  function formatterTestConcise(
+    label: string,
+    setup: (t: it.TestContext) => Promise<IssueFormatter>,
+  ) {
+    it(label + ' toString', async t => {
+      const formatter = await setup(t);
+      t.assert.snapshot?.(formatter.toString());
+    });
+    it(label + ' toJSON', async t => {
+      const formatter = await setup(t);
+      t.assert.snapshot?.(JSON.stringify(formatter.toJSON(), null, 2));
+    });
+  }
+
+  function formatterTestDetailed(
+    label: string,
+    setup: (t: it.TestContext) => Promise<IssueFormatter>,
+  ) {
+    it(label + ' toStringDetailed', async t => {
+      const formatter = await setup(t);
+      t.assert.snapshot?.(formatter.toStringDetailed());
+    });
+    it(label + ' toJSONDetailed', async t => {
+      const formatter = await setup(t);
+      t.assert.snapshot?.(JSON.stringify(formatter.toJSONDetailed(), null, 2));
+    });
+  }
+
+  formatterTestConcise('formats an issue message', async () => {
     const testGenericIssue = {
       details: () => {
         return {
@@ -55,12 +83,55 @@ describe('IssueFormatter', () => {
       .withArgs('mock.md')
       .returns(mockDescriptionFileContent);
 
-    const formatter = new IssueFormatter(mockAggregatedIssue, {
+    return new IssueFormatter(mockAggregatedIssue, {
       id: 5,
     });
+  });
 
-    const result = formatter.toStringDetailed();
-    t.assert.snapshot?.(result);
+  formatterTestConcise('formats a simplified issue', async () => {
+    const mockAggregatedIssue = getMockAggregatedIssue();
+    mockAggregatedIssue.getDescription.returns({
+      file: 'mock.md',
+      links: [],
+    });
+    mockAggregatedIssue.getAggregatedIssuesCount.returns(5);
+    getIssueDescriptionStub
+      .withArgs('mock.md')
+      .returns('# Issue Title\n\nIssue content');
+
+    return new IssueFormatter(mockAggregatedIssue, {id: 1});
+  });
+
+  formatterTestDetailed('formats a detailed issue', async () => {
+    const testGenericIssue = {
+      details: () => {
+        return {
+          violatingNodeId: 2,
+          violatingNodeAttribute: 'test',
+        };
+      },
+    };
+    const mockAggregatedIssue = getMockAggregatedIssue();
+    const mockDescription = {
+      file: 'mock.md',
+      links: [{link: 'http://example.com', linkTitle: 'Link 1'}],
+      substitutions: new Map([['PLACEHOLDER_VALUE', 'sub value']]),
+    };
+    mockAggregatedIssue.getDescription.returns(mockDescription);
+    // @ts-expect-error stubbed generic issue does not match the complete type.
+    mockAggregatedIssue.getAllIssues.returns([testGenericIssue]);
+
+    const mockDescriptionFileContent =
+      '# Mock Issue Title\n\nThis is a mock issue description {PLACEHOLDER_VALUE}';
+
+    getIssueDescriptionStub
+      .withArgs('mock.md')
+      .returns(mockDescriptionFileContent);
+
+    return new IssueFormatter(mockAggregatedIssue, {
+      id: 5,
+      elementIdResolver: () => '1_1',
+    });
   });
 
   describe('isValid', () => {
@@ -132,78 +203,6 @@ describe('IssueFormatter', () => {
       const detailed = formatter.toStringDetailed();
       assert.ok(detailed.includes('substitution value'));
       assert.ok(detailed.includes('Valid Title'));
-    });
-  });
-  describe('toJSON', () => {
-    it('formats a simplified issue', () => {
-      const mockAggregatedIssue = getMockAggregatedIssue();
-      mockAggregatedIssue.getDescription.returns({
-        file: 'mock.md',
-        links: [],
-      });
-      mockAggregatedIssue.getAggregatedIssuesCount.returns(5);
-      getIssueDescriptionStub
-        .withArgs('mock.md')
-        .returns('# Issue Title\n\nIssue content');
-
-      const formatter = new IssueFormatter(mockAggregatedIssue, {id: 1});
-      assert.deepStrictEqual(formatter.toJSON(), {
-        type: 'issue',
-        title: 'Issue Title',
-        count: 5,
-        id: 1,
-      });
-    });
-  });
-
-  describe('toJSONDetailed', () => {
-    it('formats a detailed issue', () => {
-      const testGenericIssue = {
-        details: () => {
-          return {
-            violatingNodeId: 2,
-            violatingNodeAttribute: 'test',
-          };
-        },
-      };
-      const mockAggregatedIssue = getMockAggregatedIssue();
-      const mockDescription = {
-        file: 'mock.md',
-        links: [{link: 'http://example.com', linkTitle: 'Link 1'}],
-        substitutions: new Map([['PLACEHOLDER_VALUE', 'sub value']]),
-      };
-      mockAggregatedIssue.getDescription.returns(mockDescription);
-      // @ts-expect-error stubbed generic issue does not match the complete type.
-      mockAggregatedIssue.getAllIssues.returns([testGenericIssue]);
-
-      const mockDescriptionFileContent =
-        '# Mock Issue Title\n\nThis is a mock issue description {PLACEHOLDER_VALUE}';
-
-      getIssueDescriptionStub
-        .withArgs('mock.md')
-        .returns(mockDescriptionFileContent);
-
-      const formatter = new IssueFormatter(mockAggregatedIssue, {
-        id: 5,
-      });
-
-      const detailedResult = formatter.toJSONDetailed() as unknown as Record<
-        string,
-        object
-      > & {affectedResources: Array<{data: object}>};
-      assert.strictEqual(detailedResult.id, 5);
-      assert.strictEqual(detailedResult.type, 'issue');
-      assert.strictEqual(detailedResult.title, 'Mock Issue Title');
-      assert.strictEqual(
-        detailedResult.description,
-        '# Mock Issue Title\n\nThis is a mock issue description sub value',
-      );
-      assert.deepStrictEqual(detailedResult.links, mockDescription.links);
-      assert.strictEqual(detailedResult.affectedResources.length, 1);
-      assert.deepStrictEqual(detailedResult.affectedResources[0].data, {
-        violatingNodeAttribute: 'test',
-        violatingNodeId: 2,
-      });
     });
   });
 });


### PR DESCRIPTION
- makes the id required in types
- requires toString(), toStringDetailed() to use the JSON representation.