### PR TITLE
chore: improve take_memory_snapshot tool description

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,6 +1,6 @@
 <!-- AUTO GENERATED DO NOT EDIT - run 'npm run gen' to update-->
 
-# Chrome DevTools MCP Tool Reference (~6940 cl100k_base tokens)
+# Chrome DevTools MCP Tool Reference (~6949 cl100k_base tokens)
 
 - **[Input automation](#input-automation)** (9 tools)
   - [`click`](#click)
@@ -278,7 +278,7 @@
 
 ### `take_memory_snapshot`
 
-**Description:** Capture a memory heapsnapshot of the currently selected page to memory leak debugging
+**Description:** Capture a heap snapshot of the currently selected page. Use to analyze the memory distribution of JavaScript objects and debug memory leaks.
 
 **Parameters:**
 

--- a/src/bin/cliDefinitions.ts
+++ b/src/bin/cliDefinitions.ts
@@ -582,7 +582,7 @@ export const commands: Commands = {
   },
   take_memory_snapshot: {
     description:
-      'Capture a memory heapsnapshot of the currently selected page to memory leak debugging',
+      'Capture a heap snapshot of the currently selected page. Use to analyze the memory distribution of JavaScript objects and debug memory leaks.',
     category: 'Performance',
     args: {
       filePath: {

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -11,7 +11,7 @@ import {definePageTool} from './ToolDefinition.js';
 
 export const takeMemorySnapshot = definePageTool({
   name: 'take_memory_snapshot',
-  description: `Capture a memory heapsnapshot of the currently selected page to memory leak debugging`,
+  description: `Capture a heap snapshot of the currently selected page. Use to analyze the memory distribution of JavaScript objects and debug memory leaks.`,
   annotations: {
     category: ToolCategory.PERFORMANCE,
     readOnlyHint: false,


### PR DESCRIPTION
I spotted a missing verb while looking at [the tool reference](https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/docs/tool-reference.md#take_memory_snapshot) and decided to tweak the description a bit. WDYT?