### PR TITLE
Group identical console messages in list_console_messages

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -36,6 +36,51 @@ interface TraceInsightData {
   insightName: InsightName;
 }
 
+class GroupedConsoleMessage {
+  readonly key: string;
+  #first: ConsoleFormatter;
+  #count = 0;
+  #msgids: number[] = [];
+
+  constructor(first: ConsoleFormatter) {
+    this.#first = first;
+    this.key = GroupedConsoleMessage.keyFor(first);
+    this.add(first);
+  }
+
+  static keyFor(message: ConsoleFormatter): string {
+    const json = message.toJSON();
+    return JSON.stringify({
+      type: json.type,
+      text: json.text,
+      argsCount: json.argsCount,
+    });
+  }
+
+  add(message: ConsoleFormatter): void {
+    const json = message.toJSON();
+    this.#count++;
+    this.#msgids.push(json.id);
+  }
+
+  toString(): string {
+    const base = this.#first.toString();
+    if (this.#count <= 1) {
+      return base;
+    }
+    return `${base} [${this.#count} times]`;
+  }
+
+  toJSON(): object {
+    const base = this.#first.toJSON();
+    return {
+      ...base,
+      count: this.#count,
+      msgids: this.#msgids,
+    };
+  }
+}
+
 export class McpResponse implements Response {
   #includePages = false;
   #snapshotParams?: SnapshotParams;
@@ -612,7 +657,7 @@ Call ${handleDialog.name} to handle it before continuing.`);
     }
 
     if (this.#consoleDataOptions?.include) {
-      const messages = data.consoleMessages ?? [];
+      const messages = this.#groupConsoleMessages(data.consoleMessages ?? []);
 
       response.push('## Console messages');
       if (messages.length) {
@@ -648,6 +693,41 @@ Call ${handleDialog.name} to handle it before continuing.`);
       content: [text, ...images],
       structuredContent,
     };
+  }
+
+  #groupConsoleMessages(
+    messages: Array<ConsoleFormatter | IssueFormatter>,
+  ): Array<ConsoleFormatter | IssueFormatter | GroupedConsoleMessage> {
+    const result: Array<ConsoleFormatter | IssueFormatter | GroupedConsoleMessage> = [];
+
+    let activeGroup: GroupedConsoleMessage | null = null;
+
+    const flush = () => {
+      if (activeGroup) {
+        result.push(activeGroup);
+        activeGroup = null;
+      }
+    };
+
+    for (const message of messages) {
+      if (!(message instanceof ConsoleFormatter)) {
+        flush();
+        result.push(message);
+        continue;
+      }
+
+      const key = GroupedConsoleMessage.keyFor(message);
+      if (activeGroup && activeGroup.key === key) {
+        activeGroup.add(message);
+        continue;
+      }
+
+      flush();
+      activeGroup = new GroupedConsoleMessage(message);
+    }
+
+    flush();
+    return result;
   }
 
   #dataWithPagination<T>(data: T[], pagination?: PaginationOptions) {

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -42,6 +42,30 @@ describe('console', () => {
       });
     });
 
+    it('groups identical messages', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = await context.newPage();
+        await page.setContent(`
+          <script>
+            for (let i = 0; i < 5; i++) {
+              console.log('spam');
+            }
+          </script>
+        `);
+        await listConsoleMessages.handler({params: {}}, response, context);
+        const formattedResponse = await response.handle('test', context);
+        const textContent = getTextContent(formattedResponse.content[0]);
+        assert.ok(
+          textContent.includes('msgid=1 [log] spam (1 args) [5 times]'),
+          textContent,
+        );
+        assert.ok(
+          !textContent.includes('msgid=2 [log] spam'),
+          'Should collapse subsequent identical messages',
+        );
+      });
+    });
+
     it('lists error objects', async t => {
       await withMcpContext(async (response, context) => {
         const page = await context.newPage();


### PR DESCRIPTION
Fixes #904\n\n- Collapse consecutive identical console messages in list_console_messages output and annotate with "[N times]".\n- Preserve the first msgid and expose grouped msgids/count in structuredContent.\n- Add a unit test for grouping behavior.