### PR TITLE
fix(cli): correct WebP MIME type check in handleResponse ('webp' → 'image/webp')

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -172,7 +172,7 @@ export async function handleResponse(
         case 'image/jpeg':
           extension = '.jpeg';
           break;
-        case 'webp':
+        case 'image/webp':
           extension = '.webp';
           break;
       }


### PR DESCRIPTION
## Summary

Fixes a bug in `src/daemon/client.ts` where the MIME type case for WebP images was `'webp'` instead of the correct `'image/webp'`.

## Problem

In `handleResponse`, the switch statement for determining file extension used the incorrect string `'webp'` as the MIME type. Since browsers and servers send `image/webp` as the MIME type, the case never matched, and all WebP images were saved with a `.png` extension instead of `.webp`.

```ts
// Before (buggy)
case 'webp':
  extension = '.webp';
  break;

// After (fixed)
case 'image/webp':
  extension = '.webp';
  break;
```

## Testing

WebP screenshots/images returned by the tool will now correctly receive the `.webp` extension.

Closes #1898

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>