### PR TITLE
test: fix install of chrome in test.mjs

### DIFF
--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -62,7 +62,7 @@ const nodeArgs = [
 function installChrome(version) {
   try {
     return execSync(
-      `npx @puppeteer/browsers install chrome@${version} --format "{{path}}"`,
+      `npx puppeteer browsers install chrome@${version} --format "{{path}}"`,
     )
       .toString()
       .trim();


### PR DESCRIPTION
This is used by some extension tests that rely on new CDP capabilities. cc @nroscino 