### PR TITLE
fix: skip frozen/discarded targets in page enumeration

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -564,11 +564,47 @@ export class McpContext implements Context {
     isolatedContextNames: Map<Page, string>;
   }> {
     const defaultCtx = this.browser.defaultBrowserContext();
-    const allPages = await this.browser.pages(
-      this.#options.experimentalIncludeAllPages,
-    );
 
+    // Enumerate targets individually instead of calling browser.pages() so
+    // that a single frozen/discarded background tab that times out on
+    // Network.enable cannot abort the entire page enumeration (see #1230).
     const allTargets = this.browser.targets();
+    const pageTargets = allTargets.filter(target => {
+      const type = target.type();
+      if (type === 'page') return true;
+      if (this.#options.experimentalIncludeAllPages) {
+        return type === 'background_page' || type === 'webview';
+      }
+      return false;
+    });
+    const pageResults = await Promise.all(
+      pageTargets.map(async target => {
+        try {
+          const page = await Promise.race([
+            target.page(),
+            new Promise<null>(resolve =>
+              setTimeout(() => resolve(null), DEFAULT_TIMEOUT),
+            ),
+          ]);
+          if (!page) {
+            this.logger(
+              'Timed out attaching to target at',
+              target.url(),
+              '— likely frozen or discarded',
+            );
+          }
+          return page;
+        } catch (err) {
+          this.logger(
+            'Skipping frozen/discarded target at',
+            target.url(),
+            err,
+          );
+          return null;
+        }
+      }),
+    );
+    const allPages = pageResults.filter((p): p is Page => p !== null);
     const extensionTargets = allTargets.filter(target => {
       return (
         target.url().startsWith('chrome-extension://') &&
@@ -578,7 +614,12 @@ export class McpContext implements Context {
 
     for (const target of extensionTargets) {
       // Right now target.page() returns null for popup and side panel pages.
-      let page = await target.page();
+      let page = await Promise.race([
+        target.page(),
+        new Promise<null>(resolve =>
+          setTimeout(() => resolve(null), DEFAULT_TIMEOUT),
+        ),
+      ]);
       if (!page) {
         // We need to cache pages instances for targets because target.asPage()
         // returns a new page instance every time.

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -9,9 +9,12 @@ import path from 'node:path';
 import {afterEach, describe, it} from 'node:test';
 import {pathToFileURL} from 'node:url';
 
+import logger from 'debug';
+import puppeteer, {Locator} from 'puppeteer';
 import type {Target} from 'puppeteer-core';
 import sinon from 'sinon';
 
+import {McpContext} from '../src/McpContext.js';
 import {NetworkFormatter} from '../src/formatters/NetworkFormatter.js';
 import {TextSnapshot} from '../src/TextSnapshot.js';
 import type {HTTPResponse} from '../src/third_party/index.js';
@@ -282,5 +285,68 @@ describe('McpContext', () => {
       // Real pages should still be enumerated.
       assert.ok(pages.length > 0, 'Should still enumerate healthy pages');
     });
+  });
+
+  it('should enumerate pages when a tab has a crashed renderer', async () => {
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: ['--remote-debugging-port=0'],
+      enableExtensions: true,
+      handleDevToolsAsPage: true,
+      executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+    });
+
+    try {
+      const wsEndpoint = browser.wsEndpoint();
+
+      const activePage = await browser.newPage();
+      await activePage.goto('data:text/html,<h1>Active</h1>');
+
+      const crashPage = await browser.newPage();
+      await crashPage.goto('data:text/html,<h1>Will crash</h1>');
+      try {
+        await crashPage.goto('chrome://crash');
+      } catch {}
+
+      browser.disconnect();
+
+      const reconnected = await puppeteer.connect({
+        browserWSEndpoint: wsEndpoint,
+        handleDevToolsAsPage: true,
+      });
+
+      try {
+        const start = Date.now();
+        const ctx = await McpContext.from(
+          reconnected,
+          logger('test'),
+          {
+            experimentalDevToolsDebugging: false,
+            performanceCrux: false,
+          },
+          Locator,
+        );
+        const elapsed = Date.now() - start;
+
+        assert.ok(
+          elapsed < 20_000,
+          `Took ${elapsed}ms, expected < 20s`,
+        );
+        const pages = ctx.getPages();
+        assert.ok(
+          pages.length >= 1,
+          `Expected at least 1 page, got ${pages.length}`,
+        );
+
+        ctx.dispose();
+      } finally {
+        await reconnected.close();
+      }
+    } catch (e) {
+      if (browser.connected) {
+        await browser.close();
+      }
+      throw e;
+    }
   });
 });

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import {afterEach, describe, it} from 'node:test';
 import {pathToFileURL} from 'node:url';
 
+import type {Target} from 'puppeteer-core';
 import sinon from 'sinon';
 
 import {NetworkFormatter} from '../src/formatters/NetworkFormatter.js';
@@ -255,6 +256,31 @@ describe('McpContext', () => {
         () => context.validatePath(path.resolve('/tmp/anywhere.txt')),
         /Access denied/,
       );
+    });
+  });
+
+  it('should skip frozen targets that hang on target.page()', async () => {
+    await withMcpContext(async (_response, context) => {
+      const browser = context.browser;
+      const realTargets = browser.targets();
+
+      // Inject a fake target whose page() never resolves (simulates a frozen tab).
+      const frozenTarget = {
+        type: () => 'page',
+        url: () => 'https://frozen-tab.example.com',
+        page: () => new Promise<null>(() => {}),
+      } as unknown as Target;
+
+      sinon.stub(browser, 'targets').returns([...realTargets, frozenTarget]);
+
+      const start = Date.now();
+      const pages = await context.createPagesSnapshot();
+      const elapsed = Date.now() - start;
+
+      // The frozen target should be skipped, not block for 180s.
+      assert.ok(elapsed < 15_000, `Took ${elapsed}ms, expected < 15s`);
+      // Real pages should still be enumerated.
+      assert.ok(pages.length > 0, 'Should still enumerate healthy pages');
     });
   });
 });


### PR DESCRIPTION
## Problem

When Chrome freezes or discards background tabs (memory-saving behavior), `browser.pages()` can time out on `Network.enable` for those targets and abort the entire page enumeration — even though the rest of the browser and all active tabs are healthy.

```
Network.enable timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.
```

This causes any MCP tool that needs page enumeration (`list_pages`, `take_snapshot`, navigation flows, etc.) to fail completely when the connected Chrome profile has been open long enough for background tabs to be frozen/discarded.

## Root cause

`browser.pages()` iterates every page-type target and calls `target.page()` for each, which creates a Puppeteer CDP session and sends initialization commands including `Network.enable`. Frozen/discarded targets cannot respond to page-session CDP commands, so they time out — and the error propagates out of `browser.pages()`, killing the entire list.

## Fix

Replace the single `browser.pages()` call in `#getAllPages()` with a per-target iteration over `browser.targets()`. Each call to `target.page()` is wrapped in its own `try/catch` so that one unresponsive background tab is logged and skipped instead of aborting the whole enumeration.

- `page` type targets are always included (existing behavior)
- `background_page` / `webview` types are included when `experimentalIncludeAllPages` is set (preserves existing opt-in behavior)
- The `allTargets` snapshot is reused for the extension-target loop below, so there is no extra `browser.targets()` call

Fixes #1230