### PR TITLE
test: add test for console log from content script

### DIFF
--- a/tests/tools/extensions.test.ts
+++ b/tests/tools/extensions.test.ts
@@ -11,6 +11,7 @@ import {afterEach, describe, it} from 'node:test';
 import sinon from 'sinon';
 
 import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
+import {listConsoleMessages} from '../../src/tools/console.js';
 import {
   installExtension,
   uninstallExtension,
@@ -18,10 +19,13 @@ import {
   reloadExtension,
   triggerExtensionAction,
 } from '../../src/tools/extensions.js';
+import {serverHooks} from '../server.js';
 import {
   assertNoServiceWorkerReported,
   extractExtensionId,
   withMcpContext,
+  html,
+  getTextContent,
 } from '../utils.js';
 
 const EXTENSION_WITH_SW_PATH = path.join(
@@ -32,8 +36,14 @@ const EXTENSION_PATH = path.join(
   import.meta.dirname,
   '../../../tests/tools/fixtures/extension',
 );
+const EXTENSION_CONTENT_SCRIPT_PATH = path.join(
+  import.meta.dirname,
+  '../../../tests/tools/fixtures/extension-content-script',
+);
 
 describe('extension', () => {
+  const server = serverHooks();
+
   afterEach(() => {
     sinon.restore();
   });
@@ -161,6 +171,46 @@ describe('extension', () => {
         await context.uninstallExtension(extensionId);
         const targets = context.browser.targets();
         assertNoServiceWorkerReported(targets, extensionId);
+      },
+      {},
+      {
+        categoryExtensions: true,
+      } as ParsedArguments,
+    );
+  });
+
+  it('verifies that content script console logs are received', async () => {
+    await withMcpContext(
+      async (response, context) => {
+        server.addHtmlRoute(
+          '/test-content-script',
+          html`<h1>Test Content Script</h1>`,
+        );
+        const url = server.getRoute('/test-content-script');
+
+        const extensionId = await context.installExtension(
+          EXTENSION_CONTENT_SCRIPT_PATH,
+        );
+
+        const mcpPage = context.getSelectedMcpPage();
+        const page = mcpPage.pptrPage;
+
+        await page.goto(url);
+
+        await listConsoleMessages.handler(
+          {params: {includePreservedMessages: true}, page: mcpPage},
+          response,
+          context,
+        );
+
+        const result = await response.handle('list_console_messages', context);
+        const consoleOutput = getTextContent(result.content[0]);
+        assert.ok(
+          consoleOutput.includes('from content script!'),
+          `Console output should contain message from content script. Got: ${consoleOutput}`,
+        );
+
+        await context.uninstallExtension(extensionId);
       },
       {},
       {

--- a/tests/tools/fixtures/extension-content-script/content.js
+++ b/tests/tools/fixtures/extension-content-script/content.js
@@ -1,0 +1,1 @@
+console.log('Hello from content script!');

--- a/tests/tools/fixtures/extension-content-script/manifest.json
+++ b/tests/tools/fixtures/extension-content-script/manifest.json
@@ -1,0 +1,15 @@
+{
+  "manifest_version": 3,
+  "name": "Test Extension with Content Script",
+  "version": "1.0",
+  "permissions": ["tabs", "scripting"],
+  "host_permissions": ["<all_urls>"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a test to prove extension content script can be captured in logs for pages