### PR TITLE
fix: remove stray )} characters from redirect chain output

### DIFF
--- a/src/formatters/NetworkFormatter.ts
+++ b/src/formatters/NetworkFormatter.ts
@@ -283,7 +283,7 @@ function converNetworkRequestDetailedToStringDetailed(
     let indent = 0;
     for (const request of redirectChain.reverse()) {
       response.push(
-        `${'  '.repeat(indent)}${convertNetworkRequestConciseToString(request)})}`,
+        `${'  '.repeat(indent)}${convertNetworkRequestConciseToString(request)}`,
       );
       indent++;
     }


### PR DESCRIPTION
The redirect chain formatter in `converNetworkRequestDetailedToStringDetailed` had a stray `)}` at the end of the template literal, causing every redirect chain entry to be suffixed with those characters in tool output.