### PR TITLE
refactor: remove page passing via context

### DIFF
--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -146,7 +146,7 @@ export type Context = Readonly<{
   assertPageIsFocused(page: Page): void;
   getElementByUid(uid: string, page?: Page): Promise<ElementHandle<Element>>;
   getAXNodeByUid(uid: string): TextSnapshotNode | undefined;
-  restoreEmulation(): Promise<void>;
+  restoreEmulation(page: ContextPage): Promise<void>;
   emulate(
     options: {
       networkConditions?: string | null;
@@ -175,7 +175,7 @@ export type Context = Readonly<{
     timeout?: number,
     page?: Page,
   ): Promise<Element>;
-  getDevToolsData(): Promise<DevToolsData>;
+  getDevToolsData(page: ContextPage): Promise<DevToolsData>;
   /**
    * Returns a reqid for a cdpRequestId.
    */

--- a/src/tools/lighthouse.ts
+++ b/src/tools/lighthouse.ts
@@ -95,7 +95,7 @@ export const lighthouseAudit = definePageTool({
         throw new Error('Lighthouse audit failed.');
       }
     } finally {
-      await context.restoreEmulation();
+      await context.restoreEmulation(page);
     }
 
     const lhr = result.lhr;

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -71,7 +71,7 @@ export const listNetworkRequests = definePageTool({
       ),
   },
   handler: async (request, response, context) => {
-    const data = await context.getDevToolsData();
+    const data = await context.getDevToolsData(request.page);
     response.attachDevToolsData(data);
     const reqid = data?.cdpRequestId
       ? context.resolveCdpRequestId(request.page, data.cdpRequestId)
@@ -120,7 +120,7 @@ export const getNetworkRequest = definePageTool({
         responseFilePath: request.params.responseFilePath,
       });
     } else {
-      const data = await context.getDevToolsData();
+      const data = await context.getDevToolsData(request.page);
       response.attachDevToolsData(data);
       const reqid = data?.cdpRequestId
         ? context.resolveCdpRequestId(request.page, data.cdpRequestId)

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -36,7 +36,7 @@ describe('console', () => {
 
     it('lists error messages', async () => {
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.setContent(
           '<script>console.error("This is an error")</script>',
         );
@@ -53,7 +53,7 @@ describe('console', () => {
 
     it('lists error objects', async t => {
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.setContent(
           '<script>console.error(new Error("This is an error"))</script>',
         );
@@ -70,7 +70,7 @@ describe('console', () => {
 
     it('work with primitive unhandled errors', async () => {
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.setContent('<script>throw undefined;</script>');
         await listConsoleMessages.handler(
           {params: {}, page: context.getSelectedMcpPage()},
@@ -86,7 +86,7 @@ describe('console', () => {
     describe('issues', () => {
       it('lists issues', async () => {
         await withMcpContext(async (response, context) => {
-          const page = await context.newPage();
+          const page = context.getSelectedMcpPage();
           const issuePromise = new Promise<void>(resolve => {
             page.pptrPage.once('issue', () => {
               resolve();
@@ -114,6 +114,7 @@ describe('console', () => {
       it('lists issues after a page reload', async () => {
         await withMcpContext(async (response, context) => {
           const page = await context.newPage();
+          response.setPage(page);
           const issuePromise = new Promise<void>(resolve => {
             page.pptrPage.once('issue', () => {
               resolve();
@@ -168,7 +169,7 @@ describe('console', () => {
 
     it('gets a specific console message', async () => {
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.setContent(
           '<script>console.error("This is an error")</script>',
         );
@@ -195,7 +196,7 @@ describe('console', () => {
     describe('issues type', () => {
       it('gets issue details with node id parsing', async t => {
         await withMcpContext(async (response, context) => {
-          const page = await context.newPage();
+          const page = context.getSelectedMcpPage();
           const issuePromise = new Promise<void>(resolve => {
             page.pptrPage.once('issue', () => {
               resolve();
@@ -204,7 +205,7 @@ describe('console', () => {
           await page.pptrPage.setContent(
             '<input type="text" name="username" />',
           );
-          await context.createTextSnapshot();
+          await context.createTextSnapshot(page);
           await issuePromise;
           await listConsoleMessages.handler(
             {params: {}, page: context.getSelectedMcpPage()},
@@ -230,7 +231,7 @@ describe('console', () => {
         });
 
         await withMcpContext(async (response, context) => {
-          const page = await context.newPage();
+          const page = context.getSelectedMcpPage();
           const issuePromise = new Promise<void>(resolve => {
             page.pptrPage.once('issue', () => {
               resolve();
@@ -249,9 +250,9 @@ describe('console', () => {
               });
             </script>
           `);
-          await context.createTextSnapshot();
+          await context.createTextSnapshot(page);
           await issuePromise;
-          const messages = context.getConsoleData();
+          const messages = context.getConsoleData(page);
           let issueMsg;
           for (const message of messages) {
             if (message instanceof DevTools.AggregatedIssue) {
@@ -299,7 +300,7 @@ describe('console', () => {
       );
 
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.goto(server.getRoute('/index.html'));
 
         await getConsoleMessage.handler(
@@ -328,7 +329,7 @@ describe('console', () => {
       );
 
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.goto(server.getRoute('/index.html'));
 
         await getConsoleMessage.handler(
@@ -357,7 +358,7 @@ describe('console', () => {
       );
 
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.goto(server.getRoute('/index.html'));
 
         await getConsoleMessage.handler(
@@ -386,7 +387,7 @@ describe('console', () => {
       );
 
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.goto(server.getRoute('/index.html'));
 
         await getConsoleMessage.handler(
@@ -415,7 +416,7 @@ describe('console', () => {
       );
 
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.goto(server.getRoute('/index.html'));
 
         await getConsoleMessage.handler(
@@ -458,7 +459,7 @@ describe('console', () => {
       );
 
       await withMcpContext(async (response, context) => {
-        const page = await context.newPage();
+        const page = context.getSelectedMcpPage();
         await page.pptrPage.goto(server.getRoute('/index.html'));
 
         await getConsoleMessage.handler(

--- a/tests/tools/emulation.test.ts
+++ b/tests/tools/emulation.test.ts
@@ -28,7 +28,10 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getNetworkConditions(), 'Offline');
+        assert.strictEqual(
+          context.getSelectedMcpPage().networkConditions,
+          'Offline',
+        );
       });
     });
     it('emulates network throttling when the throttling option is valid', async () => {
@@ -44,7 +47,10 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getNetworkConditions(), 'Slow 3G');
+        assert.strictEqual(
+          context.getSelectedMcpPage().networkConditions,
+          'Slow 3G',
+        );
       });
     });
 
@@ -61,7 +67,10 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getNetworkConditions(), null);
+        assert.strictEqual(
+          context.getSelectedMcpPage().networkConditions,
+          null,
+        );
       });
     });
 
@@ -78,7 +87,10 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getNetworkConditions(), null);
+        assert.strictEqual(
+          context.getSelectedMcpPage().networkConditions,
+          null,
+        );
       });
     });
 
@@ -95,12 +107,18 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getNetworkConditions(), 'Slow 3G');
+        assert.strictEqual(
+          context.getSelectedMcpPage().networkConditions,
+          'Slow 3G',
+        );
 
         const page = await context.newPage();
         context.selectPage(page);
 
-        assert.strictEqual(context.getNetworkConditions(), null);
+        assert.strictEqual(
+          context.getSelectedMcpPage().networkConditions,
+          null,
+        );
       });
     });
   });
@@ -119,7 +137,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getCpuThrottlingRate(), 4);
+        assert.strictEqual(context.getSelectedMcpPage().cpuThrottlingRate, 4);
       });
     });
 
@@ -139,7 +157,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getCpuThrottlingRate(), 1);
+        assert.strictEqual(context.getSelectedMcpPage().cpuThrottlingRate, 1);
       });
     });
 
@@ -156,12 +174,12 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getCpuThrottlingRate(), 4);
+        assert.strictEqual(context.getSelectedMcpPage().cpuThrottlingRate, 4);
 
         const page = await context.newPage();
         context.selectPage(page);
 
-        assert.strictEqual(context.getCpuThrottlingRate(), 1);
+        assert.strictEqual(context.getSelectedMcpPage().cpuThrottlingRate, 1);
       });
     });
   });
@@ -183,7 +201,7 @@ describe('emulation', () => {
           context,
         );
 
-        const geolocation = context.getGeolocation();
+        const geolocation = context.getSelectedMcpPage().geolocation;
         assert.strictEqual(geolocation?.latitude, 48.137154);
         assert.strictEqual(geolocation?.longitude, 11.576124);
       });
@@ -206,7 +224,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.notStrictEqual(context.getGeolocation(), null);
+        assert.notStrictEqual(context.getSelectedMcpPage().geolocation, null);
 
         // Then clear it by setting geolocation to null
         await emulate.handler(
@@ -220,7 +238,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getGeolocation(), null);
+        assert.strictEqual(context.getSelectedMcpPage().geolocation, null);
       });
     });
 
@@ -240,14 +258,14 @@ describe('emulation', () => {
           context,
         );
 
-        const geolocation = context.getGeolocation();
+        const geolocation = context.getSelectedMcpPage().geolocation;
         assert.strictEqual(geolocation?.latitude, 48.137154);
         assert.strictEqual(geolocation?.longitude, 11.576124);
 
         const page = await context.newPage();
         context.selectPage(page);
 
-        assert.strictEqual(context.getGeolocation(), null);
+        assert.strictEqual(context.getSelectedMcpPage().geolocation, null);
       });
     });
   });
@@ -338,7 +356,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getViewport(), null);
+        assert.strictEqual(context.getSelectedMcpPage().viewport, null);
 
         // Somehow reset of the viewport seems to be async.
         await context.getSelectedPptrPage().waitForFunction(() => {
@@ -363,12 +381,12 @@ describe('emulation', () => {
           context,
         );
 
-        assert.ok(context.getViewport());
+        assert.ok(context.getSelectedMcpPage().viewport);
 
         const page = await context.newPage();
         context.selectPage(page);
 
-        assert.strictEqual(context.getViewport(), null);
+        assert.strictEqual(context.getSelectedMcpPage().viewport, null);
         assert.ok(
           await context.getSelectedPptrPage().evaluate(() => {
             return window.innerWidth !== 400 && window.innerHeight !== 400;
@@ -392,7 +410,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getUserAgent(), 'MyUA');
+        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'MyUA');
         const page = context.getSelectedPptrPage();
         const ua = await page.evaluate(() => navigator.userAgent);
         assert.strictEqual(ua, 'MyUA');
@@ -411,7 +429,7 @@ describe('emulation', () => {
           response,
           context,
         );
-        assert.strictEqual(context.getUserAgent(), 'UA1');
+        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'UA1');
 
         await emulate.handler(
           {
@@ -423,7 +441,7 @@ describe('emulation', () => {
           response,
           context,
         );
-        assert.strictEqual(context.getUserAgent(), 'UA2');
+        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'UA2');
         const page = context.getSelectedPptrPage();
         const ua = await page.evaluate(() => navigator.userAgent);
         assert.strictEqual(ua, 'UA2');
@@ -443,7 +461,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getUserAgent(), 'MyUA');
+        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'MyUA');
 
         await emulate.handler(
           {
@@ -456,7 +474,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getUserAgent(), null);
+        assert.strictEqual(context.getSelectedMcpPage().userAgent, null);
         const page = context.getSelectedPptrPage();
         const ua = await page.evaluate(() => navigator.userAgent);
         assert.notStrictEqual(ua, 'MyUA');
@@ -477,12 +495,12 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getUserAgent(), 'MyUA');
+        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'MyUA');
 
         const page = await context.newPage();
         context.selectPage(page);
 
-        assert.strictEqual(context.getUserAgent(), null);
+        assert.strictEqual(context.getSelectedMcpPage().userAgent, null);
         assert.ok(
           await context.getSelectedPptrPage().evaluate(() => {
             return navigator.userAgent !== 'MyUA';
@@ -506,7 +524,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getColorScheme(), 'dark');
+        assert.strictEqual(context.getSelectedMcpPage().colorScheme, 'dark');
         const page = context.getSelectedPptrPage();
         const scheme = await page.evaluate(() =>
           window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -529,7 +547,7 @@ describe('emulation', () => {
           response,
           context,
         );
-        assert.strictEqual(context.getColorScheme(), 'dark');
+        assert.strictEqual(context.getSelectedMcpPage().colorScheme, 'dark');
 
         await emulate.handler(
           {
@@ -541,7 +559,7 @@ describe('emulation', () => {
           response,
           context,
         );
-        assert.strictEqual(context.getColorScheme(), 'light');
+        assert.strictEqual(context.getSelectedMcpPage().colorScheme, 'light');
         const page = context.getSelectedPptrPage();
         const scheme = await page.evaluate(() =>
           window.matchMedia('(prefers-color-scheme: light)').matches
@@ -570,7 +588,7 @@ describe('emulation', () => {
           response,
           context,
         );
-        assert.strictEqual(context.getColorScheme(), 'dark');
+        assert.strictEqual(context.getSelectedMcpPage().colorScheme, 'dark');
         // Check manually that it is dark
 
         assert.strictEqual(
@@ -591,7 +609,7 @@ describe('emulation', () => {
           context,
         );
 
-        assert.strictEqual(context.getColorScheme(), null);
+        assert.strictEqual(context.getSelectedMcpPage().colorScheme, null);
         assert.strictEqual(
           await page.evaluate(
             () => window.matchMedia('(prefers-color-scheme: dark)').matches,

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -36,7 +36,7 @@ describe('input', () => {
         await page.setContent(
           html`<button onclick="this.innerText = 'clicked';">test</button>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await click.handler(
           {
             params: {
@@ -63,7 +63,7 @@ describe('input', () => {
             >test</button
           >`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await click.handler(
           {
             params: {
@@ -98,7 +98,7 @@ describe('input', () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/link'));
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         const clickPromise = click.handler(
           {
             params: {
@@ -141,7 +141,7 @@ describe('input', () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/unstable'));
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         const handlerResolveTime = await click
           .handler(
             {
@@ -169,7 +169,7 @@ describe('input', () => {
         await page.setContent(
           html`<button onclick="this.innerText = 'clicked';">test</button>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await click.handler(
           {
             params: {
@@ -194,7 +194,7 @@ describe('input', () => {
         await page.setContent(
           html`<button onclick="this.innerText = 'clicked';">test</button>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await click.handler(
           {
             params: {
@@ -222,7 +222,7 @@ describe('input', () => {
         await page.setContent(
           html`<button onmouseover="this.innerText = 'hovered';">test</button>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await hover.handler(
           {
             params: {
@@ -253,7 +253,7 @@ describe('input', () => {
             onclick="this.innerText = 'clicked'"
           ></div>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await clickAt.handler(
           {
             params: {
@@ -283,7 +283,7 @@ describe('input', () => {
             ondblclick="this.innerText = 'dblclicked'"
           ></div>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await clickAt.handler(
           {
             params: {
@@ -311,7 +311,7 @@ describe('input', () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();
         await page.setContent(html`<input />`);
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await fill.handler(
           {
             params: {
@@ -341,7 +341,7 @@ describe('input', () => {
             ><option value="v2">two</option></select
           >`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await fill.handler(
           {
             params: {
@@ -369,7 +369,7 @@ describe('input', () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea role="combobox"></textarea>`);
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await fill.handler(
           {
             params: {
@@ -398,7 +398,7 @@ describe('input', () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea></textarea>`);
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         page.setDefaultTimeout(1000);
         await fill.handler(
           {
@@ -431,7 +431,7 @@ describe('input', () => {
         const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea></textarea>`);
         await page.click('textarea');
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await typeText.handler(
           {
             params: {
@@ -457,7 +457,7 @@ describe('input', () => {
         const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea></textarea>`);
         await page.click('textarea');
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await typeText.handler(
           {
             params: {
@@ -494,7 +494,7 @@ describe('input', () => {
         const page = context.getSelectedPptrPage();
         await page.setContent(html`<textarea></textarea>`);
         await page.click('textarea');
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         try {
           await typeText.handler(
             {
@@ -528,7 +528,7 @@ describe('input', () => {
             />
           </form>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
 
         // Fill email
         const response1 = new McpResponse({} as ParsedArguments);
@@ -622,7 +622,7 @@ describe('input', () => {
               });
             </script>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await drag.handler(
           {
             params: {
@@ -666,7 +666,7 @@ describe('input', () => {
             />
           </form>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await fillForm.handler(
           {
             params: {
@@ -721,7 +721,7 @@ describe('input', () => {
             />
           </form>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await uploadFile.handler(
           {
             params: {
@@ -764,7 +764,7 @@ describe('input', () => {
                 });
             </script>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await uploadFile.handler(
           {
             params: {
@@ -798,7 +798,7 @@ describe('input', () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();
         await page.setContent(html`<div>Not a file input</div>`);
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
 
         await assert.rejects(
           uploadFile.handler(
@@ -864,7 +864,7 @@ describe('input', () => {
             document.addEventListener('keyup', e => logs.push('u' + e.key));
           </script>`,
         );
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
 
         await pressKey.handler(
           {

--- a/tests/tools/screenshot.test.ts
+++ b/tests/tools/screenshot.test.ts
@@ -155,7 +155,7 @@ describe('screenshot', () => {
 
         const page = context.getSelectedPptrPage();
         await page.setContent(fixture.html);
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await screenshot.handler(
           {
             params: {

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -124,7 +124,7 @@ describe('script', () => {
 
         await page.setContent(html`<button id="test">test</button>`);
 
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
 
         await evaluateScript.handler(
           {
@@ -150,7 +150,7 @@ describe('script', () => {
 
         await page.setContent(html`<button id="test">test</button>`);
 
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
 
         await evaluateScript.handler(
           {
@@ -180,7 +180,7 @@ describe('script', () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();
         await page.goto(server.getRoute('/main'));
-        await context.createTextSnapshot();
+        await context.createTextSnapshot(context.getSelectedMcpPage());
         await evaluateScript.handler(
           {
             params: {


### PR DESCRIPTION
- removes several redundant getters on the context.
- removes passing page instances via context.