### PR TITLE
chore: some build and test fixes

### DIFF
--- a/scripts/post-build.ts
+++ b/scripts/post-build.ts
@@ -26,6 +26,7 @@ function main(): void {
 
   // Create i18n mock
   const i18nDir = path.join(BUILD_DIR, devtoolsFrontEndCorePath, 'i18n');
+  fs.mkdirSync(i18nDir, {recursive: true});
   const localesFile = path.join(i18nDir, 'locales.js');
   const localesContent = `
 export const LOCALES = [

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -101,6 +101,7 @@ async function runTests(attempt) {
         ...process.env,
         CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: true,
         CHROME_DEVTOOLS_MCP_CRASH_ON_UNCAUGHT: true,
+        CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS: true,
       },
     });
 


### PR DESCRIPTION
Under some cases one could not re-build correctly due to the directory being remove.
And we can save some CPU cycles in test to disable the update checker.