### PR TITLE
docs: add troubleshooting for Claude Code plugin HTTPS clone failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Then, install the plugin:
 
 Restart Claude Code to have the MCP server and skills load (check with `/skills`).
 
+> [!TIP]
+> If the plugin installation fails with a `Failed to clone repository` error (e.g., HTTPS connectivity issues behind a corporate firewall), see the [troubleshooting guide](./docs/troubleshooting.md#claude-code-plugin-installation-fails-with-failed-to-clone-repository) for workarounds, or use the CLI installation method above instead.
+
 </details>
 
 <details>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -126,6 +126,47 @@ Possible workarounds include:
     }
   ```
 
+### Claude Code plugin installation fails with `Failed to clone repository`
+
+When installing `chrome-devtools-mcp` as a Claude Code plugin (either from the
+official marketplace or via `/plugin marketplace add`), the installation may fail
+with a timeout error if your environment cannot reach `github.com` on port 443
+(HTTPS):
+
+```
+Failed to download/cache plugin chrome-devtools-mcp: Failed to clone repository:
+  Cloning into '...'...
+  fatal: unable to access 'https://github.com/ChromeDevTools/chrome-devtools-mcp.git/':
+  Failed to connect to github.com port 443
+```
+
+This can happen in environments with restricted outbound HTTPS connectivity,
+corporate firewalls, or proxy configurations that block HTTPS git operations.
+
+**Workaround 1: Use SSH instead of HTTPS**
+
+If you have SSH access to GitHub configured, you can redirect all GitHub HTTPS
+URLs to use SSH by running:
+
+```sh
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+```
+
+Then retry the plugin installation. This tells git to use your SSH key for all
+GitHub operations instead of HTTPS.
+
+**Workaround 2: Install via CLI instead**
+
+If the plugin marketplace approach fails, you can install `chrome-devtools-mcp`
+as an MCP server directly without cloning the repository:
+
+```sh
+claude mcp add chrome-devtools --scope user npx chrome-devtools-mcp@latest
+```
+
+This bypasses the git clone entirely and uses npm/npx to fetch the package. Note
+that this method installs only the MCP server without the bundled skills.
+
 ### Connection timeouts with `--autoConnect`
 
 If you are using the `--autoConnect` flag and tools like `list_pages`, `new_page`, or `navigate_page` fail with a timeout (e.g., `ProtocolError: Network.enable timed out` or `The socket connection was closed unexpectedly`), this usually means the MCP server cannot handshake with the running Chrome instance correctly. Ensure:


### PR DESCRIPTION
## Summary

When installing `chrome-devtools-mcp` as a Claude Code plugin (from the official Anthropic marketplace or via `/plugin marketplace add`), the plugin system clones the repository using HTTPS (`https://github.com/ChromeDevTools/chrome-devtools-mcp.git`). In environments where outbound HTTPS connectivity to GitHub is restricted — such as servers behind corporate firewalls, restrictive proxy configurations, or hosts with port 443 blocked — this clone operation fails with a timeout:

```
chrome-devtools-mcp@claude-plugins-official: Failed to download/cache plugin chrome-devtools-mcp:
  Failed to clone repository: Cloning into '...'...
  fatal: unable to access 'https://github.com/ChromeDevTools/chrome-devtools-mcp.git/':
  Failed to connect to github.com port 443 after 136078 ms: Couldn't connect to server
```

This is a real-world scenario encountered on production Linux servers where SSH to GitHub (port 22) works but HTTPS (port 443) is blocked or unreliable. The Claude Code plugin marketplace (`anthropics/claude-plugins-official`) specifies the HTTPS URL as the plugin source, and users have no way to override this URL within the plugin system itself.

## Changes

### `docs/troubleshooting.md`
Added a new troubleshooting section **Claude Code plugin installation fails with `Failed to clone repository`** under Specific problems that documents:

- **The exact error message** users encounter, making it searchable
- **Root cause explanation**: restricted HTTPS connectivity, firewalls, proxy configs
- **Workaround 1 — SSH redirect**: Using `git config --global url."git@github.com:".insteadOf "https://github.com/"` to transparently redirect all GitHub HTTPS git operations to use SSH
- **Workaround 2 — CLI installation**: Using `claude mcp add chrome-devtools --scope user npx chrome-devtools-mcp@latest` to install the MCP server via npm/npx instead of git clone

### `README.md`
Added a `[!TIP]` callout in the Claude Code **Install as a Plugin** section that cross-references the troubleshooting guide.

## Motivation

The HTTPS clone URL for this plugin is defined in the Anthropic official plugin marketplace, not in this repository. Since users cannot change the marketplace URL configuration, the most actionable fix from this repository's side is to document the issue and provide clear workarounds.

## Test plan

- [x] `npm run check-format` passes (eslint + prettier)
- [x] `npm run gen` produces no unexpected diff (auto-generated docs unchanged)
- [x] Documentation-only change — no code, tool, or schema modifications
- [x] Markdown anchor link in README TIP callout correctly references the troubleshooting section heading
- [x] Both workaround commands verified in the environment where this issue was encountered