### PR TITLE
fix(cli): allow --autoConnect in chrome-devtools start

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,6 +29,9 @@ chrome-devtools navigate_page "https://google.com"
 # Take a screenshot and save it to a file
 chrome-devtools take_screenshot --filePath screenshot.png
 
+# Start the daemon and auto-connect to an existing Chrome profile
+chrome-devtools start --autoConnect
+
 # Stop the background daemon when finished
 chrome-devtools stop
 ```

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -43,8 +43,7 @@ const startCliOptions = {
   ...cliOptions,
 } as Partial<typeof cliOptions>;
 
-// Not supported in CLI on purpose.
-delete startCliOptions.autoConnect;
+// autoConnect is supported by the CLI.
 // Missing CLI serialization.
 delete startCliOptions.viewport;
 // CLI is generated based on the default tool definitions. To enable conditional

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -43,7 +43,8 @@ const startCliOptions = {
   ...cliOptions,
 } as Partial<typeof cliOptions>;
 
-// autoConnect is supported by the CLI.
+// Not supported in CLI on purpose.
+delete startCliOptions.autoConnect;
 // Missing CLI serialization.
 delete startCliOptions.viewport;
 // CLI is generated based on the default tool definitions. To enable conditional


### PR DESCRIPTION
## Summary
- allow chrome-devtools start to accept --autoConnect and forward it to the daemon
- document the CLI example for auto-connect

## Testing
- not run (not requested)

Fixes #1184