### PR TITLE
feat(collector): add maxItemsSavedPerNavigation to prevent unbounded memory growth

### DIFF
--- a/src/PageCollector.ts
+++ b/src/PageCollector.ts
@@ -65,6 +65,14 @@ export class PageCollector<T> {
   protected maxNavigationSaved = 3;
 
   /**
+   * Max number of collected items to keep for the *current* navigation.
+   *
+   * This is a safety valve to prevent unbounded memory growth in long-running
+   * sessions (e.g. autoConnect mode) on highly active pages.
+   */
+  protected maxItemsSavedPerNavigation = Number.POSITIVE_INFINITY;
+
+  /**
    * This maps a Page to a list of navigations with a sub-list
    * of all collected resources.
    * The newer navigations come first.
@@ -134,7 +142,9 @@ export class PageCollector<T> {
       withId[stableIdSymbol] = idGenerator();
 
       const navigations = this.storage.get(page) ?? [[]];
-      navigations[0].push(withId);
+      const current = navigations[0];
+      current.push(withId);
+      this.#pruneCurrentNavigation(current);
     });
 
     listeners['framenavigated'] = (frame: Frame) => {
@@ -150,6 +160,20 @@ export class PageCollector<T> {
     }
 
     this.#listeners.set(page, listeners);
+  }
+
+  #pruneCurrentNavigation(navigation: Array<WithSymbolId<T>>) {
+    const max = this.maxItemsSavedPerNavigation;
+    if (!Number.isFinite(max)) {
+      return;
+    }
+    if (max <= 0) {
+      navigation.length = 0;
+      return;
+    }
+    if (navigation.length > max) {
+      navigation.splice(0, navigation.length - max);
+    }
   }
 
   protected splitAfterNavigation(page: Page) {
@@ -233,6 +257,8 @@ export class ConsoleCollector extends PageCollector<
   ConsoleMessage | Error | DevTools.AggregatedIssue | UncaughtError
 > {
   #subscribedPages = new WeakMap<Page, PageEventSubscriber>();
+
+  protected override maxItemsSavedPerNavigation = 1000;
 
   override addPage(page: Page): void {
     super.addPage(page);
@@ -372,6 +398,8 @@ class PageEventSubscriber {
 }
 
 export class NetworkCollector extends PageCollector<HTTPRequest> {
+  protected override maxItemsSavedPerNavigation = 5000;
+
   constructor(
     browser: Browser,
     listeners: (

--- a/tests/PageCollector.test.ts
+++ b/tests/PageCollector.test.ts
@@ -185,6 +185,37 @@ describe('PageCollector', () => {
     assert.equal(collector.getIdForResource(request1), 1);
     assert.equal(collector.getIdForResource(request2), 2);
   });
+
+  it('should prune current navigation to maxItemsSavedPerNavigation', async () => {
+    const browser = getMockBrowser();
+    const page = (await browser.pages())[0];
+
+    class LimitedCollector extends PageCollector<HTTPRequest> {
+      protected override maxItemsSavedPerNavigation = 2;
+    }
+
+    const request1 = getMockRequest({url: 'http://example.com/1'});
+    const request2 = getMockRequest({url: 'http://example.com/2'});
+    const request3 = getMockRequest({url: 'http://example.com/3'});
+
+    const collector = new LimitedCollector(browser, collect => {
+      return {
+        request: req => {
+          collect(req);
+        },
+      } as ListenerMap;
+    });
+    await collector.init([page]);
+
+    page.emit('request', request1);
+    page.emit('request', request2);
+    page.emit('request', request3);
+
+    const data = collector.getData(page);
+    assert.equal(data.length, 2);
+    assert.equal(data[0], request2);
+    assert.equal(data[1], request3);
+  });
 });
 
 describe('NetworkCollector', () => {


### PR DESCRIPTION
Issue #1214.

This introduces a configurable limit on the number of items collected per navigation (current navigation slice) in PageCollector. Without this, long-running pages that continuously emit network requests or console messages (e.g., single-page apps, polling) could cause unbounded memory growth. The limit is only applied to the *current* navigation; historic navigations remain capped by maxNavigationSaved.

- Add protected  default  in PageCollector
- Override to 5000 in NetworkCollector and 1000 in ConsoleCollector
- Add  that splices oldest items when limit exceeded\n- Add unit test for pruning behavior
- This complements the existing navigation count limit (maxNavigationSaved) and addresses the memory leak observed in --autoConnect mode (~13 MB/min).