### PR TITLE
test: do not suppress uncaught errors in tests

### DIFF
--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -68,6 +68,7 @@ async function runTests(attempt) {
       env: {
         ...process.env,
         CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: true,
+        CHROME_DEVTOOLS_MCP_CRASH_ON_UNCAUGHT: true,
       },
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,9 +58,11 @@ if (args.usageStatistics) {
   });
 }
 
-process.on('unhandledRejection', (reason, promise) => {
-  logger('Unhandled promise rejection', promise, reason);
-});
+if (process.env['CHROME_DEVTOOLS_MCP_CRASH_ON_UNCAUGHT'] !== 'true') {
+  process.on('unhandledRejection', (reason, promise) => {
+    logger('Unhandled promise rejection', promise, reason);
+  });
+}
 
 logger(`Starting Chrome DevTools MCP Server v${VERSION}`);
 const server = new McpServer(


### PR DESCRIPTION
We want to suppress uncaught errors in production because we do not want to crash the entire server. But it might be useful in tests.