### PR TITLE
fix: avoid duplicate plugin MCP registration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,5 @@
 {
   "name": "chrome-devtools-mcp",
   "version": "0.21.0",
-  "description": "Reliable automation, in-depth debugging, and performance analysis in Chrome using Chrome DevTools and Puppeteer",
-  "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["chrome-devtools-mcp@latest"]
-    }
-  }
+  "description": "Reliable automation, in-depth debugging, and performance analysis in Chrome using Chrome DevTools and Puppeteer"
 }


### PR DESCRIPTION
Summary:
- remove the duplicate chrome-devtools MCP server declaration from .claude-plugin/plugin.json
- keep .mcp.json as the single source of truth for plugin MCP registration
- avoid Claude Code /doctor warnings when the marketplace plugin is installed

Testing:
- node -e "JSON.parse(require('fs').readFileSync('.claude-plugin/plugin.json','utf8'))"

Fixes #1854