### PR TITLE
chore: use windowsHide in daemon client

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -85,6 +85,7 @@ export async function startDaemon(mcpArgs: string[] = []) {
     stdio: 'ignore',
     env: process.env,
     cwd: process.cwd(),
+    windowsHide: true,
   });
   child.unref();
 


### PR DESCRIPTION
prevents cmd.exe from showing on Windows.