### PR TITLE
docs: document network response and request extensions

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,6 +1,6 @@
 <!-- AUTO GENERATED DO NOT EDIT - run 'npm run gen' to update-->
 
-# Chrome DevTools MCP Tool Reference (~6951 cl100k_base tokens)
+# Chrome DevTools MCP Tool Reference (~6963 cl100k_base tokens)
 
 - **[Input automation](#input-automation)** (9 tools)
   - [`click`](#click)
@@ -295,8 +295,8 @@
 **Parameters:**
 
 - **reqid** (number) _(optional)_: The reqid of the network request. If omitted returns the currently selected request in the DevTools Network panel.
-- **requestFilePath** (string) _(optional)_: The absolute or relative path to save the request body to. If omitted, the body is returned inline.
-- **responseFilePath** (string) _(optional)_: The absolute or relative path to save the response body to. If omitted, the body is returned inline.
+- **requestFilePath** (string) _(optional)_: The absolute or relative path to a .network-request file to save the request body to. If omitted, the body is returned inline.
+- **responseFilePath** (string) _(optional)_: The absolute or relative path to a .network-response file to save the response body to. If omitted, the body is returned inline.
 
 ---
 

--- a/src/bin/cliDefinitions.ts
+++ b/src/bin/cliDefinitions.ts
@@ -214,14 +214,14 @@ export const commands: Commands = {
         name: 'requestFilePath',
         type: 'string',
         description:
-          'The absolute or relative path to save the request body to. If omitted, the body is returned inline.',
+          'The absolute or relative path to a .network-request file to save the request body to. If omitted, the body is returned inline.',
         required: false,
       },
       responseFilePath: {
         name: 'responseFilePath',
         type: 'string',
         description:
-          'The absolute or relative path to save the response body to. If omitted, the body is returned inline.',
+          'The absolute or relative path to a .network-response file to save the response body to. If omitted, the body is returned inline.',
         required: false,
       },
     },

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -104,13 +104,13 @@ export const getNetworkRequest = definePageTool({
       .string()
       .optional()
       .describe(
-        'The absolute or relative path to save the request body to. If omitted, the body is returned inline.',
+        'The absolute or relative path to a .network-request file to save the request body to. If omitted, the body is returned inline.',
       ),
     responseFilePath: zod
       .string()
       .optional()
       .describe(
-        'The absolute or relative path to save the response body to. If omitted, the body is returned inline.',
+        'The absolute or relative path to a .network-response file to save the response body to. If omitted, the body is returned inline.',
       ),
   },
   handler: async (request, response, context) => {


### PR DESCRIPTION
Extensions are enforced since https://github.com/ChromeDevTools/chrome-devtools-mcp/pull/1867