### PR TITLE
refactor: move dialog handling to McpPage

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -23,7 +23,6 @@ import type {
   BrowserContext,
   ConsoleMessage,
   Debugger,
-  Dialog,
   ElementHandle,
   HTTPRequest,
   Page,
@@ -205,7 +204,7 @@ export class McpContext implements Context {
   }
 
   #resolveTargetPage(): Page {
-    return this.#requestPage?.pptrPage ?? this.getSelectedPage();
+    return this.#requestPage?.pptrPage ?? this.getSelectedPptrPage();
   }
 
   resolveCdpRequestId(cdpRequestId: string): number | undefined {
@@ -327,7 +326,7 @@ export class McpContext implements Context {
   }
 
   async restoreEmulation(targetPage?: Page) {
-    const page = targetPage ?? this.getSelectedPage();
+    const page = targetPage ?? this.getSelectedPptrPage();
     const mcpPage = this.#getMcpPage(page);
     const currentSetting = mcpPage.emulationSettings;
     await this.emulate(currentSetting, targetPage);
@@ -344,7 +343,7 @@ export class McpContext implements Context {
     },
     targetPage?: Page,
   ): Promise<void> {
-    const page = targetPage ?? this.getSelectedPage();
+    const page = targetPage ?? this.getSelectedPptrPage();
     const mcpPage = this.#getMcpPage(page);
     const newSettings: EmulationSettings = {...mcpPage.emulationSettings};
     let timeoutsNeedUpdate = false;
@@ -492,23 +491,7 @@ export class McpContext implements Context {
     return this.#options.performanceCrux;
   }
 
-  getDialog(page?: Page): Dialog | undefined {
-    const targetPage =
-      page ?? this.#requestPage?.pptrPage ?? this.#selectedPage;
-    if (!targetPage) {
-      return undefined;
-    }
-    return this.#mcpPages.get(targetPage)?.dialog;
-  }
-
-  clearDialog(page?: Page): void {
-    const targetPage = page ?? this.#selectedPage;
-    if (targetPage) {
-      this.#mcpPages.get(targetPage)?.clearDialog();
-    }
-  }
-
-  getSelectedPage(): Page {
+  getSelectedPptrPage(): Page {
     const page = this.#selectedPage;
     if (!page) {
       throw new Error('No page selected');
@@ -522,7 +505,7 @@ export class McpContext implements Context {
   }
 
   getSelectedMcpPage(): McpPage {
-    const page = this.getSelectedPage();
+    const page = this.getSelectedPptrPage();
     return this.#getMcpPage(page);
   }
 
@@ -555,7 +538,7 @@ export class McpContext implements Context {
   }
 
   #getSelectedMcpPage(): McpPage {
-    return this.#getMcpPage(this.getSelectedPage());
+    return this.#getMcpPage(this.getSelectedPptrPage());
   }
 
   isPageSelected(page: Page): boolean {
@@ -595,7 +578,7 @@ export class McpContext implements Context {
   }
 
   #updateSelectedPageTimeouts() {
-    const page = this.getSelectedPage();
+    const page = this.getSelectedPptrPage();
     // For waiters 5sec timeout should be sufficient.
     // Increased in case we throttle the CPU
     const cpuMultiplier = this.getCpuThrottlingRate();
@@ -922,7 +905,7 @@ export class McpContext implements Context {
     devtoolsData: DevToolsData | undefined = undefined,
     targetPage?: Page,
   ): Promise<void> {
-    const page = targetPage ?? this.getSelectedPage();
+    const page = targetPage ?? this.getSelectedPptrPage();
     const mcpPage = this.#getMcpPage(page);
     const rootNode = await page.accessibility.snapshot({
       includeIframes: true,
@@ -1063,7 +1046,7 @@ export class McpContext implements Context {
     action: () => Promise<unknown>,
     options?: {timeout?: number},
   ): Promise<void> {
-    const page = this.getSelectedPage();
+    const page = this.getSelectedPptrPage();
     const cpuMultiplier = this.getCpuThrottlingRate();
     const networkMultiplier = getNetworkMultiplierFromString(
       this.getNetworkConditions(),
@@ -1085,7 +1068,7 @@ export class McpContext implements Context {
     timeout?: number,
     targetPage?: Page,
   ): Promise<Element> {
-    const page = targetPage ?? this.getSelectedPage();
+    const page = targetPage ?? this.getSelectedPptrPage();
     const frames = page.frames();
 
     let locator = this.#locatorClass.race(

--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -59,6 +59,10 @@ export class McpPage implements ContextPage {
     return this.#dialog;
   }
 
+  getDialog(): Dialog | undefined {
+    return this.dialog;
+  }
+
   clearDialog(): void {
     this.#dialog = undefined;
   }

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -10,6 +10,7 @@ import {IssueFormatter} from './formatters/IssueFormatter.js';
 import {NetworkFormatter} from './formatters/NetworkFormatter.js';
 import {SnapshotFormatter} from './formatters/SnapshotFormatter.js';
 import type {McpContext} from './McpContext.js';
+import type {McpPage} from './McpPage.js';
 import {UncaughtError} from './PageCollector.js';
 import {DevTools} from './third_party/index.js';
 import type {
@@ -70,9 +71,14 @@ export class McpResponse implements Response {
   #devToolsData?: DevToolsData;
   #tabId?: string;
   #args: ParsedArguments;
+  #page?: McpPage;
 
   constructor(args: ParsedArguments) {
     this.#args = args;
+  }
+
+  setPage(page: McpPage): void {
+    this.#page = page;
   }
 
   attachDevToolsData(data: DevToolsData): void {
@@ -517,7 +523,7 @@ export class McpResponse implements Response {
       structuredContent.colorScheme = colorScheme;
     }
 
-    const dialog = context.getDialog();
+    const dialog = this.#page?.getDialog();
     if (dialog) {
       const defaultValueIfNeeded =
         dialog.type() === 'prompt'

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,7 +153,8 @@ export async function createMcpServer(
     const schema =
       'pageScoped' in tool &&
       tool.pageScoped &&
-      serverArgs.experimentalPageIdRouting
+      serverArgs.experimentalPageIdRouting &&
+      !serverArgs.slim
         ? {...tool.schema, ...pageIdSchema}
         : tool.schema;
 
@@ -179,10 +180,13 @@ export async function createMcpServer(
           try {
             if ('pageScoped' in tool && tool.pageScoped) {
               const page =
-                serverArgs.experimentalPageIdRouting && params.pageId
+                serverArgs.experimentalPageIdRouting &&
+                params.pageId &&
+                !serverArgs.slim
                   ? context.resolvePageById(params.pageId)
                   : context.getSelectedMcpPage();
               context.setRequestPage(page);
+              response.setPage(page);
               await tool.handler(
                 {
                   params,

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -136,10 +136,6 @@ export type Context = Readonly<{
   isCruxEnabled(): boolean;
   recordedTraces(): TraceResult[];
   storeTraceRecording(result: TraceResult): void;
-  // TODO: Remove once slim tools are converted to pageScoped: true.
-  getSelectedPage(): Page;
-  getDialog(page?: Page): Dialog | undefined;
-  clearDialog(page?: Page): void;
   getPageById(pageId: number): Page;
   newPage(
     background?: boolean,
@@ -198,6 +194,9 @@ export type ContextPage = Readonly<{
   readonly pptrPage: Page;
   getAXNodeByUid(uid: string): TextSnapshotNode | undefined;
   getElementByUid(uid: string): Promise<ElementHandle<Element>>;
+
+  getDialog(): Dialog | undefined;
+  clearDialog(): void;
 }>;
 
 export function defineTool<Schema extends zod.ZodRawShape>(

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -187,7 +187,7 @@ export const navigatePage = definePageTool({
           void dialog.dismiss();
         }
         // We are not going to report the dialog like regular dialogs.
-        context.clearDialog(page.pptrPage);
+        page.clearDialog();
       }
     };
 
@@ -333,9 +333,9 @@ export const handleDialog = definePageTool({
       .optional()
       .describe('Optional prompt text to enter into the dialog.'),
   },
-  handler: async (request, response, context) => {
+  handler: async (request, response, _context) => {
     const page = request.page;
-    const dialog = context.getDialog(page.pptrPage);
+    const dialog = page.getDialog();
     if (!dialog) {
       throw new Error('No open dialog found');
     }
@@ -363,7 +363,7 @@ export const handleDialog = definePageTool({
       }
     }
 
-    context.clearDialog(page.pptrPage);
+    page.clearDialog();
     response.setIncludePages(true);
   },
 });

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -22,7 +22,7 @@ describe('McpContext', () => {
 
   it('list pages', async () => {
     await withMcpContext(async (_response, context) => {
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       await page.setContent(
         html`<button>Click me</button>
           <input
@@ -104,7 +104,7 @@ describe('McpContext', () => {
   it('resolves uid from a non-selected page snapshot', async () => {
     await withMcpContext(async (_response, context) => {
       // Page 1: set content and snapshot
-      const page1 = context.getSelectedPage();
+      const page1 = context.getSelectedPptrPage();
       await page1.setContent(html`<button>Page1 Button</button>`);
       await context.createTextSnapshot(false, undefined, page1);
 
@@ -230,7 +230,7 @@ describe('McpContext', () => {
     it('resolves for default context page alongside isolated contexts', async () => {
       await withMcpContext(async (_response, context) => {
         // Default context page (already exists from withMcpContext setup).
-        const defaultPage = context.getSelectedPage();
+        const defaultPage = context.getSelectedPptrPage();
         await defaultPage.setContent(html`<button>Default Button</button>`);
         await context.createTextSnapshot(false, undefined, defaultPage);
         const defaultUid = '1_1';

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -64,7 +64,7 @@ describe('McpResponse', () => {
 
   it('does not include anything in response if snapshot is null', async t => {
     await withMcpContext(async (response, context) => {
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       page.accessibility.snapshot = async () => null;
       const {content, structuredContent} = await response.handle(
         'test',
@@ -80,7 +80,7 @@ describe('McpResponse', () => {
 
   it('returns correctly formatted snapshot for a simple tree', async t => {
     await withMcpContext(async (response, context) => {
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       await page.setContent(
         html`<button>Click me</button>
           <input
@@ -104,7 +104,7 @@ describe('McpResponse', () => {
 
   it('returns values for textboxes', async t => {
     await withMcpContext(async (response, context) => {
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       await page.setContent(
         html`<label
           >username<input
@@ -128,7 +128,7 @@ describe('McpResponse', () => {
 
   it('returns verbose snapshot and structured content', async t => {
     await withMcpContext(async (response, context) => {
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       await page.setContent(html`<aside>test</aside>`);
       response.includeSnapshot({
         verbose: true,
@@ -147,7 +147,7 @@ describe('McpResponse', () => {
     const filePath = join(tmpdir(), 'test-screenshot.png');
     try {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(html`<aside>test</aside>`);
         response.includeSnapshot({
           verbose: true,
@@ -178,7 +178,7 @@ describe('McpResponse', () => {
 
   it('preserves mapping ids across multiple snapshots', async () => {
     await withMcpContext(async (response, context) => {
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       await page.setContent(html`
         <div>
           <button id="btn1">Button 1</button>
@@ -253,7 +253,7 @@ describe('McpResponse', () => {
             </div>
           `,
         );
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/page.html'));
 
         response.includeSnapshot();
@@ -401,13 +401,13 @@ describe('McpResponse', () => {
 
   it('adds a prompt dialog', async t => {
     await withMcpContext(async (response, context) => {
-      const page = context.getSelectedPage();
+      const page = context.getSelectedMcpPage();
       const dialogPromise = new Promise<void>(resolve => {
-        page.on('dialog', () => {
+        page.pptrPage.on('dialog', () => {
           resolve();
         });
       });
-      page.evaluate(() => {
+      page.pptrPage.evaluate(() => {
         prompt('message', 'default');
       });
       await dialogPromise;
@@ -415,7 +415,7 @@ describe('McpResponse', () => {
         'test',
         context,
       );
-      await context.getDialog()?.dismiss();
+      await page.getDialog()?.dismiss();
       t.assert.snapshot?.(getTextContent(content[0]));
       t.assert.snapshot?.(
         JSON.stringify(stabilizeStructuredContent(structuredContent), null, 2),
@@ -425,13 +425,13 @@ describe('McpResponse', () => {
 
   it('adds an alert dialog', async t => {
     await withMcpContext(async (response, context) => {
-      const page = context.getSelectedPage();
+      const page = context.getSelectedMcpPage();
       const dialogPromise = new Promise<void>(resolve => {
-        page.on('dialog', () => {
+        page.pptrPage.on('dialog', () => {
           resolve();
         });
       });
-      page.evaluate(() => {
+      page.pptrPage.evaluate(() => {
         alert('message');
       });
       await dialogPromise;
@@ -439,7 +439,7 @@ describe('McpResponse', () => {
         'test',
         context,
       );
-      await context.getDialog()?.dismiss();
+      await page.getDialog()?.dismiss();
       t.assert.snapshot?.(getTextContent(content[0]));
       t.assert.snapshot?.(
         JSON.stringify(stabilizeStructuredContent(structuredContent), null, 2),
@@ -544,7 +544,7 @@ describe('McpResponse', () => {
   it('adds console messages when the setting is true', async t => {
     await withMcpContext(async (response, context) => {
       response.setIncludeConsoleData(true);
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       const consoleMessagePromise = new Promise<void>(resolve => {
         page.on('console', () => {
           resolve();

--- a/tests/tools/emulation.test.ts
+++ b/tests/tools/emulation.test.ts
@@ -258,7 +258,7 @@ describe('emulation', () => {
 
     it('emulates viewport', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.baseUrl + '/viewport');
         await emulate.handler(
           {
@@ -298,7 +298,7 @@ describe('emulation', () => {
 
     it('clears viewport override when viewport is set to null', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         // First set a viewport
         await emulate.handler(
           {
@@ -341,7 +341,7 @@ describe('emulation', () => {
         assert.strictEqual(context.getViewport(), null);
 
         // Somehow reset of the viewport seems to be async.
-        await context.getSelectedPage().waitForFunction(() => {
+        await context.getSelectedPptrPage().waitForFunction(() => {
           return window.innerWidth !== 400 && window.innerHeight !== 400;
         });
       });
@@ -370,7 +370,7 @@ describe('emulation', () => {
 
         assert.strictEqual(context.getViewport(), null);
         assert.ok(
-          await context.getSelectedPage().evaluate(() => {
+          await context.getSelectedPptrPage().evaluate(() => {
             return window.innerWidth !== 400 && window.innerHeight !== 400;
           }),
         );
@@ -393,7 +393,7 @@ describe('emulation', () => {
         );
 
         assert.strictEqual(context.getUserAgent(), 'MyUA');
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         const ua = await page.evaluate(() => navigator.userAgent);
         assert.strictEqual(ua, 'MyUA');
       });
@@ -424,7 +424,7 @@ describe('emulation', () => {
           context,
         );
         assert.strictEqual(context.getUserAgent(), 'UA2');
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         const ua = await page.evaluate(() => navigator.userAgent);
         assert.strictEqual(ua, 'UA2');
       });
@@ -457,7 +457,7 @@ describe('emulation', () => {
         );
 
         assert.strictEqual(context.getUserAgent(), null);
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         const ua = await page.evaluate(() => navigator.userAgent);
         assert.notStrictEqual(ua, 'MyUA');
         assert.ok(ua.length > 0);
@@ -484,7 +484,7 @@ describe('emulation', () => {
 
         assert.strictEqual(context.getUserAgent(), null);
         assert.ok(
-          await context.getSelectedPage().evaluate(() => {
+          await context.getSelectedPptrPage().evaluate(() => {
             return navigator.userAgent !== 'MyUA';
           }),
         );
@@ -507,7 +507,7 @@ describe('emulation', () => {
         );
 
         assert.strictEqual(context.getColorScheme(), 'dark');
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         const scheme = await page.evaluate(() =>
           window.matchMedia('(prefers-color-scheme: dark)').matches
             ? 'dark'
@@ -542,7 +542,7 @@ describe('emulation', () => {
           context,
         );
         assert.strictEqual(context.getColorScheme(), 'light');
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         const scheme = await page.evaluate(() =>
           window.matchMedia('(prefers-color-scheme: light)').matches
             ? 'light'
@@ -554,7 +554,7 @@ describe('emulation', () => {
 
     it('resets color scheme when set to auto', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         const initial = await page.evaluate(
           () => window.matchMedia('(prefers-color-scheme: dark)').matches,

--- a/tests/tools/extensions.test.ts
+++ b/tests/tools/extensions.test.ts
@@ -48,7 +48,7 @@ describe('extension', () => {
       );
 
       const extensionId = extractId(response);
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       await page.goto('chrome://extensions');
 
       const element = await page.waitForSelector(

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -32,7 +32,7 @@ describe('input', () => {
   describe('click', () => {
     it('clicks', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<button onclick="this.innerText = 'clicked';">test</button>`,
         );
@@ -57,7 +57,7 @@ describe('input', () => {
     });
     it('double clicks', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<button ondblclick="this.innerText = 'dblclicked';"
             >test</button
@@ -96,7 +96,7 @@ describe('input', () => {
       });
 
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/link'));
         await context.createTextSnapshot();
         const clickPromise = click.handler(
@@ -139,7 +139,7 @@ describe('input', () => {
         `,
       );
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/unstable'));
         await context.createTextSnapshot();
         const handlerResolveTime = await click
@@ -165,7 +165,7 @@ describe('input', () => {
 
     it('does not include snapshot by default', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<button onclick="this.innerText = 'clicked';">test</button>`,
         );
@@ -190,7 +190,7 @@ describe('input', () => {
 
     it('includes snapshot if includeSnapshot is true', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<button onclick="this.innerText = 'clicked';">test</button>`,
         );
@@ -218,7 +218,7 @@ describe('input', () => {
   describe('hover', () => {
     it('hovers', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<button onmouseover="this.innerText = 'hovered';">test</button>`,
         );
@@ -246,7 +246,7 @@ describe('input', () => {
   describe('click_at', () => {
     it('clicks at coordinates', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<div
             style="width: 100px; height: 100px; background: red;"
@@ -276,7 +276,7 @@ describe('input', () => {
 
     it('double clicks at coordinates', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<div
             style="width: 100px; height: 100px; background: red;"
@@ -309,7 +309,7 @@ describe('input', () => {
   describe('fill', () => {
     it('fills out an input', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(html`<input />`);
         await context.createTextSnapshot();
         await fill.handler(
@@ -334,7 +334,7 @@ describe('input', () => {
 
     it('fills out a select by text', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<select
             ><option value="v1">one</option
@@ -367,7 +367,7 @@ describe('input', () => {
 
     it('fills out a textarea marked as combobox', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea role="combobox"></textarea>`);
         await context.createTextSnapshot();
         await fill.handler(
@@ -396,7 +396,7 @@ describe('input', () => {
 
     it('fills out a textarea with long text', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea></textarea>`);
         await context.createTextSnapshot();
         page.setDefaultTimeout(1000);
@@ -428,7 +428,7 @@ describe('input', () => {
 
     it('types text', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea></textarea>`);
         await page.click('textarea');
         await context.createTextSnapshot();
@@ -454,7 +454,7 @@ describe('input', () => {
 
     it('types text with submit key', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea></textarea>`);
         await page.click('textarea');
         await context.createTextSnapshot();
@@ -491,7 +491,7 @@ describe('input', () => {
 
     it('errors on invalid submit key', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea></textarea>`);
         await page.click('textarea');
         await context.createTextSnapshot();
@@ -515,7 +515,7 @@ describe('input', () => {
 
     it('reproduction: fill isolation', async () => {
       await withMcpContext(async (_response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<form>
             <input
@@ -592,7 +592,7 @@ describe('input', () => {
   describe('drags', () => {
     it('drags one element onto another', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<div
               role="button"
@@ -647,7 +647,7 @@ describe('input', () => {
   describe('fill form', () => {
     it('successfully fills out the form', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<form>
             <label
@@ -712,7 +712,7 @@ describe('input', () => {
       await fs.writeFile(testFilePath, 'test file content');
 
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<form>
             <input
@@ -748,7 +748,7 @@ describe('input', () => {
       await fs.writeFile(testFilePath, 'test file content');
 
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<button id="file-chooser-button">Upload file</button>
             <input
@@ -796,7 +796,7 @@ describe('input', () => {
       await fs.writeFile(testFilePath, 'test file content');
 
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(html`<div>Not a file input</div>`);
         await context.createTextSnapshot();
 
@@ -856,7 +856,7 @@ describe('input', () => {
 
     it('processes press_key', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(
           html`<script>
             logs = [];

--- a/tests/tools/lighthouse.test.ts
+++ b/tests/tools/lighthouse.test.ts
@@ -21,7 +21,7 @@ describe('lighthouse', () => {
       server.addHtmlRoute('/test', html`<div>Test</div>`);
 
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/test'));
 
         await lighthouseAudit.handler(
@@ -56,7 +56,7 @@ describe('lighthouse', () => {
       server.addHtmlRoute('/test-mobile', html`<div>Test Mobile</div>`);
 
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/test-mobile'));
         await context.emulate({
           viewport: {
@@ -121,7 +121,7 @@ describe('lighthouse', () => {
       server.addHtmlRoute('/test-mobile', html`<div>Test Mobile</div>`);
 
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/test-mobile'));
 
         await lighthouseAudit.handler(
@@ -156,7 +156,7 @@ describe('lighthouse', () => {
 
       try {
         await withMcpContext(async (response, context) => {
-          const page = context.getSelectedPage();
+          const page = context.getSelectedPptrPage();
           await page.goto(server.getRoute('/test-mobile'));
 
           await lighthouseAudit.handler(

--- a/tests/tools/network.test.ts
+++ b/tests/tools/network.test.ts
@@ -41,7 +41,7 @@ describe('network', () => {
 
       await withMcpContext(async (response, context) => {
         await context.setUpNetworkCollectorForTesting();
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/one'));
         await page.goto(server.getRoute('/two'));
         await page.goto(server.getRoute('/three'));
@@ -68,7 +68,7 @@ describe('network', () => {
 
       await withMcpContext(async (response, context) => {
         await context.setUpNetworkCollectorForTesting();
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/one'));
         await page.goto(server.getRoute('/two'));
         await page.goto(server.getRoute('/three'));
@@ -111,7 +111,7 @@ describe('network', () => {
 
       await withMcpContext(async (response, context) => {
         await context.setUpNetworkCollectorForTesting();
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/redirect'), {
           waitUntil: 'networkidle0',
         });
@@ -135,7 +135,7 @@ describe('network', () => {
   describe('network_get_request', () => {
     it('attaches request', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto('data:text/html,<div>Hello MCP</div>');
         await getNetworkRequest.handler(
           {params: {reqid: 1}, page: context.getSelectedMcpPage()},
@@ -148,7 +148,7 @@ describe('network', () => {
     });
     it('should not add the request list', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto('data:text/html,<div>Hello MCP</div>');
         await getNetworkRequest.handler(
           {params: {reqid: 1}, page: context.getSelectedMcpPage()},
@@ -165,7 +165,7 @@ describe('network', () => {
 
       await withMcpContext(async (response, context) => {
         await context.setUpNetworkCollectorForTesting();
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/one'));
         await page.goto(server.getRoute('/two'));
         await page.goto(server.getRoute('/three'));

--- a/tests/tools/performance.test.ts
+++ b/tests/tools/performance.test.ts
@@ -46,7 +46,7 @@ describe('performance', () => {
     it('starts a trace recording', async () => {
       await withMcpContext(async (response, context) => {
         context.setIsRunningPerformanceTrace(false);
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         const startTracingStub = sinon.stub(selectedPage.tracing, 'start');
         await startTrace.handler(
           {
@@ -68,7 +68,7 @@ describe('performance', () => {
 
     it('can navigate to about:blank and record a page reload', async () => {
       await withMcpContext(async (response, context) => {
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         sinon.stub(selectedPage, 'url').callsFake(() => 'https://www.test.com');
         const gotoStub = sinon.stub(selectedPage, 'goto');
         const startTracingStub = sinon.stub(selectedPage.tracing, 'start');
@@ -100,7 +100,7 @@ describe('performance', () => {
       const rawData = loadTraceAsBuffer('basic-trace.json.gz');
 
       await withMcpContext(async (response, context) => {
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         sinon.stub(selectedPage, 'url').callsFake(() => 'https://www.test.com');
         sinon.stub(selectedPage, 'goto').callsFake(() => Promise.resolve(null));
         const startTracingStub = sinon.stub(selectedPage.tracing, 'start');
@@ -147,7 +147,7 @@ describe('performance', () => {
     it('errors if a recording is already active', async () => {
       await withMcpContext(async (response, context) => {
         context.setIsRunningPerformanceTrace(true);
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         const startTracingStub = sinon.stub(selectedPage.tracing, 'start');
         await startTrace.handler(
           {
@@ -174,7 +174,7 @@ describe('performance', () => {
 
       await withMcpContext(async (response, context) => {
         const filePath = 'test-trace.json.gz';
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         sinon.stub(selectedPage, 'url').callsFake(() => 'https://www.test.com');
         sinon.stub(selectedPage, 'goto').callsFake(() => Promise.resolve(null));
         sinon.stub(selectedPage.tracing, 'start');
@@ -273,7 +273,7 @@ describe('performance', () => {
     it('does nothing if the trace is not running and does not error', async () => {
       await withMcpContext(async (response, context) => {
         context.setIsRunningPerformanceTrace(false);
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         const stopTracingStub = sinon.stub(selectedPage.tracing, 'stop');
         await stopTrace.handler(
           {params: {}, page: context.getSelectedMcpPage()},
@@ -289,7 +289,7 @@ describe('performance', () => {
       const rawData = loadTraceAsBuffer('basic-trace.json.gz');
       await withMcpContext(async (response, context) => {
         context.setIsRunningPerformanceTrace(true);
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         const stopTracingStub = sinon
           .stub(selectedPage.tracing, 'stop')
           .callsFake(async () => {
@@ -313,7 +313,7 @@ describe('performance', () => {
     it('throws an error if parsing the trace buffer fails', async () => {
       await withMcpContext(async (response, context) => {
         context.setIsRunningPerformanceTrace(true);
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         sinon
           .stub(selectedPage.tracing, 'stop')
           .returns(Promise.resolve(undefined));
@@ -334,7 +334,7 @@ describe('performance', () => {
       await withMcpContext(async (response, context) => {
         const filePath = 'test-trace.json';
         context.setIsRunningPerformanceTrace(true);
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         const stopTracingStub = sinon
           .stub(selectedPage.tracing, 'stop')
           .resolves(rawData);
@@ -364,7 +364,7 @@ describe('performance', () => {
       await withMcpContext(
         async (response, context) => {
           context.setIsRunningPerformanceTrace(true);
-          const selectedPage = context.getSelectedPage();
+          const selectedPage = context.getSelectedPptrPage();
           sinon.stub(selectedPage.tracing, 'stop').resolves(rawData);
 
           await stopTrace.handler(

--- a/tests/tools/screencast.test.ts
+++ b/tests/tools/screencast.test.ts
@@ -27,7 +27,7 @@ describe('screencast', () => {
     it('starts a screencast recording with filePath', async () => {
       await withMcpContext(async (response, context) => {
         const mockRecorder = createMockRecorder();
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         const screencastStub = sinon
           .stub(selectedPage, 'screencast')
           .resolves(mockRecorder as never);
@@ -58,7 +58,7 @@ describe('screencast', () => {
     it('starts a screencast recording with temp file when no filePath', async () => {
       await withMcpContext(async (response, context) => {
         const mockRecorder = createMockRecorder();
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         const screencastStub = sinon
           .stub(selectedPage, 'screencast')
           .resolves(mockRecorder as never);
@@ -85,7 +85,7 @@ describe('screencast', () => {
           filePath: '/tmp/existing.mp4',
         });
 
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         const screencastStub = sinon.stub(selectedPage, 'screencast');
 
         await startScreencast.handler(
@@ -105,7 +105,7 @@ describe('screencast', () => {
 
     it('provides a clear error when ffmpeg is not found', async () => {
       await withMcpContext(async (response, context) => {
-        const selectedPage = context.getSelectedPage();
+        const selectedPage = context.getSelectedPptrPage();
         const error = new Error('spawn ffmpeg ENOENT');
         sinon.stub(selectedPage, 'screencast').rejects(error);
 

--- a/tests/tools/screenshot.test.ts
+++ b/tests/tools/screenshot.test.ts
@@ -19,7 +19,7 @@ describe('screenshot', () => {
     it('with default options', async () => {
       await withMcpContext(async (response, context) => {
         const fixture = screenshots.basic;
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(fixture.html);
         await screenshot.handler(
           {params: {format: 'png'}, page: context.getSelectedMcpPage()},
@@ -38,7 +38,7 @@ describe('screenshot', () => {
     it('ignores quality', async () => {
       await withMcpContext(async (response, context) => {
         const fixture = screenshots.basic;
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(fixture.html);
         await screenshot.handler(
           {
@@ -92,7 +92,7 @@ describe('screenshot', () => {
     it('with full page', async () => {
       await withMcpContext(async (response, context) => {
         const fixture = screenshots.viewportOverflow;
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(fixture.html);
         await screenshot.handler(
           {
@@ -114,7 +114,7 @@ describe('screenshot', () => {
 
     it('with full page resulting in a large screenshot', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         await page.setContent(
           html`${`<div style="color:blue;">test</div>`.repeat(6500)}
@@ -153,7 +153,7 @@ describe('screenshot', () => {
       await withMcpContext(async (response, context) => {
         const fixture = screenshots.button;
 
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(fixture.html);
         await context.createTextSnapshot();
         await screenshot.handler(
@@ -182,7 +182,7 @@ describe('screenshot', () => {
         const filePath = join(tmpdir(), 'test-screenshot.png');
         try {
           const fixture = screenshots.basic;
-          const page = context.getSelectedPage();
+          const page = context.getSelectedPptrPage();
           await page.setContent(fixture.html);
           await screenshot.handler(
             {
@@ -225,7 +225,7 @@ describe('screenshot', () => {
         try {
           await withMcpContext(async (response, context) => {
             const fixture = screenshots.basic;
-            const page = context.getSelectedPage();
+            const page = context.getSelectedPptrPage();
             await page.setContent(fixture.html);
             await assert.rejects(
               screenshot.handler(
@@ -252,7 +252,7 @@ describe('screenshot', () => {
         try {
           await withMcpContext(async (response, context) => {
             const fixture = screenshots.basic;
-            const page = context.getSelectedPage();
+            const page = context.getSelectedPptrPage();
             await page.setContent(fixture.html);
             await assert.rejects(
               screenshot.handler(
@@ -280,7 +280,7 @@ describe('screenshot', () => {
         const invalidChar = process.platform === 'win32' ? '>' : '\0';
         const filePath = `malformed${invalidChar}path.png`;
         const fixture = screenshots.basic;
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.setContent(fixture.html);
         await assert.rejects(
           screenshot.handler(

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -67,7 +67,7 @@ describe('script', () => {
 
     it('work for complex objects', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         await page.setContent(html`<script src="./scripts.js"></script> `);
 
@@ -96,7 +96,7 @@ describe('script', () => {
 
     it('work for async functions', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         await page.setContent(html`<script src="./scripts.js"></script> `);
 
@@ -120,7 +120,7 @@ describe('script', () => {
 
     it('work with one argument', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         await page.setContent(html`<button id="test">test</button>`);
 
@@ -146,7 +146,7 @@ describe('script', () => {
 
     it('work with multiple args', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         await page.setContent(html`<button id="test">test</button>`);
 
@@ -178,7 +178,7 @@ describe('script', () => {
       server.addHtmlRoute('/main', html`<iframe src="/iframe"></iframe>`);
 
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/main'));
         await context.createTextSnapshot();
         await evaluateScript.handler(

--- a/tests/tools/slim/tools.test.ts
+++ b/tests/tools/slim/tools.test.ts
@@ -21,6 +21,7 @@ describe('slim', () => {
           params: {
             script: `2 * 5`,
           },
+          page: context.getSelectedMcpPage(),
         },
         response,
         context,
@@ -36,6 +37,7 @@ describe('slim', () => {
           params: {
             script: `throw new Error('test error')`,
           },
+          page: context.getSelectedMcpPage(),
         },
         response,
         context,
@@ -47,11 +49,14 @@ describe('slim', () => {
   it('navigates to correct page', async t => {
     await withMcpContext(async (response, context) => {
       await navigate.handler(
-        {params: {url: 'data:text/html,<div>Hello MCP</div>'}},
+        {
+          params: {url: 'data:text/html,<div>Hello MCP</div>'},
+          page: context.getSelectedMcpPage(),
+        },
         response,
         context,
       );
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       assert.equal(
         await page.evaluate(() => document.querySelector('div')?.textContent),
         'Hello MCP',
@@ -64,9 +69,13 @@ describe('slim', () => {
   it('with default options', async () => {
     await withMcpContext(async (response, context) => {
       const fixture = screenshots.basic;
-      const page = context.getSelectedPage();
+      const page = context.getSelectedPptrPage();
       await page.setContent(fixture.html);
-      await screenshot.handler({params: {format: 'png'}}, response, context);
+      await screenshot.handler(
+        {params: {format: 'png'}, page: context.getSelectedMcpPage()},
+        response,
+        context,
+      );
       assert(path.isAbsolute(response.responseLines.at(0)!));
       assert(fs.existsSync(response.responseLines.at(0)!));
     });

--- a/tests/tools/snapshot.test.ts
+++ b/tests/tools/snapshot.test.ts
@@ -26,7 +26,7 @@ describe('snapshot', () => {
   describe('browser_wait_for', () => {
     it('should work', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         await page.setContent(
           html`<main><span>Hello</span><span> </span><div>World</div></main>`,
@@ -52,7 +52,7 @@ describe('snapshot', () => {
 
     it('should work with any-match array', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         await page.setContent(
           html`<main><span>Status</span><div>Error</div></main>`,
@@ -78,7 +78,7 @@ describe('snapshot', () => {
 
     it('should work with any-match array when element shows up later', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         const handlePromise = waitFor.handler(
           {
@@ -109,7 +109,7 @@ describe('snapshot', () => {
 
     it('should work with element that show up later', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         const handlePromise = waitFor.handler(
           {
@@ -137,7 +137,7 @@ describe('snapshot', () => {
     });
     it('should work with aria elements', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         await page.setContent(
           html`<main><h1>Header</h1><div>Text</div></main>`,
@@ -164,7 +164,7 @@ describe('snapshot', () => {
 
     it('should work with iframe content', async () => {
       await withMcpContext(async (response, context) => {
-        const page = context.getSelectedPage();
+        const page = context.getSelectedPptrPage();
 
         await page.setContent(
           html`<h1>Top level</h1>

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -103,6 +103,8 @@ export async function withMcpContext(
       Locator,
     );
 
+    response.setPage(context.getSelectedMcpPage());
+
     await cb(response, context);
   }, options);
 }


### PR DESCRIPTION
- renamed getSelectedPage to getSelectedPptrPage
- removes getSelectedPptrPage from tool interfaces
- moves dialog handling to McpPage
- makes responses to be optionally McpPage-scoped