### PR TITLE
Fix window.atob/window.btoa runtime crashes under Node

### DIFF
--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -57,6 +57,14 @@ import {
   generateReport as generateReportImpl,
 } from './lighthouse-devtools-mcp-bundle.js';
 
+// Some vendored DevTools/Lighthouse code paths call window.atob/window.btoa even
+// when running under Node.js. Expose a browser-like alias so those runtime calls
+// resolve to Node's global atob/btoa instead of throwing ReferenceError.
+if (typeof globalThis.window === 'undefined') {
+  globalThis.window = globalThis as typeof globalThis & Window & typeof globalThis;
+}
+
+
 export const snapshot = snapshotImpl as (
   page: Page,
   options: {flags?: Flags},


### PR DESCRIPTION
## Summary
- define a Node-safe `globalThis.window` alias before vendored DevTools/Lighthouse runtime paths execute
- avoid `ReferenceError: window is not defined` when runtime code calls `window.atob` / `window.btoa`

## Context
The published `chrome-devtools-mcp` bundle currently includes vendored runtime code paths that call `window.atob` and `window.btoa` even when the MCP server is running under Node.js. In that environment, Node provides global `atob`/`btoa`, but not a browser `window` object, which causes crashes during affected flows (for example SSE parsing through the MCP transport).

This patch keeps the fix narrow by exposing `globalThis.window = globalThis` when `window` is otherwise absent, so those vendored runtime calls resolve correctly in Node.

Here is the original error:
```
[mcp-proxy] establishing new SSE stream for session ID 6081ef15-f8a4-4f81-9594-a80f7cf8cb56
file:///Users/evar/.npm/_npx/15c61037b1978c83/node_modules/chrome-devtools-mcp/build/src/third_party/index.js:129773
        const binString = window.atob(chunk);
                          ^

ReferenceError: window is not defined
    at Base64TextDecoder.addBase64Chunk (file:///Users/evar/.npm/_npx/15c61037b1978c83/node_modules/chrome-devtools-mcp/build/src/third_party/index.js:129773:27)
    at ServerSentEventsParser.addBase64Chunk (file:///Users/evar/.npm/_npx/15c61037b1978c83/node_modules/chrome-devtools-mcp/build/src/third_party/index.js:129704:29)
    at file:///Users/evar/.npm/_npx/15c61037b1978c83/node_modules/chrome-devtools-mcp/build/src/third_party/index.js:129793:40
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

