### PR TITLE
fix: kill stale MCP processes on reconnect to same endpoint

### DIFF
--- a/src/bin/chrome-devtools-mcp-main.ts
+++ b/src/bin/chrome-devtools-mcp-main.ts
@@ -8,6 +8,7 @@ import '../polyfill.js';
 
 import process from 'node:process';
 
+import {acquireEndpointLock, releaseEndpointLock} from '../browser.js';
 import {createMcpServer, logDisclaimers} from '../index.js';
 import {logger, saveLogsToFile} from '../logger.js';
 import {computeFlagUsage} from '../telemetry/flagUtils.js';
@@ -34,6 +35,28 @@ if (process.env['CHROME_DEVTOOLS_MCP_CRASH_ON_UNCAUGHT'] !== 'true') {
     logger('Unhandled promise rejection', promise, reason);
   });
 }
+
+// Acquire endpoint lock early so stale instances are killed before we connect.
+const lockedEndpoint = args.browserUrl ?? args.wsEndpoint;
+if (lockedEndpoint) {
+  acquireEndpointLock(lockedEndpoint);
+}
+
+// Clean up lock on exit. SIGTERM/SIGINT handlers must call process.exit()
+// or the default exit behavior is suppressed and the process stays alive.
+function cleanupAndExit() {
+  if (lockedEndpoint) {
+    releaseEndpointLock(lockedEndpoint);
+  }
+  process.exit(0);
+}
+process.on('SIGINT', cleanupAndExit);
+process.on('SIGTERM', cleanupAndExit);
+process.on('exit', () => {
+  if (lockedEndpoint) {
+    releaseEndpointLock(lockedEndpoint);
+  }
+});
 
 logger(`Starting Chrome DevTools MCP Server v${VERSION}`);
 const {server, clearcutLogger} = await createMcpServer(args, {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -8,6 +8,7 @@ import {execSync} from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 
 import {logger} from './logger.js';
 import type {
@@ -19,6 +20,92 @@ import type {
 import {puppeteer} from './third_party/index.js';
 
 let browser: Browser | undefined;
+
+/**
+ * Ensures only one chrome-devtools-mcp process connects to a given endpoint.
+ * Multiple CDP clients on the same debug port cause "Network.enable timed out"
+ * errors because sessions conflict. This kills any previous instance before
+ * connecting.
+ */
+function getLockDir(): string {
+  const uid = os.userInfo().uid;
+  const dir = path.join(os.tmpdir(), `chrome-devtools-mcp-${uid}`);
+  fs.mkdirSync(dir, {recursive: true});
+  return dir;
+}
+
+function endpointToLockName(endpoint: string): string {
+  // Normalize endpoint to a safe filename. Include host so different
+  // hosts on the same port don't collide.
+  return endpoint.replace(/[^a-zA-Z0-9]/g, '_') + '.lock';
+}
+
+export function acquireEndpointLock(endpoint: string): void {
+  const lockPath = path.join(getLockDir(), endpointToLockName(endpoint));
+
+  // Check for and kill any existing owner.
+  try {
+    const content = fs.readFileSync(lockPath, 'utf-8').trim();
+    const lines = content.split('\n');
+    const pid = parseInt(lines[0] ?? '', 10);
+    if (!isNaN(pid) && pid !== process.pid) {
+      try {
+        process.kill(pid, 0); // Throws if process doesn't exist.
+        logger(`Killing previous MCP process (PID ${pid}) for ${endpoint}`);
+        process.kill(pid, 'SIGTERM');
+        // Wait for the process to actually exit before proceeding.
+        const start = Date.now();
+        while (Date.now() - start < 1000) {
+          try {
+            process.kill(pid, 0);
+          } catch {
+            break; // Process exited.
+          }
+        }
+        // Force kill if still alive after 1s.
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // Already dead.
+        }
+      } catch {
+        // Process already dead, stale lock file.
+      }
+      // Remove stale lock before acquiring.
+      try {
+        fs.unlinkSync(lockPath);
+      } catch {
+        // Best effort.
+      }
+    }
+  } catch {
+    // No lock file exists yet.
+  }
+
+  // Write lock atomically. If another process races us, one of us will fail
+  // the 'wx' open and retry or proceed without the lock.
+  try {
+    const fd = fs.openSync(lockPath, 'wx');
+    fs.writeSync(fd, `${process.pid}\n${endpoint}\n`);
+    fs.closeSync(fd);
+  } catch {
+    // File already exists (race). Overwrite since we already killed the owner.
+    fs.writeFileSync(lockPath, `${process.pid}\n${endpoint}\n`);
+  }
+}
+
+export function releaseEndpointLock(endpoint: string): void {
+  try {
+    const lockPath = path.join(getLockDir(), endpointToLockName(endpoint));
+    const content = fs.readFileSync(lockPath, 'utf-8').trim();
+    const pid = parseInt(content.split('\n')[0] ?? '', 10);
+    if (pid === process.pid) {
+      fs.unlinkSync(lockPath);
+    }
+  } catch {
+    // Best effort cleanup.
+  }
+}
 
 function makeTargetFilter(enableExtensions = false) {
   const ignoredPrefixes = new Set(['chrome://', 'chrome-untrusted://']);
@@ -116,6 +203,12 @@ export async function ensureBrowserConnected(options: {
     throw new Error(
       'Either browserURL, wsEndpoint, channel or userDataDir must be provided',
     );
+  }
+
+  // Acquire endpoint lock to prevent multiple clients on the same browser.
+  const endpoint = options.browserURL ?? options.wsEndpoint;
+  if (endpoint) {
+    acquireEndpointLock(endpoint);
   }
 
   logger('Connecting Puppeteer to ', JSON.stringify(connectOptions));


### PR DESCRIPTION
## Problem

When MCP clients reconnect (e.g. running `/mcp` in Claude Code), each reconnect spawns a new `chrome-devtools-mcp` process without killing the previous one. Multiple CDP clients on the same debug port cause `Network.enable timed out` errors because sessions conflict.

Reproducing is easy: run `/mcp` three times in a row and check `lsof -i :9222`. You'll see 3+ node processes all connected to the same debug port.

## Fix

Adds endpoint-based PID lock files. On startup, the server:

1. Checks if another instance is already connected to the same endpoint
2. Sends SIGTERM (with SIGKILL fallback after 1s)
3. Waits for the old process to actually exit
4. Acquires the lock with its own PID (atomic via `openSync` with `wx` flag)
5. Releases the lock on exit (SIGINT/SIGTERM/exit handlers call `process.exit()`)

Lock files are keyed by normalized endpoint URL (not just port) so different hosts on the same port don't collide. Both `--browserUrl` and `--wsEndpoint` connections are covered.

## Changes

- `src/browser.ts`: `acquireEndpointLock()` and `releaseEndpointLock()` functions
- `src/bin/chrome-devtools-mcp-main.ts`: early lock acquisition on startup, cleanup on exit

## Tested

Verified locally on macOS with Arc browser (port 9222):
- Instance 1 acquires lock, Instance 2 kills Instance 1 and takes over
- Lock file correctly transitions between PIDs
- Old process actually dies (SIGTERM + SIGKILL fallback)
- Lock released on clean exit

Fixes #1763
Related: #1156, #657