### PR TITLE
fix: ignore unmapped PerformanceIssue events

### DIFF
--- a/src/PageCollector.ts
+++ b/src/PageCollector.ts
@@ -342,6 +342,11 @@ class PageEventSubscriber {
 
   #onIssueAdded = (inspectorIssue: Issue) => {
     try {
+      // DevTools currently defines this protocol issue code but has no
+      // IssuesManager handler for it, so calling into the mapper only warns.
+      if (String(inspectorIssue.code) === 'PerformanceIssue') {
+        return;
+      }
       const issue = DevTools.createIssuesFromProtocolIssue(
         null,
         // @ts-expect-error Protocol types diverge.

--- a/tests/PageCollector.test.ts
+++ b/tests/PageCollector.test.ts
@@ -358,6 +358,35 @@ describe('ConsoleCollector', () => {
     assert.equal(data.length, 2);
   });
 
+  it('silently ignores unmapped PerformanceIssue events', async () => {
+    const browser = getMockBrowser();
+    const page = (await browser.pages())[0];
+    const warnStub = sinon.stub(console, 'warn');
+
+    const collector = new ConsoleCollector(browser, collect => {
+      return {
+        devtoolsAggregatedIssue: issue => {
+          collect(issue);
+        },
+      } as ListenerMap;
+    });
+    await collector.init([page]);
+
+    const performanceIssue = {
+      code: 'PerformanceIssue',
+      details: {
+        performanceIssueDetails: {
+          performanceIssueType: 'DocumentCookie',
+        },
+      },
+    } as unknown as Protocol.Audits.InspectorIssue;
+
+    page.emit('issue', performanceIssue);
+
+    assert.equal(collector.getData(page).length, 0);
+    sinon.assert.notCalled(warnStub);
+  });
+
   it('filters duplicated issues', async () => {
     const browser = getMockBrowser();
     const page = (await browser.pages())[0];


### PR DESCRIPTION
## Summary

- ignore Audits `PerformanceIssue` events before passing them to the DevTools IssuesManager mapper, which currently has no handler for that issue code
- preserve the existing mapper/logging path for other issue codes
- add regression coverage that `PerformanceIssue` is ignored without collecting an issue or writing a console warning

Fixes #1850

## Testing

- `npm run build`
- `npm run test:no-build -- tests/PageCollector.test.ts`
- `npm run check-format`