### PR TITLE
test: save WebP responses with the right extension

### DIFF
--- a/tests/daemon/client.test.ts
+++ b/tests/daemon/client.test.ts
@@ -107,5 +107,20 @@ describe('daemon client', () => {
       const response = await handleResponse(unsupportedContentResponse, 'md');
       assert.ok(response.includes('.png'));
     });
+
+    it('uses the webp extension for WebP images', async () => {
+      const webpContentResponse = {
+        content: [
+          {
+            type: 'image' as const,
+            data: 'base64data',
+            mimeType: 'image/webp',
+          },
+        ],
+        structuredContent: {},
+      };
+      const response = await handleResponse(webpContentResponse, 'md');
+      assert.ok(response.includes('.webp'));
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fix the WebP MIME type match in daemon response handling
- save  responses with a  suffix instead of falling back to 
- add a regression test for WebP image handling

## Testing
- npm run build
- node --test --test-name-pattern="parsing" build/tests/daemon/client.test.js

Fixes #1898