### PR TITLE
test: add tests for checking behavior when dialog is open

### DIFF
--- a/tests/tools/console.test.js.snapshot
+++ b/tests/tools/console.test.js.snapshot
@@ -118,6 +118,47 @@ Learn more:
 reqid=<reqid> data={"corsErrorStatus":{"corsError":"PreflightMissingAllowOriginHeader","failedParameter":""},"isWarning":false,"request":{"url":"http://hostname:port/data.json"},"initiatorOrigin":"","clientSecurityState":{"initiatorIsSecureContext":false,"initiatorIPAddressSpace":"Loopback","localNetworkAccessRequestPolicy":"BlockFromInsecureToMorePrivate"}}
 `;
 
+exports[`console > get_console_message > when dialog is open 1`] = `
+{
+  "dialog": {
+    "type": "alert",
+    "message": "test dialog",
+    "defaultValue": ""
+  },
+  "consoleMessage": {
+    "id": 1,
+    "type": "error",
+    "text": "This is an error",
+    "argsCount": 1,
+    "args": [
+      "This is an error"
+    ],
+    "stackTrace": "at  (VM7:1:9)\\nat  (pptr:;CdpFrame.%3Canonymous%3E%20(<file-path>)\\n--- PendingScript ----------------------\\nat  (pptr:;CdpFrame.%3Canonymous%3E%20(<file-path>)\\nNote: line and column numbers use 1-based indexing"
+  },
+  "pagination": {
+    "currentPage": 0,
+    "totalPages": 1,
+    "hasNextPage": false,
+    "hasPreviousPage": false,
+    "startIndex": 0,
+    "endIndex": 1,
+    "invalidPage": false
+  },
+  "consoleMessages": [
+    {
+      "type": "error",
+      "text": "This is an error",
+      "argsCount": 1,
+      "id": 1
+    }
+  ]
+}
+`;
+
+exports[`console > list_console_messages > issues > when dialog is open 1`] = `
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Console messages\\nShowing 1-1 of 1 (Page 1 of 1).\\nmsgid=1 [log] Pre-dialog message (1 args)"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pagination":{"currentPage":0,"totalPages":1,"hasNextPage":false,"hasPreviousPage":false,"startIndex":0,"endIndex":1,"invalidPage":false},"consoleMessages":[{"type":"log","text":"Pre-dialog message","argsCount":1,"id":1}]}}
+`;
+
 exports[`console > list_console_messages > lists error objects 1`] = `
 ## Console messages
 Showing 1-1 of 1 (Page 1 of 1).

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -7,6 +7,8 @@
 import assert from 'node:assert';
 import {before, describe, it} from 'node:test';
 
+import type {Dialog} from 'puppeteer-core';
+
 import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
 import {loadIssueDescriptions} from '../../src/issue-descriptions.js';
 import {McpResponse} from '../../src/McpResponse.js';
@@ -17,7 +19,11 @@ import {
   listConsoleMessages,
 } from '../../src/tools/console.js';
 import {serverHooks} from '../server.js';
-import {getTextContent, withMcpContext} from '../utils.js';
+import {
+  getTextContent,
+  withMcpContext,
+  stabilizeStructuredContent,
+} from '../utils.js';
 
 describe('console', () => {
   before(async () => {
@@ -160,6 +166,37 @@ describe('console', () => {
               ),
             );
           }
+        });
+      });
+
+      it('when dialog is open', async t => {
+        await withMcpContext(async (response, context) => {
+          const page = context.getSelectedPptrPage();
+          await page.setContent(
+            '<script>console.log("Pre-dialog message")</script>',
+          );
+
+          const dialogPromise = new Promise<Dialog>(resolve => {
+            page.on('dialog', dialog => resolve(dialog));
+          });
+
+          page.evaluate(() => {
+            alert('test dialog');
+          });
+          const dialog = await dialogPromise;
+
+          await listConsoleMessages().handler(
+            {params: {}, page: context.getSelectedMcpPage()},
+            response,
+            context,
+          );
+
+          const result = await response.handle(
+            'list_console_messages',
+            context,
+          );
+          t.assert.snapshot?.(JSON.stringify(result));
+          await dialog.dismiss();
         });
       });
     });
@@ -472,6 +509,45 @@ describe('console', () => {
         const rawText = getTextContent(formattedResponse.content[0]);
 
         t.assert.snapshot?.(rawText);
+      });
+    });
+
+    it('when dialog is open', async t => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+        await page.setContent(
+          '<script>console.error("This is an error")</script>',
+        );
+
+        await listConsoleMessages().handler(
+          {params: {}, page: context.getSelectedMcpPage()},
+          response,
+          context,
+        );
+
+        const dialogPromise = new Promise<Dialog>(resolve => {
+          page.on('dialog', dialog => resolve(dialog));
+        });
+        page.evaluate(() => {
+          alert('test dialog');
+        });
+        const dialog = await dialogPromise;
+
+        await getConsoleMessage.handler(
+          {params: {msgid: 1}, page: context.getSelectedMcpPage()},
+          response,
+          context,
+        );
+
+        const result = await response.handle('get_console_message', context);
+        t.assert.snapshot?.(
+          JSON.stringify(
+            stabilizeStructuredContent(result.structuredContent),
+            null,
+            2,
+          ),
+        );
+        await dialog.dismiss();
       });
     });
   });

--- a/tests/tools/pages.test.js.snapshot
+++ b/tests/tools/pages.test.js.snapshot
@@ -1,3 +1,7 @@
+exports[`pages > close_page > when dialog is open 1`] = `
+{"content":[{"type":"text","text":"## Pages\\n1: about:blank [selected]"}],"structuredContent":{"pages":[{"id":1,"url":"about:blank","selected":true}]}}
+`;
+
 exports[`pages > list_pages > list pages for extension pages with --category-extensions 1`] = `
 ## Pages
 1: about:blank [selected]
@@ -24,4 +28,24 @@ exports[`pages > list_pages > list pages for side panels with --category-extensi
 2: chrome-extension://<extension-id>/sidepanel.html [selected]
 ## Extension Service Workers
 sw-1: chrome-extension://<extension-id>/sw.js
+`;
+
+exports[`pages > list_pages > when dialog is open 1`] = `
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","selected":true}]}}
+`;
+
+exports[`pages > navigate_page > when dialog is open 1`] = `
+{"content":[{"type":"text","text":"Successfully navigated to data:text/html,<div>Navigated</div>.\\n# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: data:text/html,<div>Navigated</div> [selected]"}],"structuredContent":{"message":"Successfully navigated to data:text/html,<div>Navigated</div>.","dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"data:text/html,<div>Navigated</div>","selected":true}]}}
+`;
+
+exports[`pages > new_page with isolatedContext > when dialog is open 1`] = `
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank\\n2: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","selected":false},{"id":2,"url":"about:blank","selected":true}]}}
+`;
+
+exports[`pages > resize > when dialog is open 1`] = `
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","selected":true}]}}
+`;
+
+exports[`pages > select_page > when dialog is open 1`] = `
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","selected":true}]}}
 `;

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -205,6 +205,29 @@ describe('pages', () => {
         } as ParsedArguments,
       );
     });
+
+    it('when dialog is open', async t => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+
+        const dialogPromise = new Promise<Dialog>(resolve => {
+          page.on('dialog', dialog => {
+            resolve(dialog);
+          });
+        });
+
+        page.evaluate(() => {
+          alert('test dialog');
+        });
+        const dialog = await dialogPromise;
+
+        await listPages().handler({params: {}}, response, context);
+
+        const result = await response.handle('list_pages', context);
+        t.assert.snapshot?.(JSON.stringify(result));
+        await dialog.dismiss();
+      });
+    });
   });
   describe('new_page', () => {
     it('create a page', async () => {
@@ -354,6 +377,33 @@ describe('pages', () => {
         assert.ok(page.isClosed());
       });
     });
+
+    it('when dialog is open', async t => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+
+        const dialogPromise = new Promise<Dialog>(resolve => {
+          page.on('dialog', dialog => {
+            resolve(dialog);
+          });
+        });
+
+        page.evaluate(() => {
+          alert('test dialog');
+        });
+        const dialog = await dialogPromise;
+
+        await newPage().handler(
+          {params: {url: 'about:blank'}},
+          response,
+          context,
+        );
+
+        const result = await response.handle('new_page', context);
+        t.assert.snapshot?.(JSON.stringify(result));
+        await dialog.dismiss();
+      });
+    });
   });
 
   it('navigate_page targets the pageId page, not the global selection', async () => {
@@ -424,6 +474,35 @@ describe('pages', () => {
         );
         assert.ok(response.includePages);
         assert.ok(!page.isClosed());
+      });
+    });
+
+    it('when dialog is open', async t => {
+      await withMcpContext(async (response, context) => {
+        const page = await context.newPage();
+        assert.strictEqual(
+          context.getPageById(2),
+          context.getSelectedMcpPage(),
+        );
+        assert.strictEqual(context.getPageById(2), page);
+
+        const dialogPromise = new Promise<void>(resolve => {
+          page.pptrPage.on('dialog', () => resolve());
+        });
+
+        page.pptrPage
+          .evaluate(() => {
+            alert('test dialog');
+          })
+          .catch(() => {
+            // Ignore TargetCloseError when page is closed with open dialog
+          });
+        await dialogPromise;
+
+        await closePage.handler({params: {pageId: 2}}, response, context);
+
+        const result = await response.handle('close_page', context);
+        t.assert.snapshot?.(JSON.stringify(result));
       });
     });
   });
@@ -512,6 +591,29 @@ describe('pages', () => {
           await pageB.evaluate(() => document.hasFocus()),
           true,
         );
+      });
+    });
+
+    it('when dialog is open', async t => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+
+        const dialogPromise = new Promise<Dialog>(resolve => {
+          page.on('dialog', dialog => {
+            resolve(dialog);
+          });
+        });
+
+        page.evaluate(() => {
+          alert('test dialog');
+        });
+        const dialog = await dialogPromise;
+
+        await selectPage.handler({params: {pageId: 1}}, response, context);
+
+        const result = await response.handle('select_page', context);
+        t.assert.snapshot?.(JSON.stringify(result));
+        await dialog.dismiss();
       });
     });
   });
@@ -762,6 +864,32 @@ describe('pages', () => {
         assert.ok(response.includePages);
       });
     });
+
+    it('when dialog is open', async t => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+        const dialogPromise = new Promise<void>(resolve => {
+          page.on('dialog', () => resolve());
+        });
+
+        page.evaluate(() => {
+          alert('test dialog');
+        });
+        await dialogPromise;
+
+        await navigatePage().handler(
+          {
+            params: {url: 'data:text/html,<div>Navigated</div>'},
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+
+        const result = await response.handle('navigate_page', context);
+        t.assert.snapshot?.(JSON.stringify(result));
+      });
+    });
   });
   describe('resize', () => {
     it('resize the page', async () => {
@@ -924,6 +1052,35 @@ describe('pages', () => {
           return [window.innerWidth, window.innerHeight];
         });
         assert.deepStrictEqual(dimensions, [850, 650]);
+      });
+    });
+
+    it('when dialog is open', async t => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+        const dialogPromise = new Promise<Dialog>(resolve => {
+          page.on('dialog', dialog => {
+            resolve(dialog);
+          });
+        });
+
+        page.evaluate(() => {
+          alert('test dialog');
+        });
+        const dialog = await dialogPromise;
+
+        await resizePage.handler(
+          {
+            params: {width: 1600, height: 1400},
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+
+        const result = await response.handle('resize_page', context);
+        t.assert.snapshot?.(JSON.stringify(result));
+        await dialog.dismiss();
       });
     });
   });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -287,6 +287,10 @@ export function stabilizeResponseOutput(text: unknown) {
   const acceptLanguageRegEx = /accept-language:.*\n/g;
   output = output.replaceAll(acceptLanguageRegEx, 'accept-language:<lang>\n');
 
+  // Stabilize URL-encoded file paths
+  const fileUriRegEx = /file%3A%2F%2F%2F[^)\n]+/g;
+  output = output.replaceAll(fileUriRegEx, '<file-path>');
+
   return output;
 }
 


### PR DESCRIPTION
This is the first part of adding tests for checking tool behavior when a dialog is already open (related to #1069)

In future CL, I will be focusing on tools which currently get blocked due to open dialogs. As part of those CLs, proactive rejection of tool execution will be implemented.