### PR TITLE
feat(cli): generate commands for conditional tools

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -398,7 +398,7 @@ in the DevTools Elements panel (if any).
 
 ## Extensions
 
-> NOTE: Extensions are not active by default. Use the '--category-extensions' flag
+> NOTE: Extensions are not active by default. Use the '--categoryExtensions' flag
 
 ### `install_extension`
 

--- a/scripts/generate-cli.ts
+++ b/scripts/generate-cli.ts
@@ -11,7 +11,12 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 
 import {parseArguments} from '../build/src/bin/chrome-devtools-mcp-cli-options.js';
-import {labels, ToolCategory} from '../build/src/tools/categories.js';
+import {CONDITION_TO_FLAG, buildFlag} from '../build/src/index.js';
+import {
+  labels,
+  ToolCategory,
+  OFF_BY_DEFAULT_CATEGORIES,
+} from '../build/src/tools/categories.js';
 import {createTools} from '../build/src/tools/tools.js';
 
 const OUTPUT_PATH = path.join(
@@ -83,10 +88,7 @@ function schemaToCLIOptions(schema: JsonSchema): CliOption[] {
   const properties = schema.properties;
   return Object.entries(properties).map(([name, prop]) => {
     const isRequired = required.includes(name);
-    let description = prop.description || '';
-    if (isRequired) {
-      description += ' (required)';
-    }
+    const description = prop.description || '';
     if (typeof prop.type !== 'string') {
       throw new Error(
         `Property ${name} has a complex type not supported by CLI.`,
@@ -107,12 +109,12 @@ async function generateCli() {
   const tools = await fetchTools();
 
   const staticTools = createTools(parseArguments());
-  const toolNameToCategory = new Map<string, string>();
+  const toolNameToCategoryEnum = new Map<string, string>();
+  const toolNameToConditions = new Map<string, string[]>();
+
   for (const tool of staticTools) {
-    toolNameToCategory.set(
-      tool.name,
-      labels[tool.annotations.category as keyof typeof labels],
-    );
+    toolNameToCategoryEnum.set(tool.name, tool.annotations.category);
+    toolNameToConditions.set(tool.name, tool.annotations.conditions || []);
   }
 
   // Sort tools by name
@@ -134,7 +136,7 @@ async function generateCli() {
         return false;
       }
       // Skipping in_page tools as they are not launched yet
-      if (toolNameToCategory.get(tool.name) === labels[ToolCategory.IN_PAGE]) {
+      if (toolNameToCategoryEnum.get(tool.name) === ToolCategory.IN_PAGE) {
         return false;
       }
       return true;
@@ -151,15 +153,40 @@ async function generateCli() {
     for (const opt of options) {
       args[opt.name] = opt;
     }
-    const category = toolNameToCategory.get(tool.name);
-    if (!category) {
+
+    const categoryEnum = toolNameToCategoryEnum.get(tool.name);
+    if (!categoryEnum) {
       throw new Error(`Tool ${tool.name} has no category.`);
     }
+    const category = labels[categoryEnum as unknown as keyof typeof labels];
     if (!tool.description) {
-      throw new Error(`Tool ${tool.name} is missing descripttion`);
+      throw new Error(`Tool ${tool.name} is missing description`);
     }
+
+    let description = tool.description;
+    const requiredFlags: string[] = [];
+
+    const isOffByDefault = OFF_BY_DEFAULT_CATEGORIES.includes(categoryEnum);
+    if (isOffByDefault) {
+      const categoryFlag = buildFlag(categoryEnum);
+      requiredFlags.push(`--${categoryFlag}=true`);
+    }
+
+    const conditions = toolNameToConditions.get(tool.name) || [];
+    for (const condition of conditions) {
+      const flag =
+        CONDITION_TO_FLAG[condition as keyof typeof CONDITION_TO_FLAG];
+      if (flag) {
+        requiredFlags.push(`--${flag}=true`);
+      }
+    }
+
+    if (requiredFlags.length > 0) {
+      description += ` (requires flag: ${requiredFlags.join(', ')})`;
+    }
+
     commands[tool.name] = {
-      description: tool.description,
+      description,
       category,
       args,
     };

--- a/scripts/generate-cli.ts
+++ b/scripts/generate-cli.ts
@@ -11,7 +11,7 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 
 import {parseArguments} from '../build/src/bin/chrome-devtools-mcp-cli-options.js';
-import {labels} from '../build/src/tools/categories.js';
+import {labels, ToolCategory} from '../build/src/tools/categories.js';
 import {createTools} from '../build/src/tools/tools.js';
 
 const OUTPUT_PATH = path.join(
@@ -29,7 +29,7 @@ async function fetchTools() {
 
   const transport = new StdioClientTransport({
     command: 'node',
-    args: [serverPath],
+    args: [serverPath, '--viaCli'],
     env: {...process.env, CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true'},
   });
 
@@ -83,7 +83,10 @@ function schemaToCLIOptions(schema: JsonSchema): CliOption[] {
   const properties = schema.properties;
   return Object.entries(properties).map(([name, prop]) => {
     const isRequired = required.includes(name);
-    const description = prop.description || '';
+    let description = prop.description || '';
+    if (isRequired) {
+      description += ' (required)';
+    }
     if (typeof prop.type !== 'string') {
       throw new Error(
         `Property ${name} has a complex type not supported by CLI.`,
@@ -103,6 +106,15 @@ function schemaToCLIOptions(schema: JsonSchema): CliOption[] {
 async function generateCli() {
   const tools = await fetchTools();
 
+  const staticTools = createTools(parseArguments());
+  const toolNameToCategory = new Map<string, string>();
+  for (const tool of staticTools) {
+    toolNameToCategory.set(
+      tool.name,
+      labels[tool.annotations.category as keyof typeof labels],
+    );
+  }
+
   // Sort tools by name
   const sortedTools = tools
     .sort((a, b) => a.name.localeCompare(b.name))
@@ -117,17 +129,16 @@ async function generateCli() {
       if (tool.name === 'wait_for') {
         return false;
       }
+      // Skipping get_tab_id as it is for internal integrations
+      if (tool.name === 'get_tab_id') {
+        return false;
+      }
+      // Skipping in_page tools as they are not launched yet
+      if (toolNameToCategory.get(tool.name) === labels[ToolCategory.IN_PAGE]) {
+        return false;
+      }
       return true;
     });
-
-  const staticTools = createTools(parseArguments());
-  const toolNameToCategory = new Map<string, string>();
-  for (const tool of staticTools) {
-    toolNameToCategory.set(
-      tool.name,
-      labels[tool.annotations.category as keyof typeof labels],
-    );
-  }
 
   const commands: Record<
     string,

--- a/scripts/generate-cli.ts
+++ b/scripts/generate-cli.ts
@@ -11,7 +11,7 @@ import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
 
 import {parseArguments} from '../build/src/bin/chrome-devtools-mcp-cli-options.js';
-import {CONDITION_TO_FLAG, buildFlag} from '../build/src/index.js';
+import {buildFlag} from '../build/src/index.js';
 import {
   labels,
   ToolCategory,
@@ -174,11 +174,7 @@ async function generateCli() {
 
     const conditions = toolNameToConditions.get(tool.name) || [];
     for (const condition of conditions) {
-      const flag =
-        CONDITION_TO_FLAG[condition as keyof typeof CONDITION_TO_FLAG];
-      if (flag) {
-        requiredFlags.push(`--${flag}=true`);
-      }
+      requiredFlags.push(`--${condition}=true`);
     }
 
     if (requiredFlags.length > 0) {

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -13,6 +13,7 @@ import {get_encoding} from 'tiktoken';
 
 import {cliOptions} from '../build/src/bin/chrome-devtools-mcp-cli-options.js';
 import type {ParsedArguments} from '../build/src/bin/chrome-devtools-mcp-cli-options.js';
+import {buildFlag} from '../build/src/index.js';
 import {
   ToolCategory,
   OFF_BY_DEFAULT_CATEGORIES,
@@ -356,7 +357,7 @@ async function generateReference(
     markdown += `## ${categoryName}\n\n`;
 
     if (OFF_BY_DEFAULT_CATEGORIES.includes(category)) {
-      const flagName = `--category-${category}`;
+      const flagName = `--${buildFlag(category)}`;
 
       markdown += `> NOTE: ${categoryName} are not active by default. Use the '${flagName}' flag\n\n`;
     }
@@ -446,6 +447,11 @@ function getToolsAndCategories(tools: any) {
   // Convert ToolDefinitions to ToolWithAnnotations
   const toolsWithAnnotations: ToolWithAnnotations[] = tools
     .filter(tool => {
+      // Skipping in_page tools as they are not launched yet
+      if (tool.annotations.category.includes('experimental')) {
+        return false;
+      }
+
       if (!tool.annotations.conditions) {
         return true;
       }

--- a/skills/chrome-devtools-cli/SKILL.md
+++ b/skills/chrome-devtools-cli/SKILL.md
@@ -123,6 +123,27 @@ chrome-devtools take_snapshot # Take a text snapshot of the page from the a11y t
 chrome-devtools take_snapshot --verbose true --filePath "s.txt" # Take a verbose snapshot and save to file
 ```
 
+## Extensions
+
+```bash
+chrome-devtools list_extensions # Lists all the Chrome extensions installed in the browser
+chrome-devtools install_extension "/path/to/extension" # Installs a Chrome extension from the given path
+chrome-devtools uninstall_extension "extension_id" # Uninstalls a Chrome extension by its ID
+chrome-devtools reload_extension "extension_id" # Reloads an unpacked Chrome extension by its ID
+chrome-devtools trigger_extension_action "extension_id" # Triggers the default action of an extension by its ID
+```
+
+## Experimental Features
+
+Experimental tools are disabled by default. Enable them with the corresponding flag during `start`.
+
+```bash
+chrome-devtools click_at 100 200 # Clicks at the provided coordinates (requires --experimentalVision=true)
+chrome-devtools screencast_start # Starts a screencast recording (requires --experimentalScreencast=true and ffmpeg)
+chrome-devtools screencast_stop # Stops the active screencast
+chrome-devtools list_webmcp_tools # List all WebMCP tools (requires --experimentalWebmcp=true)
+```
+
 ## Service Management
 
 ```bash

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -245,7 +245,7 @@ export class McpResponse implements Response {
   }
 
   setListInPageTools(): void {
-    if (this.#args.categoryInPageTools) {
+    if (this.#args.categoryExperimentalInPage) {
       this.#listInPageTools = true;
     }
   }

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -31,7 +31,7 @@ export const commands: Commands = {
         name: 'uid',
         type: 'string',
         description:
-          'The uid of an element on the page from the page content snapshot (required)',
+          'The uid of an element on the page from the page content snapshot',
         required: true,
       },
       dblClick: {
@@ -50,19 +50,20 @@ export const commands: Commands = {
     },
   },
   click_at: {
-    description: 'Clicks at the provided coordinates',
+    description:
+      'Clicks at the provided coordinates (requires flag: --experimentalVision=true)',
     category: 'Input automation',
     args: {
       x: {
         name: 'x',
         type: 'number',
-        description: 'The x coordinate (required)',
+        description: 'The x coordinate',
         required: true,
       },
       y: {
         name: 'y',
         type: 'number',
-        description: 'The y coordinate (required)',
+        description: 'The y coordinate',
         required: true,
       },
       dblClick: {
@@ -89,7 +90,7 @@ export const commands: Commands = {
         name: 'pageId',
         type: 'number',
         description:
-          'The ID of the page to close. Call list_pages to list pages. (required)',
+          'The ID of the page to close. Call list_pages to list pages.',
         required: true,
       },
     },
@@ -101,13 +102,13 @@ export const commands: Commands = {
       from_uid: {
         name: 'from_uid',
         type: 'string',
-        description: 'The uid of the element to drag (required)',
+        description: 'The uid of the element to drag',
         required: true,
       },
       to_uid: {
         name: 'to_uid',
         type: 'string',
-        description: 'The uid of the element to drop into (required)',
+        description: 'The uid of the element to drop into',
         required: true,
       },
       includeSnapshot: {
@@ -177,7 +178,7 @@ export const commands: Commands = {
         name: 'function',
         type: 'string',
         description:
-          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`\n (required)',
+          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`\n',
         required: true,
       },
       args: {
@@ -196,13 +197,14 @@ export const commands: Commands = {
     },
   },
   execute_webmcp_tool: {
-    description: 'Executes a WebMCP tool exposed by the page.',
+    description:
+      'Executes a WebMCP tool exposed by the page. (requires flag: --experimentalWebmcp=true)',
     category: 'Debugging',
     args: {
       toolName: {
         name: 'toolName',
         type: 'string',
-        description: 'The name of the WebMCP tool to execute (required)',
+        description: 'The name of the WebMCP tool to execute',
         required: true,
       },
       input: {
@@ -223,13 +225,13 @@ export const commands: Commands = {
         name: 'uid',
         type: 'string',
         description:
-          'The uid of an element on the page from the page content snapshot (required)',
+          'The uid of an element on the page from the page content snapshot',
         required: true,
       },
       value: {
         name: 'value',
         type: 'string',
-        description: 'The value to fill in (required)',
+        description: 'The value to fill in',
         required: true,
       },
       includeSnapshot: {
@@ -250,20 +252,20 @@ export const commands: Commands = {
         name: 'msgid',
         type: 'number',
         description:
-          'The msgid of a console message on the page from the listed console messages (required)',
+          'The msgid of a console message on the page from the listed console messages',
         required: true,
       },
     },
   },
   get_memory_snapshot_details: {
     description:
-      'Loads a memory heapsnapshot and returns all available information including statistics, static data, and aggregated node information. Supports pagination for aggregates.',
+      'Loads a memory heapsnapshot and returns all available information including statistics, static data, and aggregated node information. Supports pagination for aggregates. (requires flag: --experimentalMemory=true)',
     category: 'Memory',
     args: {
       filePath: {
         name: 'filePath',
         type: 'string',
-        description: 'A path to a .heapsnapshot file to read. (required)',
+        description: 'A path to a .heapsnapshot file to read.',
         required: true,
       },
       pageIdx: {
@@ -310,20 +312,20 @@ export const commands: Commands = {
   },
   get_nodes_by_class: {
     description:
-      'Loads a memory heapsnapshot and returns instances of a specific class with their stable IDs.',
+      'Loads a memory heapsnapshot and returns instances of a specific class with their stable IDs. (requires flag: --experimentalMemory=true)',
     category: 'Memory',
     args: {
       filePath: {
         name: 'filePath',
         type: 'string',
-        description: 'A path to a .heapsnapshot file to read. (required)',
+        description: 'A path to a .heapsnapshot file to read.',
         required: true,
       },
       uid: {
         name: 'uid',
         type: 'number',
         description:
-          'The unique UID for the class, obtained from aggregates listing. (required)',
+          'The unique UID for the class, obtained from aggregates listing.',
         required: true,
       },
       pageIdx: {
@@ -348,7 +350,7 @@ export const commands: Commands = {
       action: {
         name: 'action',
         type: 'string',
-        description: 'Whether to dismiss or accept the dialog (required)',
+        description: 'Whether to dismiss or accept the dialog',
         required: true,
         enum: ['accept', 'dismiss'],
       },
@@ -368,7 +370,7 @@ export const commands: Commands = {
         name: 'uid',
         type: 'string',
         description:
-          'The uid of an element on the page from the page content snapshot (required)',
+          'The uid of an element on the page from the page content snapshot',
         required: true,
       },
       includeSnapshot: {
@@ -381,14 +383,14 @@ export const commands: Commands = {
     },
   },
   install_extension: {
-    description: 'Installs a Chrome extension from the given path.',
+    description:
+      'Installs a Chrome extension from the given path. (requires flag: --categoryExtensions=true)',
     category: 'Extensions',
     args: {
       path: {
         name: 'path',
         type: 'string',
-        description:
-          'Absolute path to the unpacked extension folder. (required)',
+        description: 'Absolute path to the unpacked extension folder.',
         required: true,
       },
     },
@@ -461,7 +463,7 @@ export const commands: Commands = {
   },
   list_extensions: {
     description:
-      'Lists all the Chrome extensions installed in the browser. This includes their name, ID, version, and enabled status.',
+      'Lists all the Chrome extensions installed in the browser. This includes their name, ID, version, and enabled status. (requires flag: --categoryExtensions=true)',
     category: 'Extensions',
     args: {},
   },
@@ -507,19 +509,20 @@ export const commands: Commands = {
     args: {},
   },
   list_webmcp_tools: {
-    description: 'Lists all WebMCP tools the page exposes.',
+    description:
+      'Lists all WebMCP tools the page exposes. (requires flag: --experimentalWebmcp=true)',
     category: 'Debugging',
     args: {},
   },
   load_memory_snapshot: {
     description:
-      'Loads a memory heapsnapshot and returns snapshot summary stats.',
+      'Loads a memory heapsnapshot and returns snapshot summary stats. (requires flag: --experimentalMemory=true)',
     category: 'Memory',
     args: {
       filePath: {
         name: 'filePath',
         type: 'string',
-        description: 'A path to a .heapsnapshot file to read. (required)',
+        description: 'A path to a .heapsnapshot file to read.',
         required: true,
       },
     },
@@ -581,7 +584,7 @@ export const commands: Commands = {
       url: {
         name: 'url',
         type: 'string',
-        description: 'URL to load in a new page. (required)',
+        description: 'URL to load in a new page.',
         required: true,
       },
       background: {
@@ -616,14 +619,14 @@ export const commands: Commands = {
         name: 'insightSetId',
         type: 'string',
         description:
-          'The id for the specific insight set. Only use the ids given in the "Available insight sets" list. (required)',
+          'The id for the specific insight set. Only use the ids given in the "Available insight sets" list.',
         required: true,
       },
       insightName: {
         name: 'insightName',
         type: 'string',
         description:
-          'The name of the Insight you want more information on. For example: "DocumentLatency" or "LCPBreakdown" (required)',
+          'The name of the Insight you want more information on. For example: "DocumentLatency" or "LCPBreakdown"',
         required: true,
       },
     },
@@ -681,7 +684,7 @@ export const commands: Commands = {
         name: 'key',
         type: 'string',
         description:
-          'A key or a combination (e.g., "Enter", "Control+A", "Control++", "Control+Shift+R"). Modifiers: Control, Shift, Alt, Meta (required)',
+          'A key or a combination (e.g., "Enter", "Control+A", "Control++", "Control+Shift+R"). Modifiers: Control, Shift, Alt, Meta',
         required: true,
       },
       includeSnapshot: {
@@ -694,13 +697,14 @@ export const commands: Commands = {
     },
   },
   reload_extension: {
-    description: 'Reloads an unpacked Chrome extension by its ID.',
+    description:
+      'Reloads an unpacked Chrome extension by its ID. (requires flag: --categoryExtensions=true)',
     category: 'Extensions',
     args: {
       id: {
         name: 'id',
         type: 'string',
-        description: 'ID of the extension to reload. (required)',
+        description: 'ID of the extension to reload.',
         required: true,
       },
     },
@@ -713,20 +717,20 @@ export const commands: Commands = {
       width: {
         name: 'width',
         type: 'number',
-        description: 'Page width (required)',
+        description: 'Page width',
         required: true,
       },
       height: {
         name: 'height',
         type: 'number',
-        description: 'Page height (required)',
+        description: 'Page height',
         required: true,
       },
     },
   },
   screencast_start: {
     description:
-      'Starts recording a screencast (video) of the selected page in specified format.',
+      'Starts recording a screencast (video) of the selected page in specified format. (requires flag: --experimentalScreencast=true)',
     category: 'Debugging',
     args: {
       filePath: {
@@ -739,7 +743,8 @@ export const commands: Commands = {
     },
   },
   screencast_stop: {
-    description: 'Stops the active screencast recording on the selected page.',
+    description:
+      'Stops the active screencast recording on the selected page. (requires flag: --experimentalScreencast=true)',
     category: 'Debugging',
     args: {},
   },
@@ -751,7 +756,7 @@ export const commands: Commands = {
         name: 'pageId',
         type: 'number',
         description:
-          'The ID of the page to select. Call list_pages to get available pages. (required)',
+          'The ID of the page to select. Call list_pages to get available pages.',
         required: true,
       },
       bringToFront: {
@@ -771,7 +776,7 @@ export const commands: Commands = {
         name: 'filePath',
         type: 'string',
         description:
-          'A path to a .heapsnapshot file to save the heapsnapshot to. (required)',
+          'A path to a .heapsnapshot file to save the heapsnapshot to.',
         required: true,
       },
     },
@@ -841,14 +846,14 @@ export const commands: Commands = {
     },
   },
   trigger_extension_action: {
-    description: 'Triggers the default action of an extension by its ID.',
+    description:
+      'Triggers the default action of an extension by its ID. (requires flag: --categoryExtensions=true)',
     category: 'Extensions',
     args: {
       id: {
         name: 'id',
         type: 'string',
-        description:
-          'ID of the extension to trigger the action for. (required)',
+        description: 'ID of the extension to trigger the action for.',
         required: true,
       },
     },
@@ -860,7 +865,7 @@ export const commands: Commands = {
       text: {
         name: 'text',
         type: 'string',
-        description: 'The text to type (required)',
+        description: 'The text to type',
         required: true,
       },
       submitKey: {
@@ -873,13 +878,14 @@ export const commands: Commands = {
     },
   },
   uninstall_extension: {
-    description: 'Uninstalls a Chrome extension by its ID.',
+    description:
+      'Uninstalls a Chrome extension by its ID. (requires flag: --categoryExtensions=true)',
     category: 'Extensions',
     args: {
       id: {
         name: 'id',
         type: 'string',
-        description: 'ID of the extension to uninstall. (required)',
+        description: 'ID of the extension to uninstall.',
         required: true,
       },
     },
@@ -892,13 +898,13 @@ export const commands: Commands = {
         name: 'uid',
         type: 'string',
         description:
-          'The uid of the file input element or an element that will open file chooser on the page from the page content snapshot (required)',
+          'The uid of the file input element or an element that will open file chooser on the page from the page content snapshot',
         required: true,
       },
       filePath: {
         name: 'filePath',
         type: 'string',
-        description: 'The local path of the file to upload (required)',
+        description: 'The local path of the file to upload',
         required: true,
       },
       includeSnapshot: {

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -31,7 +31,38 @@ export const commands: Commands = {
         name: 'uid',
         type: 'string',
         description:
-          'The uid of an element on the page from the page content snapshot',
+          'The uid of an element on the page from the page content snapshot (required)',
+        required: true,
+      },
+      dblClick: {
+        name: 'dblClick',
+        type: 'boolean',
+        description: 'Set to true for double clicks. Default is false.',
+        required: false,
+      },
+      includeSnapshot: {
+        name: 'includeSnapshot',
+        type: 'boolean',
+        description:
+          'Whether to include a snapshot in the response. Default is false.',
+        required: false,
+      },
+    },
+  },
+  click_at: {
+    description: 'Clicks at the provided coordinates',
+    category: 'Input automation',
+    args: {
+      x: {
+        name: 'x',
+        type: 'number',
+        description: 'The x coordinate (required)',
+        required: true,
+      },
+      y: {
+        name: 'y',
+        type: 'number',
+        description: 'The y coordinate (required)',
         required: true,
       },
       dblClick: {
@@ -58,7 +89,7 @@ export const commands: Commands = {
         name: 'pageId',
         type: 'number',
         description:
-          'The ID of the page to close. Call list_pages to list pages.',
+          'The ID of the page to close. Call list_pages to list pages. (required)',
         required: true,
       },
     },
@@ -70,13 +101,13 @@ export const commands: Commands = {
       from_uid: {
         name: 'from_uid',
         type: 'string',
-        description: 'The uid of the element to drag',
+        description: 'The uid of the element to drag (required)',
         required: true,
       },
       to_uid: {
         name: 'to_uid',
         type: 'string',
-        description: 'The uid of the element to drop into',
+        description: 'The uid of the element to drop into (required)',
         required: true,
       },
       includeSnapshot: {
@@ -146,7 +177,7 @@ export const commands: Commands = {
         name: 'function',
         type: 'string',
         description:
-          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`\n',
+          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`\n (required)',
         required: true,
       },
       args: {
@@ -164,6 +195,25 @@ export const commands: Commands = {
       },
     },
   },
+  execute_webmcp_tool: {
+    description: 'Executes a WebMCP tool exposed by the page.',
+    category: 'Debugging',
+    args: {
+      toolName: {
+        name: 'toolName',
+        type: 'string',
+        description: 'The name of the WebMCP tool to execute (required)',
+        required: true,
+      },
+      input: {
+        name: 'input',
+        type: 'string',
+        description:
+          'The JSON-stringified parameters to pass to the WebMCP tool',
+        required: false,
+      },
+    },
+  },
   fill: {
     description:
       'Type text into an input, text area or select an option from a <select> element.',
@@ -173,13 +223,13 @@ export const commands: Commands = {
         name: 'uid',
         type: 'string',
         description:
-          'The uid of an element on the page from the page content snapshot',
+          'The uid of an element on the page from the page content snapshot (required)',
         required: true,
       },
       value: {
         name: 'value',
         type: 'string',
-        description: 'The value to fill in',
+        description: 'The value to fill in (required)',
         required: true,
       },
       includeSnapshot: {
@@ -200,8 +250,33 @@ export const commands: Commands = {
         name: 'msgid',
         type: 'number',
         description:
-          'The msgid of a console message on the page from the listed console messages',
+          'The msgid of a console message on the page from the listed console messages (required)',
         required: true,
+      },
+    },
+  },
+  get_memory_snapshot_details: {
+    description:
+      'Loads a memory heapsnapshot and returns all available information including statistics, static data, and aggregated node information. Supports pagination for aggregates.',
+    category: 'Memory',
+    args: {
+      filePath: {
+        name: 'filePath',
+        type: 'string',
+        description: 'A path to a .heapsnapshot file to read. (required)',
+        required: true,
+      },
+      pageIdx: {
+        name: 'pageIdx',
+        type: 'number',
+        description: 'The page index for pagination of aggregates.',
+        required: false,
+      },
+      pageSize: {
+        name: 'pageSize',
+        type: 'number',
+        description: 'The page size for pagination of aggregates.',
+        required: false,
       },
     },
   },
@@ -233,6 +308,38 @@ export const commands: Commands = {
       },
     },
   },
+  get_nodes_by_class: {
+    description:
+      'Loads a memory heapsnapshot and returns instances of a specific class with their stable IDs.',
+    category: 'Memory',
+    args: {
+      filePath: {
+        name: 'filePath',
+        type: 'string',
+        description: 'A path to a .heapsnapshot file to read. (required)',
+        required: true,
+      },
+      uid: {
+        name: 'uid',
+        type: 'number',
+        description:
+          'The unique UID for the class, obtained from aggregates listing. (required)',
+        required: true,
+      },
+      pageIdx: {
+        name: 'pageIdx',
+        type: 'number',
+        description: 'The page index for pagination.',
+        required: false,
+      },
+      pageSize: {
+        name: 'pageSize',
+        type: 'number',
+        description: 'The page size for pagination.',
+        required: false,
+      },
+    },
+  },
   handle_dialog: {
     description:
       'If a browser dialog was opened, use this command to handle it',
@@ -241,7 +348,7 @@ export const commands: Commands = {
       action: {
         name: 'action',
         type: 'string',
-        description: 'Whether to dismiss or accept the dialog',
+        description: 'Whether to dismiss or accept the dialog (required)',
         required: true,
         enum: ['accept', 'dismiss'],
       },
@@ -261,7 +368,7 @@ export const commands: Commands = {
         name: 'uid',
         type: 'string',
         description:
-          'The uid of an element on the page from the page content snapshot',
+          'The uid of an element on the page from the page content snapshot (required)',
         required: true,
       },
       includeSnapshot: {
@@ -270,6 +377,19 @@ export const commands: Commands = {
         description:
           'Whether to include a snapshot in the response. Default is false.',
         required: false,
+      },
+    },
+  },
+  install_extension: {
+    description: 'Installs a Chrome extension from the given path.',
+    category: 'Extensions',
+    args: {
+      path: {
+        name: 'path',
+        type: 'string',
+        description:
+          'Absolute path to the unpacked extension folder. (required)',
+        required: true,
       },
     },
   },
@@ -339,6 +459,12 @@ export const commands: Commands = {
       },
     },
   },
+  list_extensions: {
+    description:
+      'Lists all the Chrome extensions installed in the browser. This includes their name, ID, version, and enabled status.',
+    category: 'Extensions',
+    args: {},
+  },
   list_network_requests: {
     description:
       'List all requests for the currently selected page since the last navigation.',
@@ -379,6 +505,24 @@ export const commands: Commands = {
     description: 'Get a list of pages open in the browser.',
     category: 'Navigation automation',
     args: {},
+  },
+  list_webmcp_tools: {
+    description: 'Lists all WebMCP tools the page exposes.',
+    category: 'Debugging',
+    args: {},
+  },
+  load_memory_snapshot: {
+    description:
+      'Loads a memory heapsnapshot and returns snapshot summary stats.',
+    category: 'Memory',
+    args: {
+      filePath: {
+        name: 'filePath',
+        type: 'string',
+        description: 'A path to a .heapsnapshot file to read. (required)',
+        required: true,
+      },
+    },
   },
   navigate_page: {
     description:
@@ -437,7 +581,7 @@ export const commands: Commands = {
       url: {
         name: 'url',
         type: 'string',
-        description: 'URL to load in a new page.',
+        description: 'URL to load in a new page. (required)',
         required: true,
       },
       background: {
@@ -472,14 +616,14 @@ export const commands: Commands = {
         name: 'insightSetId',
         type: 'string',
         description:
-          'The id for the specific insight set. Only use the ids given in the "Available insight sets" list.',
+          'The id for the specific insight set. Only use the ids given in the "Available insight sets" list. (required)',
         required: true,
       },
       insightName: {
         name: 'insightName',
         type: 'string',
         description:
-          'The name of the Insight you want more information on. For example: "DocumentLatency" or "LCPBreakdown"',
+          'The name of the Insight you want more information on. For example: "DocumentLatency" or "LCPBreakdown" (required)',
         required: true,
       },
     },
@@ -537,7 +681,7 @@ export const commands: Commands = {
         name: 'key',
         type: 'string',
         description:
-          'A key or a combination (e.g., "Enter", "Control+A", "Control++", "Control+Shift+R"). Modifiers: Control, Shift, Alt, Meta',
+          'A key or a combination (e.g., "Enter", "Control+A", "Control++", "Control+Shift+R"). Modifiers: Control, Shift, Alt, Meta (required)',
         required: true,
       },
       includeSnapshot: {
@@ -549,6 +693,18 @@ export const commands: Commands = {
       },
     },
   },
+  reload_extension: {
+    description: 'Reloads an unpacked Chrome extension by its ID.',
+    category: 'Extensions',
+    args: {
+      id: {
+        name: 'id',
+        type: 'string',
+        description: 'ID of the extension to reload. (required)',
+        required: true,
+      },
+    },
+  },
   resize_page: {
     description:
       "Resizes the selected page's window so that the page has specified dimension",
@@ -557,16 +713,35 @@ export const commands: Commands = {
       width: {
         name: 'width',
         type: 'number',
-        description: 'Page width',
+        description: 'Page width (required)',
         required: true,
       },
       height: {
         name: 'height',
         type: 'number',
-        description: 'Page height',
+        description: 'Page height (required)',
         required: true,
       },
     },
+  },
+  screencast_start: {
+    description:
+      'Starts recording a screencast (video) of the selected page in specified format.',
+    category: 'Debugging',
+    args: {
+      filePath: {
+        name: 'filePath',
+        type: 'string',
+        description:
+          'Output file path (.webm,.mp4 are supported). Uses mkdtemp to generate a unique path if not provided.',
+        required: false,
+      },
+    },
+  },
+  screencast_stop: {
+    description: 'Stops the active screencast recording on the selected page.',
+    category: 'Debugging',
+    args: {},
   },
   select_page: {
     description: 'Select a page as a context for future tool calls.',
@@ -576,7 +751,7 @@ export const commands: Commands = {
         name: 'pageId',
         type: 'number',
         description:
-          'The ID of the page to select. Call list_pages to get available pages.',
+          'The ID of the page to select. Call list_pages to get available pages. (required)',
         required: true,
       },
       bringToFront: {
@@ -596,7 +771,7 @@ export const commands: Commands = {
         name: 'filePath',
         type: 'string',
         description:
-          'A path to a .heapsnapshot file to save the heapsnapshot to.',
+          'A path to a .heapsnapshot file to save the heapsnapshot to. (required)',
         required: true,
       },
     },
@@ -665,6 +840,19 @@ export const commands: Commands = {
       },
     },
   },
+  trigger_extension_action: {
+    description: 'Triggers the default action of an extension by its ID.',
+    category: 'Extensions',
+    args: {
+      id: {
+        name: 'id',
+        type: 'string',
+        description:
+          'ID of the extension to trigger the action for. (required)',
+        required: true,
+      },
+    },
+  },
   type_text: {
     description: 'Type text using keyboard into a previously focused input',
     category: 'Input automation',
@@ -672,7 +860,7 @@ export const commands: Commands = {
       text: {
         name: 'text',
         type: 'string',
-        description: 'The text to type',
+        description: 'The text to type (required)',
         required: true,
       },
       submitKey: {
@@ -684,6 +872,18 @@ export const commands: Commands = {
       },
     },
   },
+  uninstall_extension: {
+    description: 'Uninstalls a Chrome extension by its ID.',
+    category: 'Extensions',
+    args: {
+      id: {
+        name: 'id',
+        type: 'string',
+        description: 'ID of the extension to uninstall. (required)',
+        required: true,
+      },
+    },
+  },
   upload_file: {
     description: 'Upload a file through a provided element.',
     category: 'Input automation',
@@ -692,13 +892,13 @@ export const commands: Commands = {
         name: 'uid',
         type: 'string',
         description:
-          'The uid of the file input element or an element that will open file chooser on the page from the page content snapshot',
+          'The uid of the file input element or an element that will open file chooser on the page from the page content snapshot (required)',
         required: true,
       },
       filePath: {
         name: 'filePath',
         type: 'string',
-        description: 'The local path of the file to upload',
+        description: 'The local path of the file to upload (required)',
         required: true,
       },
       includeSnapshot: {

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -237,9 +237,10 @@ export const cliOptions = {
     describe:
       'Set to true to include tools related to extensions. Note: This feature is currently only supported with a pipe connection. autoConnect, browserUrl, and wsEndpoint are not supported with this feature until 149 will be released.',
   },
-  categoryInPageTools: {
+  categoryExperimentalInPage: {
     type: 'boolean',
     hidden: true,
+    default: false,
     describe:
       'Set to true to enable tools exposed by the inspected page itself',
   },

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -49,6 +49,15 @@ delete startCliOptions.autoConnect;
 delete startCliOptions.viewport;
 
 // Change the defaults for the CLI.
+delete startCliOptions.experimentalStructuredContent;
+delete startCliOptions.experimentalInteropTools;
+delete startCliOptions.experimentalPageIdRouting;
+if (!('default' in cliOptions.headless)) {
+  throw new Error('headless cli option unexpectedly does not have a default');
+}
+if ('default' in cliOptions.isolated) {
+  throw new Error('isolated cli option unexpectedly has a default');
+}
 startCliOptions.headless!.default = true;
 startCliOptions.isolated!.description =
   'If specified, creates a temporary user-data-dir that is automatically cleaned up after the browser is closed. Defaults to true unless userDataDir is provided.';

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -47,29 +47,12 @@ const startCliOptions = {
 delete startCliOptions.autoConnect;
 // Missing CLI serialization.
 delete startCliOptions.viewport;
-// CLI is generated based on the default tool definitions. To enable conditional
-// tools, they need to be enabled during CLI generation.
-delete startCliOptions.experimentalPageIdRouting;
-delete startCliOptions.experimentalVision;
-delete startCliOptions.experimentalWebmcp;
-delete startCliOptions.experimentalInteropTools;
-delete startCliOptions.experimentalScreencast;
-delete startCliOptions.categoryEmulation;
-delete startCliOptions.categoryPerformance;
-delete startCliOptions.categoryNetwork;
-delete startCliOptions.categoryExtensions;
-// Always on in CLI.
-delete startCliOptions.experimentalStructuredContent;
-// Change the defaults.
-if (!('default' in cliOptions.headless)) {
-  throw new Error('headless cli option unexpectedly does not have a default');
-}
-if ('default' in cliOptions.isolated) {
-  throw new Error('isolated cli option unexpectedly has a default');
-}
+
+// Change the defaults for the CLI.
 startCliOptions.headless!.default = true;
 startCliOptions.isolated!.description =
   'If specified, creates a temporary user-data-dir that is automatically cleaned up after the browser is closed. Defaults to true unless userDataDir is provided.';
+startCliOptions.categoryExtensions!.default = true;
 
 const y = yargs(hideBin(process.argv))
   .scriptName('chrome-devtools')

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,20 +24,15 @@ import {
   ListRootsResultSchema,
   RootsListChangedNotificationSchema,
 } from './third_party/index.js';
-import {
-  ToolCategory,
-  labels,
-  OFF_BY_DEFAULT_CATEGORIES,
-} from './tools/categories.js';
+import type {ToolCategory} from './tools/categories.js';
+import {labels, OFF_BY_DEFAULT_CATEGORIES} from './tools/categories.js';
 import type {DefinedPageTool, ToolDefinition} from './tools/ToolDefinition.js';
 import {pageIdSchema} from './tools/ToolDefinition.js';
 import {createTools} from './tools/tools.js';
 import {VERSION} from './version.js';
 
 export function buildFlag(category: ToolCategory) {
-  return category === ToolCategory.IN_PAGE
-    ? 'categoryInPageTools'
-    : `category${category.charAt(0).toUpperCase() + category.slice(1)}`;
+  return `category${category.charAt(0).toUpperCase() + category.slice(1)}`;
 }
 
 function buildDisabledMessage(

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,14 +34,6 @@ import {pageIdSchema} from './tools/ToolDefinition.js';
 import {createTools} from './tools/tools.js';
 import {VERSION} from './version.js';
 
-export const CONDITION_TO_FLAG: Record<string, string> = {
-  computerVision: 'experimentalVision',
-  experimentalMemory: 'experimentalMemory',
-  experimentalInteropTools: 'experimentalInteropTools',
-  screencast: 'experimentalScreencast',
-  experimentalWebmcp: 'experimentalWebmcp',
-};
-
 export function buildFlag(category: ToolCategory) {
   return category === ToolCategory.IN_PAGE
     ? 'categoryInPageTools'
@@ -88,9 +80,8 @@ function getConditionStatus(
   condition: string,
   serverArgs: ReturnType<typeof parseArguments>,
 ): {conditionFlag?: string; disabled: boolean} {
-  const experimentalFlag = CONDITION_TO_FLAG[condition];
-  if (experimentalFlag && !serverArgs[experimentalFlag]) {
-    return {conditionFlag: experimentalFlag, disabled: true};
+  if (condition && !serverArgs[condition]) {
+    return {conditionFlag: condition, disabled: true};
   }
 
   return {disabled: false};

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,13 +34,19 @@ import {pageIdSchema} from './tools/ToolDefinition.js';
 import {createTools} from './tools/tools.js';
 import {VERSION} from './version.js';
 
-const CONDITION_TO_FLAG: Record<string, string> = {
+export const CONDITION_TO_FLAG: Record<string, string> = {
   computerVision: 'experimentalVision',
   experimentalMemory: 'experimentalMemory',
   experimentalInteropTools: 'experimentalInteropTools',
   screencast: 'experimentalScreencast',
   experimentalWebmcp: 'experimentalWebmcp',
 };
+
+export function buildFlag(category: ToolCategory) {
+  return category === ToolCategory.IN_PAGE
+    ? 'categoryInPageTools'
+    : `category${category.charAt(0).toUpperCase() + category.slice(1)}`;
+}
 
 function buildDisabledMessage(
   toolName: string,
@@ -58,10 +64,7 @@ function getCategoryStatus(
   category: ToolCategory,
   serverArgs: ReturnType<typeof parseArguments>,
 ): {categoryFlag?: string; disabled: boolean} {
-  const categoryFlag =
-    category === ToolCategory.IN_PAGE
-      ? 'categoryInPageTools'
-      : `category${category.charAt(0).toUpperCase() + category.slice(1)}`;
+  const categoryFlag = buildFlag(category);
 
   const flagValue = serverArgs[categoryFlag];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,120 @@ import {
   ListRootsResultSchema,
   RootsListChangedNotificationSchema,
 } from './third_party/index.js';
-import {ToolCategory} from './tools/categories.js';
+import {
+  ToolCategory,
+  labels,
+  OFF_BY_DEFAULT_CATEGORIES,
+} from './tools/categories.js';
 import type {DefinedPageTool, ToolDefinition} from './tools/ToolDefinition.js';
 import {pageIdSchema} from './tools/ToolDefinition.js';
 import {createTools} from './tools/tools.js';
 import {VERSION} from './version.js';
+
+const CONDITION_TO_FLAG: Record<string, string> = {
+  computerVision: 'experimentalVision',
+  experimentalMemory: 'experimentalMemory',
+  experimentalInteropTools: 'experimentalInteropTools',
+  screencast: 'experimentalScreencast',
+  experimentalWebmcp: 'experimentalWebmcp',
+};
+
+function buildDisabledMessage(
+  toolName: string,
+  flag: string,
+  categoryLabel?: string,
+): string {
+  const reason = categoryLabel
+    ? `is in category ${categoryLabel} which`
+    : `requires experimental feature ${flag} and`;
+
+  return `Tool ${toolName} ${reason} is currently disabled. Enable it by running chrome-devtools start ${flag}=true. For more information check the README.`;
+}
+
+function getCategoryStatus(
+  category: ToolCategory,
+  serverArgs: ReturnType<typeof parseArguments>,
+): {categoryFlag?: string; disabled: boolean} {
+  const categoryFlag =
+    category === ToolCategory.IN_PAGE
+      ? 'categoryInPageTools'
+      : `category${category.charAt(0).toUpperCase() + category.slice(1)}`;
+
+  const flagValue = serverArgs[categoryFlag];
+
+  const isDisabled = OFF_BY_DEFAULT_CATEGORIES.includes(category)
+    ? !flagValue
+    : flagValue === false;
+
+  if (isDisabled) {
+    return {
+      categoryFlag,
+      disabled: true,
+    };
+  }
+
+  return {
+    disabled: false,
+  };
+}
+
+function getConditionStatus(
+  condition: string,
+  serverArgs: ReturnType<typeof parseArguments>,
+): {conditionFlag?: string; disabled: boolean} {
+  const experimentalFlag = CONDITION_TO_FLAG[condition];
+  if (experimentalFlag && !serverArgs[experimentalFlag]) {
+    return {conditionFlag: experimentalFlag, disabled: true};
+  }
+
+  return {disabled: false};
+}
+
+function getToolStatusInfo(
+  tool: ToolDefinition | DefinedPageTool,
+  serverArgs: ReturnType<typeof parseArguments>,
+): {disabled: boolean; reason?: string} {
+  const category = tool.annotations.category;
+  const categoryCheck = getCategoryStatus(category, serverArgs);
+
+  if (category && categoryCheck.disabled) {
+    if (!categoryCheck.categoryFlag) {
+      throw new Error(
+        'when the category is disabled there should always be a flag set',
+      );
+    }
+
+    return {
+      disabled: true,
+      reason: buildDisabledMessage(
+        tool.name,
+        `--${categoryCheck.categoryFlag}`,
+        labels[category!],
+      ),
+    };
+  }
+
+  for (const condition of tool.annotations.conditions || []) {
+    const conditionCheck = getConditionStatus(condition, serverArgs);
+    if (conditionCheck.disabled) {
+      if (!conditionCheck.conditionFlag) {
+        throw new Error(
+          'when the condition is disabled there should always be a flag set',
+        );
+      }
+
+      return {
+        disabled: true,
+        reason: buildDisabledMessage(
+          tool.name,
+          `--${conditionCheck.conditionFlag}`,
+        ),
+      };
+    }
+  }
+
+  return {disabled: false};
+}
 
 export async function createMcpServer(
   serverArgs: ReturnType<typeof parseArguments>,
@@ -143,66 +252,15 @@ export async function createMcpServer(
   const toolMutex = new Mutex();
 
   function registerTool(tool: ToolDefinition | DefinedPageTool): void {
-    if (
-      tool.annotations.category === ToolCategory.EMULATION &&
-      serverArgs.categoryEmulation === false
-    ) {
+    const {disabled, reason: disabledReason} = getToolStatusInfo(
+      tool,
+      serverArgs,
+    );
+
+    if (disabled && !serverArgs.viaCli) {
       return;
     }
-    if (
-      tool.annotations.category === ToolCategory.PERFORMANCE &&
-      serverArgs.categoryPerformance === false
-    ) {
-      return;
-    }
-    if (
-      tool.annotations.category === ToolCategory.NETWORK &&
-      serverArgs.categoryNetwork === false
-    ) {
-      return;
-    }
-    if (
-      tool.annotations.category === ToolCategory.EXTENSIONS &&
-      serverArgs.categoryExtensions === false
-    ) {
-      return;
-    }
-    if (
-      tool.annotations.category === ToolCategory.IN_PAGE &&
-      !serverArgs.categoryInPageTools
-    ) {
-      return;
-    }
-    if (
-      tool.annotations.conditions?.includes('computerVision') &&
-      !serverArgs.experimentalVision
-    ) {
-      return;
-    }
-    if (
-      tool.annotations.conditions?.includes('experimentalMemory') &&
-      !serverArgs.experimentalMemory
-    ) {
-      return;
-    }
-    if (
-      tool.annotations.conditions?.includes('experimentalInteropTools') &&
-      !serverArgs.experimentalInteropTools
-    ) {
-      return;
-    }
-    if (
-      tool.annotations.conditions?.includes('screencast') &&
-      !serverArgs.experimentalScreencast
-    ) {
-      return;
-    }
-    if (
-      tool.annotations.conditions?.includes('experimentalWebmcp') &&
-      !serverArgs.experimentalWebmcp
-    ) {
-      return;
-    }
+
     const schema =
       'pageScoped' in tool &&
       tool.pageScoped &&
@@ -219,6 +277,18 @@ export async function createMcpServer(
         annotations: tool.annotations,
       },
       async (params): Promise<CallToolResult> => {
+        if (disabledReason) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: disabledReason,
+              },
+            ],
+            isError: true,
+          };
+        }
+
         const guard = await toolMutex.acquire();
         const startTime = Date.now();
         let success = false;

--- a/src/telemetry/flag_usage_metrics.json
+++ b/src/telemetry/flag_usage_metrics.json
@@ -192,11 +192,13 @@
   },
   {
     "name": "category_in_page_tools",
-    "flagType": "boolean"
+    "flagType": "boolean",
+    "isDeprecated": true
   },
   {
     "name": "category_in_page_tools_present",
-    "flagType": "boolean"
+    "flagType": "boolean",
+    "isDeprecated": true
   },
   {
     "name": "clearcut_endpoint_present",
@@ -264,6 +266,14 @@
   },
   {
     "name": "via_cli_present",
+    "flagType": "boolean"
+  },
+  {
+    "name": "category_experimental_in_page_present",
+    "flagType": "boolean"
+  },
+  {
+    "name": "category_experimental_in_page",
     "flagType": "boolean"
   }
 ]

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -12,7 +12,7 @@ export enum ToolCategory {
   NETWORK = 'network',
   DEBUGGING = 'debugging',
   EXTENSIONS = 'extensions',
-  IN_PAGE = 'in-page',
+  IN_PAGE = 'inPageTools',
   MEMORY = 'memory',
 }
 

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -28,4 +28,7 @@ export const labels = {
   [ToolCategory.MEMORY]: 'Memory',
 };
 
-export const OFF_BY_DEFAULT_CATEGORIES = [ToolCategory.EXTENSIONS];
+export const OFF_BY_DEFAULT_CATEGORIES = [
+  ToolCategory.EXTENSIONS,
+  ToolCategory.IN_PAGE,
+];

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -12,7 +12,7 @@ export enum ToolCategory {
   NETWORK = 'network',
   DEBUGGING = 'debugging',
   EXTENSIONS = 'extensions',
-  IN_PAGE = 'inPageTools',
+  IN_PAGE = 'experimentalInPage',
   MEMORY = 'memory',
 }
 

--- a/src/tools/inPage.ts
+++ b/src/tools/inPage.ts
@@ -48,7 +48,7 @@ export const listInPageTools = definePageTool({
   annotations: {
     category: ToolCategory.IN_PAGE,
     readOnlyHint: true,
-    conditions: ['inPageTools'],
+    conditions: ['experimentalInPageTools'],
   },
   schema: {},
   blockedByDialog: false,
@@ -63,7 +63,7 @@ export const executeInPageTool = definePageTool({
   annotations: {
     category: ToolCategory.IN_PAGE,
     readOnlyHint: false,
-    conditions: ['inPageTools'],
+    conditions: ['experimentalInPageTools'],
   },
   schema: {
     toolName: zod.string().describe('The name of the tool to execute'),

--- a/src/tools/inPage.ts
+++ b/src/tools/inPage.ts
@@ -48,7 +48,6 @@ export const listInPageTools = definePageTool({
   annotations: {
     category: ToolCategory.IN_PAGE,
     readOnlyHint: true,
-    conditions: ['experimentalInPageTools'],
   },
   schema: {},
   blockedByDialog: false,
@@ -63,7 +62,6 @@ export const executeInPageTool = definePageTool({
   annotations: {
     category: ToolCategory.IN_PAGE,
     readOnlyHint: false,
-    conditions: ['experimentalInPageTools'],
   },
   schema: {
     toolName: zod.string().describe('The name of the tool to execute'),

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -90,7 +90,7 @@ export const clickAt = definePageTool({
   annotations: {
     category: ToolCategory.INPUT,
     readOnlyHint: false,
-    conditions: ['computerVision'],
+    conditions: ['experimentalVision'],
   },
   schema: {
     x: zod.number().describe('The x coordinate'),

--- a/src/tools/screencast.ts
+++ b/src/tools/screencast.ts
@@ -28,7 +28,7 @@ export const startScreencast = definePageTool(args => ({
   annotations: {
     category: ToolCategory.DEBUGGING,
     readOnlyHint: false,
-    conditions: ['screencast'],
+    conditions: ['experimentalScreencast'],
   },
   schema: {
     filePath: zod
@@ -99,7 +99,7 @@ export const stopScreencast = definePageTool({
   annotations: {
     category: ToolCategory.DEBUGGING,
     readOnlyHint: false,
-    conditions: ['screencast'],
+    conditions: ['experimentalScreencast'],
   },
   schema: {},
   blockedByDialog: false,

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -1111,7 +1111,7 @@ describe('inPage tools', () => {
         t.assert.snapshot?.(JSON.stringify(structuredContent, null, 2));
       },
       undefined,
-      {categoryInPageTools: true} as ParsedArguments,
+      {categoryExperimentalInPage: true} as ParsedArguments,
     );
   });
 
@@ -1162,14 +1162,14 @@ describe('inPage tools', () => {
         );
       },
       undefined,
-      {categoryInPageTools: true} as ParsedArguments,
+      {categoryExperimentalInPage: true} as ParsedArguments,
     );
   }
 
   it('includes in-page tools in list_pages response', async () => {
     await testIncludesInPageTools(async (response, context) => {
       const listPagesDef = listPages({
-        categoryInPageTools: true,
+        categoryExperimentalInPage: true,
       } as ParsedArguments);
       await listPagesDef.handler({params: {}}, response, context);
     }, 'list_pages');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -19,6 +19,8 @@ describe('cli args parsing', () => {
     categoryNetwork: true,
     'category-extensions': false,
     categoryExtensions: false,
+    'category-experimental-in-page': false,
+    categoryExperimentalInPage: false,
     'auto-connect': undefined,
     autoConnect: undefined,
     'performance-crux': true,

--- a/tests/e2e/chrome-devtools-commands.test.ts
+++ b/tests/e2e/chrome-devtools-commands.test.ts
@@ -71,4 +71,39 @@ describe('chrome-devtools', () => {
       'take_screenshot output is unexpected',
     );
   });
+
+  it('fails to invoke list_network_requests when categoryNetwork is disabled', async () => {
+    await runCli(['start', '--categoryNetwork=false'], sessionId);
+
+    const result = await runCli(['list_network_requests'], sessionId);
+    assert.strictEqual(result.status, 0);
+
+    assert(
+      result.stdout.includes(
+        'Tool list_network_requests is in category Network which is currently disabled',
+      ),
+      'error message is unexpected: ' + result.stdout,
+    );
+    assert(
+      result.stdout.includes('chrome-devtools start --categoryNetwork=true'),
+      'restart command suggestion is missing: ' + result.stdout,
+    );
+  });
+
+  it('fails to invoke click_at when experimentalVision is disabled (default)', async () => {
+    await runCli(['start'], sessionId);
+
+    const result = await runCli(['click_at', '100', '100'], sessionId);
+    assert.strictEqual(result.status, 0);
+    assert(
+      result.stdout.includes(
+        'Tool click_at requires experimental feature --experimentalVision and is currently disabled',
+      ),
+      'error message is unexpected: ' + result.stdout,
+    );
+    assert(
+      result.stdout.includes('chrome-devtools start --experimentalVision=true'),
+      'restart command suggestion is miss: ' + result.stdout,
+    );
+  });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -114,7 +114,7 @@ describe('e2e', () => {
         );
         assert.ok(listInPageTools);
       },
-      ['--category-in-page-tools', '--experimental-in-page-tools'],
+      ['--category-experimental-in-page'],
     );
   });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -114,7 +114,7 @@ describe('e2e', () => {
         );
         assert.ok(listInPageTools);
       },
-      ['--category-in-page-tools'],
+      ['--category-in-page-tools', '--experimental-in-page-tools'],
     );
   });
 

--- a/tests/tools/inPage.test.ts
+++ b/tests/tools/inPage.test.ts
@@ -72,7 +72,7 @@ describe('inPage', () => {
           });
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -102,7 +102,7 @@ describe('inPage', () => {
           );
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -131,7 +131,7 @@ describe('inPage', () => {
           );
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -150,7 +150,7 @@ describe('inPage', () => {
           );
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
   });
@@ -215,7 +215,7 @@ describe('inPage', () => {
           );
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -302,7 +302,7 @@ describe('inPage', () => {
           );
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -347,7 +347,7 @@ describe('inPage', () => {
           );
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -486,7 +486,7 @@ describe('inPage', () => {
           );
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -535,7 +535,7 @@ describe('inPage', () => {
           );
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -590,7 +590,7 @@ describe('inPage', () => {
           );
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -647,7 +647,7 @@ describe('inPage', () => {
           stub.restore();
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -713,7 +713,7 @@ describe('inPage', () => {
           stubSnapshot.restore();
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
 
@@ -771,7 +771,7 @@ describe('inPage', () => {
           stubSnapshot.restore();
         },
         undefined,
-        {categoryInPageTools: true} as ParsedArguments,
+        {categoryExperimentalInPage: true} as ParsedArguments,
       );
     });
   });


### PR DESCRIPTION
This PR adds all tools in the CLI interface. When a tool is not enabled the server responds with an error guiding the user on how to enable the category or the experiment.

Closes: https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/1933