### PR TITLE
fix: remove double space in navigate error message

### DIFF
--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -222,7 +222,7 @@ export const navigatePage = definePageTool({
                 );
               } catch (error) {
                 response.appendResponseLine(
-                  `Unable to navigate in the  selected page: ${error.message}.`,
+                  `Unable to navigate in the selected page: ${error.message}.`,
                 );
               }
               break;


### PR DESCRIPTION
## Summary

Fixes a double space in the navigate error message in `src/tools/pages.ts`.

## Problem

Line 225 contains an error message with double space:
```
'Unable to navigate in the  selected page: ...'
```

## Fix

Changed to single space:
```
'Unable to navigate in the selected page: ...'
```

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>