### PR TITLE
chore: remove specific chrome executable usage on extensions tests

### DIFF
--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -92,9 +92,6 @@ async function runTests(attempt) {
   });
 }
 
-const chromePath = installChrome('146.0.7680.31');
-process.env.CHROME_M146_EXECUTABLE_PATH = chromePath;
-
 const maxAttempts = shouldRetry ? 3 : 1;
 let exitCode = 1;
 

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -59,7 +59,7 @@ const nodeArgs = [
   ...files,
 ];
 
-function installChrome(version) {
+function _installChrome(version) {
   try {
     return execSync(
       `npx puppeteer browsers install chrome@${version} --format "{{path}}"`,

--- a/tests/tools/extensions.test.ts
+++ b/tests/tools/extensions.test.ts
@@ -122,6 +122,9 @@ describe('extension', () => {
       assert.ok(list.length === 1, 'List should have only one extension');
       const reinstalled = list.find(e => e.id === extensionId);
       assert.ok(reinstalled, 'Extension should be present after reload');
+      try {
+        await context.uninstallExtension(EXTENSION_WITH_SW_PATH);
+      } catch (e) {}
     });
   });
   it('triggers an extension action', async () => {
@@ -147,6 +150,9 @@ describe('extension', () => {
           t => t.type() === 'page' && t.url().includes(extensionId),
         );
         assert.ok(pageTargetAfter, 'Page should exist after action');
+        try {
+          await context.uninstallExtension(EXTENSION_WITH_SW_PATH);
+        } catch (e) {}
       },
       {},
       {

--- a/tests/tools/extensions.test.ts
+++ b/tests/tools/extensions.test.ts
@@ -148,9 +148,7 @@ describe('extension', () => {
         );
         assert.ok(pageTargetAfter, 'Page should exist after action');
       },
-      {
-        executablePath: process.env.CHROME_M146_EXECUTABLE_PATH,
-      },
+      {},
       {
         categoryExtensions: true,
       } as ParsedArguments,

--- a/tests/tools/extensions.test.ts
+++ b/tests/tools/extensions.test.ts
@@ -122,9 +122,6 @@ describe('extension', () => {
       assert.ok(list.length === 1, 'List should have only one extension');
       const reinstalled = list.find(e => e.id === extensionId);
       assert.ok(reinstalled, 'Extension should be present after reload');
-      try {
-        await context.uninstallExtension(EXTENSION_WITH_SW_PATH);
-      } catch (e) {}
     });
   });
   it('triggers an extension action', async () => {
@@ -150,9 +147,6 @@ describe('extension', () => {
           t => t.type() === 'page' && t.url().includes(extensionId),
         );
         assert.ok(pageTargetAfter, 'Page should exist after action');
-        try {
-          await context.uninstallExtension(EXTENSION_WITH_SW_PATH);
-        } catch (e) {}
       },
       {},
       {

--- a/tests/tools/extensions.test.ts
+++ b/tests/tools/extensions.test.ts
@@ -122,7 +122,6 @@ describe('extension', () => {
       assert.ok(list.length === 1, 'List should have only one extension');
       const reinstalled = list.find(e => e.id === extensionId);
       assert.ok(reinstalled, 'Extension should be present after reload');
-      await context.uninstallExtension(EXTENSION_WITH_SW_PATH);
     });
   });
   it('triggers an extension action', async () => {
@@ -148,7 +147,6 @@ describe('extension', () => {
           t => t.type() === 'page' && t.url().includes(extensionId),
         );
         assert.ok(pageTargetAfter, 'Page should exist after action');
-        await context.uninstallExtension(EXTENSION_WITH_SW_PATH);
       },
       {},
       {

--- a/tests/tools/extensions.test.ts
+++ b/tests/tools/extensions.test.ts
@@ -122,6 +122,7 @@ describe('extension', () => {
       assert.ok(list.length === 1, 'List should have only one extension');
       const reinstalled = list.find(e => e.id === extensionId);
       assert.ok(reinstalled, 'Extension should be present after reload');
+      await context.uninstallExtension(EXTENSION_WITH_SW_PATH);
     });
   });
   it('triggers an extension action', async () => {
@@ -147,6 +148,7 @@ describe('extension', () => {
           t => t.type() === 'page' && t.url().includes(extensionId),
         );
         assert.ok(pageTargetAfter, 'Page should exist after action');
+        await context.uninstallExtension(EXTENSION_WITH_SW_PATH);
       },
       {},
       {

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -88,6 +88,7 @@ describe('pages', () => {
             '<extension-id>',
           );
           t.assert.snapshot?.(text);
+          await context.uninstallExtension(extensionId);
         },
         {},
         {
@@ -142,6 +143,7 @@ describe('pages', () => {
               '<extension-id>',
             );
             t.assert.snapshot?.(text);
+            await context.uninstallExtension(extensionId);
           },
           {},
           {
@@ -193,6 +195,7 @@ describe('pages', () => {
             '<extension-id>',
           );
           t.assert.snapshot?.(text);
+          await context.uninstallExtension(extensionId);
         },
         {},
         {

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -198,7 +198,7 @@ describe('pages', () => {
           await context.uninstallExtension(extensionId);
         },
         {
-          userDataDir: '/tmp/chrome-test',
+          spawnNewBrowser: true,
         },
         {
           categoryExtensions: true,

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -197,7 +197,9 @@ describe('pages', () => {
           t.assert.snapshot?.(text);
           await context.uninstallExtension(extensionId);
         },
-        {},
+        {
+          userDataDir: '/tmp/chrome-test',
+        },
         {
           categoryExtensions: true,
         } as ParsedArguments,

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -89,9 +89,7 @@ describe('pages', () => {
           );
           t.assert.snapshot?.(text);
         },
-        {
-          executablePath: process.env.CHROME_M146_EXECUTABLE_PATH,
-        },
+        {},
         {
           categoryExtensions: true,
         } as ParsedArguments,
@@ -196,9 +194,7 @@ describe('pages', () => {
           );
           t.assert.snapshot?.(text);
         },
-        {
-          executablePath: process.env.CHROME_M146_EXECUTABLE_PATH,
-        },
+        {},
         {
           categoryExtensions: true,
         } as ParsedArguments,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -62,6 +62,7 @@ export async function withBrowser(
     debug?: boolean;
     autoOpenDevTools?: boolean;
     executablePath?: string;
+    userDataDir?: string;
   } = {},
 ) {
   const launchOptions: LaunchOptions = {
@@ -74,6 +75,7 @@ export async function withBrowser(
     handleDevToolsAsPage: true,
     args: ['--screen-info={3840x2160}'],
     enableExtensions: true,
+    userDataDir: options.userDataDir,
   };
   const key = JSON.stringify(launchOptions);
 
@@ -102,6 +104,7 @@ export async function withMcpContext(
     autoOpenDevTools?: boolean;
     performanceCrux?: boolean;
     executablePath?: string;
+    userDataDir?: string;
   } = {},
   args: ParsedArguments = {} as ParsedArguments,
 ) {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -62,7 +62,7 @@ export async function withBrowser(
     debug?: boolean;
     autoOpenDevTools?: boolean;
     executablePath?: string;
-    userDataDir?: string;
+    spawnNewBrowser?: boolean;
   } = {},
 ) {
   const launchOptions: LaunchOptions = {
@@ -75,11 +75,10 @@ export async function withBrowser(
     handleDevToolsAsPage: true,
     args: ['--screen-info={3840x2160}'],
     enableExtensions: true,
-    userDataDir: options.userDataDir,
   };
   const key = JSON.stringify(launchOptions);
 
-  let browser = browsers.get(key);
+  let browser = options.spawnNewBrowser && browsers.get(key);
   if (!browser) {
     browser = await puppeteer.launch(launchOptions);
     browsers.set(key, browser);
@@ -104,7 +103,7 @@ export async function withMcpContext(
     autoOpenDevTools?: boolean;
     performanceCrux?: boolean;
     executablePath?: string;
-    userDataDir?: string;
+    spawnNewBrowser?: boolean;
   } = {},
   args: ParsedArguments = {} as ParsedArguments,
 ) {


### PR DESCRIPTION
This change removes the download and usage of the version 146.0.7680.31. 
The version was previously needed to get the triggerAction working in extensions. This is no longer needed since the current stable now has the CDP command available.