### PR TITLE
chore: make eval scripts cross-platform compatible (Windows)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare": "node --experimental-strip-types scripts/prepare.ts",
     "verify-server-json-version": "node --experimental-strip-types scripts/verify-server-json-version.ts",
     "verify-npm-package": "node scripts/verify-npm-package.mjs",
-    "eval": "npm run build && CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS=true node --experimental-strip-types scripts/eval_gemini.ts",
+    "eval": "npm run build && node --experimental-strip-types scripts/eval_gemini.ts",
     "count-tokens": "node --experimental-strip-types scripts/count_tokens.ts"
   },
   "files": [

--- a/scripts/eval_gemini.ts
+++ b/scripts/eval_gemini.ts
@@ -6,6 +6,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import {pathToFileURL} from 'node:url';
 import {parseArgs} from 'node:util';
 
 import {GoogleGenAI, mcpToTool} from '@google/genai';
@@ -35,7 +36,7 @@ export interface TestScenario {
 }
 
 async function loadScenario(scenarioPath: string): Promise<TestScenario> {
-  const module = await import(scenarioPath);
+  const module = await import(pathToFileURL(scenarioPath).href);
   if (!module.scenario) {
     throw new Error(
       `Scenario file ${scenarioPath} does not export a 'scenario' object.`,
@@ -110,6 +111,7 @@ async function runSingleScenario(
         env[key] = value;
       }
     });
+    env['CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS'] = 'true';
 
     const args = [serverPath];
     if (!debug) {


### PR DESCRIPTION
Fixes #1029

## Summary
- Use `pathToFileURL()` from `node:url` for dynamic imports in `eval_gemini.ts` to fix `ERR_UNSUPPORTED_ESM_URL_SCHEME` on Windows - converts absolute paths like `D:\projects\...\console_test.ts` to proper `file:///D:/projects/.../console_test.ts` URLs that the Node.js ESM loader accepts on all platforms
- Move `CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS=true` from Unix-only shell env var prefix in `package.json` into `eval_gemini.ts` code, matching the pattern already used in `scripts/test.mjs`
- Add `.gitattributes` with `* text=auto eol=lf` to enforce LF line endings on checkout - Windows contributors cloning the repo would otherwise get CRLF endings, which conflicts with the project's Prettier `endOfLine: 'lf'` config and causes spurious diffs or formatting failures
