### PR TITLE
feat: experimental click_at(x,y) tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,10 @@ The Chrome DevTools MCP server supports the following configuration option:
   If enabled, ignores errors relative to self-signed and expired certificates. Use with caution.
   - **Type:** boolean
 
+- **`--experimentalVision`/ `--experimental-vision`**
+  Whether to enable coordinate-based tools such as click_at(x,y). Usually requires a computer-use model able to produce accurate coordinates by looking at screenshots.
+  - **Type:** boolean
+
 - **`--experimentalScreencast`/ `--experimental-screencast`**
   Exposes experimental screencast tools (requires ffmpeg). Install ffmpeg https://www.ffmpeg.org/download.html and ensure it is available in the MCP server PATH.
   - **Type:** boolean

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -160,8 +160,9 @@ export const cliOptions = {
   },
   experimentalVision: {
     type: 'boolean',
-    describe: 'Whether to enable vision tools',
-    hidden: true,
+    describe:
+      'Whether to enable coordinate-based tools such as click_at(x,y). Usually requires a computer-use model able to produce accurate coordinates by looking at screenshots.',
+    hidden: false,
   },
   experimentalStructuredContent: {
     type: 'boolean',


### PR DESCRIPTION
Specify `--experimental-vision` argument for `chrome-devtools-mcp` to enable additional tools for vision models. Currently, only `click_at(x,y)` tool is supported. Usually you need a specialized model that can provide accurate coordinates based on the screenshots.

Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/403