### PR TITLE
fix: list_pages should work after selected page is closed

### DIFF
--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -16,7 +16,7 @@ import {
   timeoutSchema,
 } from './ToolDefinition.js';
 
-export const listPages = definePageTool(args => {
+export const listPages = defineTool(args => {
   return {
     name: 'list_pages',
     description: `Get a list of pages ${args?.categoryExtensions ? 'including extension service workers' : ''} open in the browser.`,

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -45,11 +45,7 @@ describe('pages', () => {
   describe('list_pages', () => {
     it('list pages', async () => {
       await withMcpContext(async (response, context) => {
-        await listPages().handler(
-          {params: {}},
-          response,
-          context,
-        );
+        await listPages().handler({params: {}}, response, context);
         assert.ok(response.includePages);
       });
     });
@@ -63,11 +59,7 @@ describe('pages', () => {
         await page2.pptrPage.close();
 
         // list_pages should still work even though the selected page is gone.
-        await listPages().handler(
-          {params: {}},
-          response,
-          context,
-        );
+        await listPages().handler({params: {}}, response, context);
         assert.ok(response.includePages);
       });
     });
@@ -88,11 +80,7 @@ describe('pages', () => {
           const listPageDef = listPages({
             categoryExtensions: true,
           } as ParsedArguments);
-          await listPageDef.handler(
-            {params: {}},
-            response,
-            context,
-          );
+          await listPageDef.handler({params: {}}, response, context);
 
           const result = await response.handle(listPageDef.name, context);
           const textContent = result.content.find(c => c.type === 'text') as {
@@ -134,11 +122,7 @@ describe('pages', () => {
             const listPageDef = listPages({
               categoryExtensions,
             } as ParsedArguments);
-            await listPageDef.handler(
-              {params: {}},
-              response,
-              context,
-            );
+            await listPageDef.handler({params: {}}, response, context);
 
             const result = await response.handle(listPageDef.name, context);
             const textContent = result.content.find(c => c.type === 'text') as {
@@ -195,11 +179,7 @@ describe('pages', () => {
           const listPageDef = listPages({
             categoryExtensions: true,
           } as ParsedArguments);
-          await listPageDef.handler(
-            {params: {}},
-            response,
-            context,
-          );
+          await listPageDef.handler({params: {}}, response, context);
 
           const result = await response.handle(listPageDef.name, context);
           const textContent = result.content.find(c => c.type === 'text') as {

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -46,7 +46,25 @@ describe('pages', () => {
     it('list pages', async () => {
       await withMcpContext(async (response, context) => {
         await listPages().handler(
-          {params: {}, page: context.getSelectedMcpPage()},
+          {params: {}},
+          response,
+          context,
+        );
+        assert.ok(response.includePages);
+      });
+    });
+    it('list pages after selected page is closed', async () => {
+      await withMcpContext(async (response, context) => {
+        // Create a second page and select it.
+        const page2 = await context.newPage();
+        assert.strictEqual(context.getSelectedMcpPage(), page2);
+
+        // Close the selected page via puppeteer (simulating external close).
+        await page2.pptrPage.close();
+
+        // list_pages should still work even though the selected page is gone.
+        await listPages().handler(
+          {params: {}},
           response,
           context,
         );
@@ -71,7 +89,7 @@ describe('pages', () => {
             categoryExtensions: true,
           } as ParsedArguments);
           await listPageDef.handler(
-            {params: {}, page: context.getSelectedMcpPage()},
+            {params: {}},
             response,
             context,
           );
@@ -117,7 +135,7 @@ describe('pages', () => {
               categoryExtensions,
             } as ParsedArguments);
             await listPageDef.handler(
-              {params: {}, page: context.getSelectedMcpPage()},
+              {params: {}},
               response,
               context,
             );
@@ -178,7 +196,7 @@ describe('pages', () => {
             categoryExtensions: true,
           } as ParsedArguments);
           await listPageDef.handler(
-            {params: {}, page: context.getSelectedMcpPage()},
+            {params: {}},
             response,
             context,
           );


### PR DESCRIPTION
## Problem

After closing the currently selected page, calling `list_pages` throws an error:
```
The selected page has been closed. Call list_pages to see open pages.
```

This creates a deadlock: the error message tells users to call `list_pages`, but `list_pages` itself throws the same error.

## Root Cause

`list_pages` is defined with `definePageTool`, which marks it as `pageScoped: true`. The handler dispatch in `index.ts` (line ~186) calls `context.getSelectedMcpPage()` for all page-scoped tools **before** invoking the handler. When the selected page is closed, `getSelectedPptrPage()` throws.

However, `list_pages` doesn't actually use the `page` parameter — its handler only calls `response.setIncludePages(true)`.

## Fix

Change `list_pages` from `definePageTool` to `defineTool`. This bypasses the page-scoped check while preserving all existing behavior since the handler never used the page reference.

## Testing

Reproduced the issue following the steps in #1138:
1. Call `list_pages` → returns page list ✅
2. Close the selected page
3. Call `list_pages` → now returns updated page list instead of throwing ✅

Fixes #1138