### PR TITLE
feat: add set_extra_http_headers tool for Network.setExtraHTTPHeaders

### DIFF
--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -86,6 +86,34 @@ export const listNetworkRequests = definePageTool({
   },
 });
 
+export const setExtraHttpHeaders = definePageTool({
+  name: 'set_extra_http_headers',
+  description: `Set extra HTTP headers that will be included in every request the page makes. These headers are applied to all resource types including document, script, stylesheet, image, fetch, and XHR requests. The headers persist across navigations until explicitly cleared by calling this tool with an empty headers object.`,
+  annotations: {
+    category: ToolCategory.NETWORK,
+    readOnlyHint: false,
+  },
+  schema: {
+    headers: zod
+      .record(zod.string(), zod.string())
+      .describe(
+        'HTTP headers as key-value pairs to include in every request. Pass an empty object {} to clear previously set headers.',
+      ),
+  },
+  handler: async (request, response) => {
+    const page = request.page;
+    await page.pptrPage.setExtraHTTPHeaders(request.params.headers);
+    const count = Object.keys(request.params.headers).length;
+    if (count === 0) {
+      response.appendResponseLine('Cleared all extra HTTP headers.');
+    } else {
+      response.appendResponseLine(
+        `Set ${count} extra HTTP header(s): ${Object.keys(request.params.headers).join(', ')}`,
+      );
+    }
+  },
+});
+
 export const getNetworkRequest = definePageTool({
   name: 'get_network_request',
   description: `Gets a network request by an optional reqid, if omitted returns the currently selected request in the DevTools Network panel.`,

--- a/tests/tools/network.test.ts
+++ b/tests/tools/network.test.ts
@@ -10,6 +10,7 @@ import {describe, it} from 'node:test';
 import {
   getNetworkRequest,
   listNetworkRequests,
+  setExtraHttpHeaders,
 } from '../../src/tools/network.js';
 import {serverHooks} from '../server.js';
 import {
@@ -132,6 +133,65 @@ describe('network', () => {
       });
     });
   });
+  describe('set_extra_http_headers', () => {
+    it('sets headers and reports count', async () => {
+      await withMcpContext(async (response, context) => {
+        await setExtraHttpHeaders.handler(
+          {
+            params: {headers: {'X-Custom': 'value', 'X-Lane': 'test'}},
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+        assert.strictEqual(
+          response.responseLines[0],
+          'Set 2 extra HTTP header(s): X-Custom, X-Lane',
+        );
+      });
+    });
+
+    it('clears headers when empty object is passed', async () => {
+      await withMcpContext(async (response, context) => {
+        await setExtraHttpHeaders.handler(
+          {
+            params: {headers: {}},
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+        assert.strictEqual(
+          response.responseLines[0],
+          'Cleared all extra HTTP headers.',
+        );
+      });
+    });
+
+    it('headers are included in subsequent requests', async () => {
+      server.addRoute('/echo-headers', async (req, res) => {
+        res.writeHead(200, {'Content-Type': 'application/json'});
+        res.end(JSON.stringify(req.headers));
+      });
+
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+        await setExtraHttpHeaders.handler(
+          {
+            params: {headers: {'X-Test-Header': 'hello-mcp'}},
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+
+        const navResponse = await page.goto(server.getRoute('/echo-headers'));
+        const body = await navResponse!.json();
+        assert.strictEqual(body['x-test-header'], 'hello-mcp');
+      });
+    });
+  });
+
   describe('network_get_request', () => {
     it('attaches request', async () => {
       await withMcpContext(async (response, context) => {


### PR DESCRIPTION
## Summary
- Add a new MCP tool `set_extra_http_headers` that allows setting extra HTTP headers on all page requests via Puppeteer's `page.setExtraHTTPHeaders()`
- Headers persist across navigations and can be cleared by passing an empty object
- This addresses the need for injecting custom headers (e.g. swim-lane routing, A/B testing, feature flags) on all request types including initial document loads

Closes #1175

## Test plan
- [x] Test setting multiple headers returns correct count and header names
- [x] Test clearing headers with empty object returns clear confirmation
- [x] Test headers are actually included in subsequent requests (end-to-end via echo server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)