### PR TITLE
fix: block tool calls when a dialog is open

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,7 +714,6 @@ Check the performance of https://developers.chrome.com
 > [!NOTE]
 > The <code>autoConnect</code> option requires the user to start Chrome. If the user has multiple active profiles, the MCP server will connect to the default profile (as determined by Chrome). The MCP server has access to all open windows for the selected profile.
 >
-> [!NOTE]
 > Network requests that occurred before the MCP server connected are not available via <code>list_network_requests</code> / <code>get_network_request</code>. If you need those, start the MCP server first or reload the page after it connects.
 
 The Chrome DevTools MCP server will try to connect to your running Chrome

--- a/README.md
+++ b/README.md
@@ -713,6 +713,9 @@ Check the performance of https://developers.chrome.com
 
 > [!NOTE]
 > The <code>autoConnect</code> option requires the user to start Chrome. If the user has multiple active profiles, the MCP server will connect to the default profile (as determined by Chrome). The MCP server has access to all open windows for the selected profile.
+>
+> [!NOTE]
+> Network requests that occurred before the MCP server connected are not available via <code>list_network_requests</code> / <code>get_network_request</code>. If you need those, start the MCP server first or reload the page after it connects.
 
 The Chrome DevTools MCP server will try to connect to your running Chrome
 instance. It shows a dialog asking for user permission.

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,6 +199,11 @@ export async function createMcpServer(
                 ? context.getPageById(params.pageId)
                 : context.getSelectedMcpPage();
             response.setPage(page);
+            if (page.getDialog() && tool.name !== 'handle_dialog') {
+              throw new Error(
+                'A browser dialog is open. Call handle_dialog to accept or dismiss it before continuing.',
+              );
+            }
             await tool.handler(
               {
                 params,


### PR DESCRIPTION
## Summary
- block page-scoped tool calls when a browser dialog is open
- instruct agents to call handle_dialog first

## Testing
- not run (not requested)

Fixes #1069