### PR TITLE
feat: add Claude plugin executablePath user config

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,11 +2,18 @@
   "name": "chrome-devtools-mcp",
   "version": "0.23.0",
   "description": "Reliable automation, in-depth debugging, and performance analysis in Chrome using Chrome DevTools and Puppeteer",
+  "userConfig": {
+    "executablePath": {
+      "description": "Optional path to a custom Chrome executable. Useful when the system has multiple Chrome installations (e.g. point at the Chrome for Testing binary so the MCP-launched Chrome stays separate from the user's regular Chrome and can be scripted unambiguously by AppleScript / OS automation tools). Leave blank to use the auto-detected stable Chrome.",
+      "sensitive": false
+    }
+  },
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
       "args": [
-        "chrome-devtools-mcp@latest"
+        "chrome-devtools-mcp@latest",
+        "--executablePath=${user_config.executablePath}"
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ Then, install the plugin:
 
 Restart Claude Code to have the MCP server and skills load (check with `/skills`).
 
+To point the plugin at a custom Chrome binary (e.g. [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) so the MCP-launched Chrome has a separate bundle ID from the user's regular Chrome and can be scripted unambiguously by macOS AppleScript), set the plugin's `executablePath` option in your Claude Code settings:
+
+```json
+{
+  "pluginConfigs": {
+    "chrome-devtools-mcp@claude-plugins-official": {
+      "options": {
+        "executablePath": "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+      }
+    }
+  }
+}
+```
+
+Leave `executablePath` blank to use the default behavior where Chrome DevTools MCP auto-detects stable Chrome.
+
 > [!TIP]
 > If the plugin installation fails with a `Failed to clone repository` error (e.g., HTTPS connectivity issues behind a corporate firewall), see the [troubleshooting guide](./docs/troubleshooting.md#claude-code-plugin-installation-fails-with-failed-to-clone-repository) for workarounds, or use the CLI installation method above instead.
 


### PR DESCRIPTION
## Summary

- Add a Claude plugin `executablePath` user config option so users can point the MCP at a custom Chrome binary (e.g. Chrome for Testing) without editing the plugin manifest in their plugin cache.
- Pass the option through with `--executablePath=${user_config.executablePath}`. A blank value keeps the default auto-detected-stable-Chrome behavior.
- Document the Claude Code `pluginConfigs` settings shape, mirroring #1851.

## Motivation

On macOS, when the user's regular Chrome and the MCP-launched Chrome share bundle ID `com.google.Chrome`, AppleScript `tell application "Google Chrome"` becomes ambiguous and OS-automation menu commands (e.g. *Tab → Pin Tab*) silently no-op on the wrong window. Pointing the MCP at `/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing` (bundle ID `com.google.chrome.for.testing`) gives the MCP-launched Chrome a separate AppleScript identity and resolves the conflict — but currently requires patching the plugin manifest in the user's plugin cache, which gets reset on plugin upgrade.

## Testing

- `jq . .claude-plugin/plugin.json` parses cleanly
- `npm run check-format` (eslint + prettier) passes
