### PR TITLE
feat(new_page): support incognito browser contexts

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -254,6 +254,7 @@ export class McpContext implements Context {
   async newPage(
     background?: boolean,
     isolatedContextName?: string,
+    incognito = false,
   ): Promise<McpPage> {
     let page: Page;
     if (isolatedContextName !== undefined) {
@@ -262,6 +263,11 @@ export class McpContext implements Context {
         ctx = await this.browser.createBrowserContext();
         this.#isolatedContexts.set(isolatedContextName, ctx);
       }
+      page = await ctx.newPage();
+    } else if (incognito) {
+      const contextName = `incognito-context-${this.#nextIsolatedContextId++}`;
+      const ctx = await this.browser.createBrowserContext();
+      this.#isolatedContexts.set(contextName, ctx);
       page = await ctx.newPage();
     } else {
       page = await this.browser.newPage({background});

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -594,6 +594,13 @@ export const commands: Commands = {
           'Whether to open the page in the background without bringing it to the front. Default is false (foreground).',
         required: false,
       },
+      incognito: {
+        name: 'incognito',
+        type: 'boolean',
+        description:
+          'Whether to create the page in a fresh incognito browser context. A new context is created for each call and is isolated from all other pages.',
+        required: false,
+      },
       isolatedContext: {
         name: 'isolatedContext',
         type: 'string',

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -181,6 +181,7 @@ export type Context = Readonly<{
   newPage(
     background?: boolean,
     isolatedContextName?: string,
+    incognito?: boolean,
   ): Promise<ContextPage>;
   closePage(pageId: number): Promise<void>;
   selectPage(page: ContextPage): void;

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -168,6 +168,12 @@ export const newPage = defineTool(args => {
         .describe(
           'Whether to open the page in the background without bringing it to the front. Default is false (foreground).',
         ),
+      incognito: zod
+        .boolean()
+        .optional()
+        .describe(
+          'Whether to create the page in a fresh incognito browser context. A new context is created for each call and is isolated from all other pages.',
+        ),
       isolatedContext: zod
         .string()
         .optional()
@@ -190,9 +196,16 @@ export const newPage = defineTool(args => {
     },
     blockedByDialog: false,
     handler: async (request, response, context) => {
+      if (request.params.incognito && request.params.isolatedContext) {
+        throw new Error(
+          'The incognito and isolatedContext parameters are mutually exclusive.',
+        );
+      }
+
       const page = await context.newPage(
         request.params.background,
         request.params.isolatedContext,
+        request.params.incognito,
       );
 
       await navigateWithInterception(

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -275,6 +275,64 @@ describe('pages', () => {
         assert.ok(response.includePages);
       });
     });
+
+    it('creates a page in a fresh incognito context', async () => {
+      await withMcpContext(async (response, context) => {
+        await newPage().handler(
+          {params: {url: 'about:blank', incognito: true}},
+          response,
+          context,
+        );
+        const page = context.getSelectedPptrPage();
+        const isolatedContextName = context.getIsolatedContextName(page);
+        assert.ok(isolatedContextName);
+        assert.ok(isolatedContextName.startsWith('incognito-context-'));
+        assert.ok(response.includePages);
+      });
+    });
+
+    it('creates a new context for each incognito page', async () => {
+      await withMcpContext(async (response, context) => {
+        await newPage().handler(
+          {params: {url: 'about:blank', incognito: true}},
+          response,
+          context,
+        );
+        const page1 = context.getSelectedPptrPage();
+        const isolatedContext1 = context.getIsolatedContextName(page1);
+
+        await newPage().handler(
+          {params: {url: 'about:blank', incognito: true}},
+          response,
+          context,
+        );
+        const page2 = context.getSelectedPptrPage();
+        const isolatedContext2 = context.getIsolatedContextName(page2);
+
+        assert.notStrictEqual(page1.browserContext(), page2.browserContext());
+        assert.notStrictEqual(isolatedContext1, isolatedContext2);
+      });
+    });
+
+    it('throws when incognito and isolatedContext are both provided', async () => {
+      await withMcpContext(async (response, context) => {
+        await assert.rejects(
+          () =>
+            newPage().handler(
+              {
+                params: {
+                  url: 'about:blank',
+                  incognito: true,
+                  isolatedContext: 'session-a',
+                },
+              },
+              response,
+              context,
+            ),
+          /mutually exclusive/,
+        );
+      });
+    });
   });
   describe('new_page with isolatedContext', () => {
     it('creates a page in an isolated context', async () => {


### PR DESCRIPTION
solves #1985

## Summary
This PR adds incognito support to the `new_page` tool by introducing an optional `incognito` boolean parameter.

When `incognito: true` is provided, `new_page` creates a fresh isolated browser context for that page. This improves session isolation for multi-user and auth-sensitive testing scenarios.

## Changes
- Added `incognito?: boolean` to `new_page` tool schema and context API.
- Implemented incognito page creation in `McpContext.newPage(...)` using a fresh browser context per call.
- Added validation to reject using `incognito` and `isolatedContext` together.
- Updated CLI command metadata for `new_page` to include `incognito`.
- Added tool tests covering:
  - incognito context creation,
  - new context per incognito page,
  - mutual-exclusivity validation with `isolatedContext`.

## Notes
- Existing `isolatedContext` behavior remains unchanged.
- This provides browser-context isolation; it does not launch a separate Chrome process/profile.