### PR TITLE
feat: add Docker image for the MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.agent
+.claude-plugin
+build
+node_modules
+npm-debug.log
+coverage
+*.tsbuildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:24-bookworm-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run bundle
+
+FROM node:24-bookworm-slim
+
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV CHROME_PATH=/usr/bin/google-chrome
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg wget \
+    && mkdir -p /etc/apt/keyrings \
+    && wget -qO- https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/google-linux.gpg \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/build ./build
+COPY --from=build /app/LICENSE ./LICENSE
+
+ENTRYPOINT ["node", "build/src/bin/chrome-devtools-mcp.js"]
+CMD ["--headless", "--chrome-arg=--no-sandbox", "--chrome-arg=--disable-dev-shm-usage"]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ If you are interested in doing only basic browser tasks, use the `--slim` mode:
 
 See [Slim tool reference](./docs/slim-tool-reference.md).
 
+### Docker
+
+Build and run the MCP server in a container:
+
+```bash
+docker build -t chrome-devtools-mcp .
+docker run --rm -i chrome-devtools-mcp
+```
+
+The container image installs Google Chrome and starts the MCP server in headless
+mode by default. The bundled command also includes `--no-sandbox` and
+`--disable-dev-shm-usage`, which are commonly needed in containerized
+environments. Extra CLI flags can be appended to `docker run`, for example:
+
+```bash
+docker run --rm -i chrome-devtools-mcp --log-file=/tmp/chrome-devtools.log
+```
+
 ### MCP Client configuration
 
 <details>


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for building and running chrome-devtools-mcp
- install Google Chrome in the runtime image and start the server in headless mode by default
- document the container workflow in the README and exclude unnecessary files from build context

## Testing
- npm ci
- npm run build
- node build/src/bin/chrome-devtools-mcp.js --help

Closes #584