### PR TITLE
fix(telemetry): bucketize string length

### DIFF
--- a/src/telemetry/ClearcutLogger.ts
+++ b/src/telemetry/ClearcutLogger.ts
@@ -90,12 +90,25 @@ export function transformArgType(zodType: ZodType): string {
   }
 }
 
+const BUCKETS = [
+  0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000,
+];
+
+function bucketize(value: number): number {
+  for (const bucket of BUCKETS) {
+    if (bucket >= value) {
+      return bucket;
+    }
+  }
+  return BUCKETS[BUCKETS.length - 1];
+}
+
 function transformValue(
   zodType: ZodType,
   value: unknown,
 ): LoggedToolCallArgValue {
   if (zodType === 'ZodString') {
-    return (value as string).length;
+    return bucketize((value as string).length);
   } else if (zodType === 'ZodArray') {
     return (value as unknown[]).length;
   } else {

--- a/tests/telemetry/ClearcutLogger.test.ts
+++ b/tests/telemetry/ClearcutLogger.test.ts
@@ -235,6 +235,35 @@ describe('ClearcutLogger', () => {
       });
     });
 
+    it('bucketizes string lengths correctly', () => {
+      const schema = {
+        str0: zod.string(),
+        str1: zod.string(),
+        str3: zod.string(),
+        str5: zod.string(),
+        str10000: zod.string(),
+        str10001: zod.string(),
+      };
+
+      const params = {
+        str0: '',
+        str1: 'a',
+        str3: 'abc',
+        str5: 'abcde',
+        str10000: 'a'.repeat(10000),
+        str10001: 'a'.repeat(10001),
+      };
+
+      const sanitized = sanitizeParams(params, schema);
+
+      assert.strictEqual(sanitized.str0_length, 0);
+      assert.strictEqual(sanitized.str1_length, 1);
+      assert.strictEqual(sanitized.str3_length, 5); // snaps to 5
+      assert.strictEqual(sanitized.str5_length, 5);
+      assert.strictEqual(sanitized.str10000_length, 10000);
+      assert.strictEqual(sanitized.str10001_length, 10000); // snaps to 10000
+    });
+
     it('throws error for unsupported types', () => {
       const schema = {
         myObj: zod.object({foo: zod.string()}),


### PR DESCRIPTION
Only the string length needs to be bucketized. We can log the array size as-is.