### PR TITLE
chore: fix lingering enum types in tool_call_metrics.json

### DIFF
--- a/src/telemetry/toolMetricsUtils.ts
+++ b/src/telemetry/toolMetricsUtils.ts
@@ -52,8 +52,14 @@ export function generateToolMetrics(tools: ToolDefinition[]): ToolMetric[] {
       const transformedName = transformArgName(zodType, name);
       let argType = transformArgType(zodType);
 
-      if (zodType === 'ZodEnum' && schema._def.values?.length > 0) {
-        argType = validateEnumHomogeneity(schema._def.values);
+      if (argType === 'enum') {
+        let values;
+        if (schema._def.values?.length > 0) {
+          values = schema._def.values;
+        } else {
+          values = schema._def.innerType._def.values;
+        }
+        argType = validateEnumHomogeneity(values);
       }
 
       args.push({

--- a/src/telemetry/tool_call_metrics.json
+++ b/src/telemetry/tool_call_metrics.json
@@ -64,7 +64,7 @@
     "args": [
       {
         "name": "networkConditions",
-        "argType": "enum"
+        "argType": "string"
       },
       {
         "name": "cpuThrottlingRate",
@@ -80,7 +80,7 @@
       },
       {
         "name": "colorScheme",
-        "argType": "enum"
+        "argType": "string"
       },
       {
         "name": "viewport_length",
@@ -211,11 +211,11 @@
     "args": [
       {
         "name": "mode",
-        "argType": "enum"
+        "argType": "string"
       },
       {
         "name": "device",
-        "argType": "enum"
+        "argType": "string"
       },
       {
         "name": "outputDirPath_length",
@@ -291,7 +291,7 @@
     "args": [
       {
         "name": "type",
-        "argType": "enum"
+        "argType": "string"
       },
       {
         "name": "url_length",
@@ -303,7 +303,7 @@
       },
       {
         "name": "handleBeforeUnload",
-        "argType": "enum"
+        "argType": "string"
       },
       {
         "name": "initScript_length",
@@ -454,7 +454,7 @@
     "args": [
       {
         "name": "format",
-        "argType": "enum"
+        "argType": "string"
       },
       {
         "name": "quality",


### PR DESCRIPTION
We shouldn't keep having enum type in the JSON at all since we are checking the permitted values to deduce the type already. This fixes input to the type deducing logic.