### PR TITLE
refactor: optimize slim tool descriptions and params

### DIFF
--- a/docs/slim-tool-reference.md
+++ b/docs/slim-tool-reference.md
@@ -1,6 +1,6 @@
 <!-- AUTO GENERATED DO NOT EDIT - run 'npm run docs' to update-->
 
-# Chrome DevTools MCP Slim Tool Reference (~368 cl100k_base tokens)
+# Chrome DevTools MCP Slim Tool Reference (~359 cl100k_base tokens)
 
 - **[Navigation automation](#navigation-automation)** (1 tools)
   - [`navigate`](#navigate)
@@ -12,11 +12,11 @@
 
 ### `navigate`
 
-**Description:** Load URL in the browser
+**Description:** Loads a URL
 
 **Parameters:**
 
-- **url** (string) **(required)**: Page URL
+- **url** (string) **(required)**: URL to [`navigate`](#navigate) to
 
 ---
 
@@ -24,17 +24,17 @@
 
 ### `evaluate`
 
-**Description:** [`Evaluate`](#evaluate) a JavaScript function on the last loaded page
+**Description:** Evaluates a JavaScript script
 
 **Parameters:**
 
-- **fn** (string) **(required)**: A JavaScript function to be executed on the active page
+- **script** (string) **(required)**: JS script to run on the page
 
 ---
 
 ### `screenshot`
 
-**Description:** Take a [`screenshot`](#screenshot) of the active page.
+**Description:** Takes a [`screenshot`](#screenshot)
 
 **Parameters:** None
 

--- a/src/tools/slim/tools.ts
+++ b/src/tools/slim/tools.ts
@@ -12,7 +12,7 @@ import {defineTool} from '../ToolDefinition.js';
 
 export const screenshot = defineTool({
   name: 'screenshot',
-  description: `Take a screenshot of the active page.`,
+  description: `Takes a screenshot`,
   annotations: {
     category: ToolCategory.DEBUGGING,
     // Not read-only due to filePath param.
@@ -32,13 +32,13 @@ export const screenshot = defineTool({
 
 export const navigate = defineTool({
   name: 'navigate',
-  description: `Load URL in the browser`,
+  description: `Loads a URL`,
   annotations: {
     category: ToolCategory.NAVIGATION,
     readOnlyHint: false,
   },
   schema: {
-    url: zod.string().describe('Page URL'),
+    url: zod.string().describe('URL to navigate to'),
   },
   handler: async (request, response, context) => {
     const page = context.getSelectedPage();
@@ -68,29 +68,21 @@ export const navigate = defineTool({
 
 export const evaluate = defineTool({
   name: 'evaluate',
-  description: `Evaluate a JavaScript function on the last loaded page`,
+  description: `Evaluates a JavaScript script`,
   annotations: {
     category: ToolCategory.DEBUGGING,
     readOnlyHint: false,
   },
   schema: {
-    fn: zod
-      .string()
-      .describe(`A JavaScript function to be executed on the active page`),
+    script: zod.string().describe(`JS script to run on the page`),
   },
   handler: async (request, response, context) => {
     const page = context.getSelectedPage();
-    const fn = await page.evaluateHandle(`(${request.params.fn})`);
     try {
-      const result = await page.evaluate(async fn => {
-        // @ts-expect-error no types.
-        return JSON.stringify(await fn());
-      }, fn);
-      response.appendResponseLine(result);
+      const result = await page.evaluate(request.params.script);
+      response.appendResponseLine(JSON.stringify(result));
     } catch (err) {
       response.appendResponseLine(String(err.message));
-    } finally {
-      void fn.dispose();
     }
   },
 });

--- a/tests/tools/slim/tools.test.ts
+++ b/tests/tools/slim/tools.test.ts
@@ -17,7 +17,11 @@ describe('slim', () => {
   it('evaluates', async t => {
     await withMcpContext(async (response, context) => {
       await evaluate.handler(
-        {params: {fn: String(() => 2 * 5)}},
+        {
+          params: {
+            script: `2 * 5`,
+          },
+        },
         response,
         context,
       );
@@ -30,9 +34,7 @@ describe('slim', () => {
       await evaluate.handler(
         {
           params: {
-            fn: String(() => {
-              throw new Error('test error');
-            }),
+            script: `throw new Error('test error')`,
           },
         },
         response,


### PR DESCRIPTION
Minor changes to shorten descriptions and improve ease of use.

Note that `--slim` mode is not released yet and this is an improvement for it.