### PR TITLE
fix: wrap .mcp.json config in mcpServers key

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,8 @@
 {
-  "chrome-devtools": {
-    "command": "npx",
-    "args": ["chrome-devtools-mcp@latest"]
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- The `.mcp.json` file was missing the required `mcpServers` wrapper key, causing MCP clients (e.g., Claude Code) to fail parsing with a schema validation error.
- Wraps the existing config inside `mcpServers` to match the expected MCP configuration schema.

## Test plan
- [x] Run `claude /doctor` — config parse error is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)