### PR TITLE
fix: remove endsWith for filePath in memory tools

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,6 +1,6 @@
 <!-- AUTO GENERATED DO NOT EDIT - run 'npm run docs' to update-->
 
-# Chrome DevTools MCP Tool Reference (~7095 cl100k_base tokens)
+# Chrome DevTools MCP Tool Reference (~7084 cl100k_base tokens)
 
 - **[Input automation](#input-automation)** (9 tools)
   - [`click`](#click)

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -19,8 +19,7 @@ export const takeMemorySnapshot = defineTool({
   schema: {
     filePath: zod
       .string()
-      .describe('A path to a .heapsnapshot file to save the heapsnapshot to.')
-      .endsWith('.heapsnapshot'),
+      .describe('A path to a .heapsnapshot file to save the heapsnapshot to.'),
   },
   handler: async (request, response, context) => {
     const page = context.getSelectedPage();


### PR DESCRIPTION
Looks like there is another incompatibility in JSON schema handling between MCP clients.

Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/1039