### PR TITLE
chore: work around the SDK's MCP client issues

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -54,6 +54,10 @@ async function setupMCPClient() {
   console.log('Setting up MCP client connection...');
 
   // Create stdio transport for chrome-devtools-mcp
+  // Workaround for https://github.com/modelcontextprotocol/typescript-sdk/blob/v1.x/src/client/stdio.ts#L128
+  // which causes the console window to show on Windows.
+  // @ts-expect-error no types for type.
+  process.type = 'mcp-client';
   mcpTransport = new StdioClientTransport({
     command: process.execPath,
     args: [INDEX_SCRIPT_PATH, ...mcpServerArgs],


### PR DESCRIPTION
MCP SDK client does not set windowsHide when spawning the process unless it is on windows under Electron (not sure why). But I think we can safely pretend to be "electron".

Refs https://github.com/modelcontextprotocol/typescript-sdk/issues/1638
Refs https://github.com/ChromeDevTools/chrome-devtools-mcp/pull/1100