### PR TITLE
chore: ignore claude plugin format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 # Prettier-only ignores.
 CHANGELOG.md
 src/third_party/lighthouse-devtools-mcp-bundle.js
+
+# Release-please formatting brakes CI checks
+.claude-plugin/plugin.json


### PR DESCRIPTION
When release please tries to update the version it change the format which then fails CI check,
We can safely ignore the formatting for that file.