### PR TITLE
chore: adding metadata file for the VS code plugin

### DIFF
--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "chrome-devtools-mcp",
+  "version": "0.20.3",
+  "description": "Reliable automation, in-depth debugging, and performance analysis in Chrome using Chrome DevTools and Puppeteer",
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest"]
+    }
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -39,6 +39,11 @@
           "type": "json",
           "path": ".claude-plugin/plugin.json",
           "jsonpath": "version"
+        },
+        {
+          "type": "json",
+          "path": ".github/plugin/plugin.json",
+          "jsonpath": "version"
         }
       ]
     }


### PR DESCRIPTION
This is part of bundling the MCP server and the skills as an "agent plugin" for VS code.

The marketplace file is being added into github's repo as an [external plugin](https://github.com/github/awesome-copilot?tab=contributing-ov-file#adding-external-plugins) ([PR](https://github.com/github/awesome-copilot/pull/1161)). [Here](https://code.visualstudio.com/docs/copilot/customization/agent-plugins#_configure-plugin-marketplaces) is the general instructions for the agent plugin.

With that we still need the plugin metadata file in our repo. This file should specify the version and we should update each time we release. The version here will silently override the version in the marketplace file ([doc](https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels)). The version in the marketplace file is a dummy.