### PR TITLE
build: add dev source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "files": [
     "build/src",
     "LICENSE",
-    "!*.tsbuildinfo"
+    "!*.tsbuildinfo",
+    "!*.js.map"
   ],
   "repository": "ChromeDevTools/chrome-devtools-mcp",
   "author": "Google LLC",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -169,6 +169,7 @@ async function getToolsWithFilteredCategories(
   const definedNames = [];
   for (const file of files) {
     if (
+      !file.endsWith('.js') ||
       file === 'ToolDefinition.js' ||
       file === 'tools.js' ||
       file === 'slim'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
     "incremental": true,
+    "sourceMap": true,
     "allowJs": true,
     "useUnknownInCatchVariables": false
   },


### PR DESCRIPTION
This allows setting up a debugger script with either enabled debugging port or tools like VS Code or Antigravity.