### PR TITLE
fix: respect npm_config_registry for update checks

### DIFF
--- a/src/bin/check-latest-version.ts
+++ b/src/bin/check-latest-version.ts
@@ -12,8 +12,11 @@ const cachePath = process.argv[2];
 
 if (cachePath) {
   try {
+    const registry =
+      process.env.npm_config_registry?.replace(/\/$/, '') ||
+      'https://registry.npmjs.org';
     const response = await fetch(
-      'https://registry.npmjs.org/chrome-devtools-mcp/latest',
+      `${registry}/chrome-devtools-mcp/latest`,
     );
     const data = response.ok ? await response.json() : null;
 

--- a/src/bin/check-latest-version.ts
+++ b/src/bin/check-latest-version.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {execSync} from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
@@ -12,9 +13,15 @@ const cachePath = process.argv[2];
 
 if (cachePath) {
   try {
-    const registry =
-      process.env.npm_config_registry?.replace(/\/$/, '') ||
-      'https://registry.npmjs.org';
+    let registry;
+    try {
+      registry = execSync('npm config get registry', {
+        encoding: 'utf8',
+      }).trim().replace(/\/$/, '');
+    } catch {
+      // npm not on PATH, fall back to default
+    }
+    registry ||= 'https://registry.npmjs.org';
     const response = await fetch(
       `${registry}/chrome-devtools-mcp/latest`,
     );


### PR DESCRIPTION
## Summary

Use `npm_config_registry` environment variable for npm registry URL in update checks, instead of hardcoding `registry.npmjs.org`.

## Fix

`check-latest-version.ts` now respects the user's npm registry configuration. This helps users behind corporate proxies or using private registries (e.g., JFrog Artifactory).

When `npm_config_registry` is not set, falls back to the default public registry.

## Validation

- [x] `npm run build` passes
- [x] `npm test` passes

Fixes #1943