### PR TITLE
docs: extract WebMCP into its own category

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,15 +505,13 @@ If you run into any issues, checkout our [troubleshooting guide](./docs/troubles
 - **Network** (2 tools)
   - [`get_network_request`](docs/tool-reference.md#get_network_request)
   - [`list_network_requests`](docs/tool-reference.md#list_network_requests)
-- **Debugging** (10 tools)
+- **Debugging** (8 tools)
   - [`evaluate_script`](docs/tool-reference.md#evaluate_script)
   - [`get_console_message`](docs/tool-reference.md#get_console_message)
   - [`lighthouse_audit`](docs/tool-reference.md#lighthouse_audit)
   - [`list_console_messages`](docs/tool-reference.md#list_console_messages)
   - [`take_screenshot`](docs/tool-reference.md#take_screenshot)
   - [`take_snapshot`](docs/tool-reference.md#take_snapshot)
-  - [`execute_webmcp_tool`](docs/tool-reference.md#execute_webmcp_tool)
-  - [`list_webmcp_tools`](docs/tool-reference.md#list_webmcp_tools)
   - [`screencast_start`](docs/tool-reference.md#screencast_start)
   - [`screencast_stop`](docs/tool-reference.md#screencast_stop)
 - **Memory** (4 tools)
@@ -527,6 +525,9 @@ If you run into any issues, checkout our [troubleshooting guide](./docs/troubles
   - [`reload_extension`](docs/tool-reference.md#reload_extension)
   - [`trigger_extension_action`](docs/tool-reference.md#trigger_extension_action)
   - [`uninstall_extension`](docs/tool-reference.md#uninstall_extension)
+- **WebMCP** (2 tools)
+  - [`execute_webmcp_tool`](docs/tool-reference.md#execute_webmcp_tool)
+  - [`list_webmcp_tools`](docs/tool-reference.md#list_webmcp_tools)
 
 <!-- END AUTO GENERATED TOOLS -->
 
@@ -603,7 +604,7 @@ The Chrome DevTools MCP server supports the following configuration option:
   Path to ffmpeg executable for screencast recording.
   - **Type:** string
 
-- **`--experimentalWebmcp`/ `--experimental-webmcp`**
+- **`--categoryExperimentalWebmcp`/ `--category-experimental-webmcp`**
   Set to true to enable debugging WebMCP tools. Requires Chrome 149+ with the following flags: `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`
   - **Type:** boolean
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -30,15 +30,13 @@
 - **[Network](#network)** (2 tools)
   - [`get_network_request`](#get_network_request)
   - [`list_network_requests`](#list_network_requests)
-- **[Debugging](#debugging)** (10 tools)
+- **[Debugging](#debugging)** (8 tools)
   - [`evaluate_script`](#evaluate_script)
   - [`get_console_message`](#get_console_message)
   - [`lighthouse_audit`](#lighthouse_audit)
   - [`list_console_messages`](#list_console_messages)
   - [`take_screenshot`](#take_screenshot)
   - [`take_snapshot`](#take_snapshot)
-  - [`execute_webmcp_tool`](#execute_webmcp_tool)
-  - [`list_webmcp_tools`](#list_webmcp_tools)
   - [`screencast_start`](#screencast_start)
   - [`screencast_stop`](#screencast_stop)
 - **[Memory](#memory)** (4 tools)
@@ -52,6 +50,9 @@
   - [`reload_extension`](#reload_extension)
   - [`trigger_extension_action`](#trigger_extension_action)
   - [`uninstall_extension`](#uninstall_extension)
+- **[WebMCP](#webmcp)** (2 tools)
+  - [`execute_webmcp_tool`](#execute_webmcp_tool)
+  - [`list_webmcp_tools`](#list_webmcp_tools)
 
 ## Input automation
 
@@ -417,25 +418,6 @@ in the DevTools Elements panel (if any).
 
 ---
 
-### `execute_webmcp_tool`
-
-**Description:** Executes a WebMCP tool exposed by the page. (requires flag: --experimentalWebmcp=true)
-
-**Parameters:**
-
-- **toolName** (string) **(required)**: The name of the WebMCP tool to execute
-- **input** (string) _(optional)_: The JSON-stringified parameters to pass to the WebMCP tool
-
----
-
-### `list_webmcp_tools`
-
-**Description:** Lists all WebMCP tools the page exposes. (requires flag: --experimentalWebmcp=true)
-
-**Parameters:** None
-
----
-
 ### `screencast_start`
 
 **Description:** Starts recording a screencast (video) of the selected page in specified format. (requires flag: --experimentalScreencast=true)
@@ -503,7 +485,7 @@ in the DevTools Elements panel (if any).
 
 ## Extensions
 
-> NOTE: Extensions are not active by default. Use the '--categoryExtensions' flag
+> NOTE: The Extensions category is not active by default. Use the '--categoryExtensions' flag.
 
 ### `install_extension`
 
@@ -550,5 +532,28 @@ in the DevTools Elements panel (if any).
 **Parameters:**
 
 - **id** (string) **(required)**: ID of the extension to uninstall.
+
+---
+
+## WebMCP
+
+> NOTE: The WebMCP category is not active by default. Use the '--categoryExperimentalWebmcp' flag.
+
+### `execute_webmcp_tool`
+
+**Description:** Executes a WebMCP tool exposed by the page. (requires flag: --categoryExperimentalWebmcp=true)
+
+**Parameters:**
+
+- **toolName** (string) **(required)**: The name of the WebMCP tool to execute
+- **input** (string) _(optional)_: The JSON-stringified parameters to pass to the WebMCP tool
+
+---
+
+### `list_webmcp_tools`
+
+**Description:** Lists all WebMCP tools the page exposes. (requires flag: --categoryExperimentalWebmcp=true)
+
+**Parameters:** None
 
 ---

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -373,7 +373,7 @@ async function generateReference(
     if (OFF_BY_DEFAULT_CATEGORIES.includes(category)) {
       const flagName = `--${buildFlag(category)}`;
 
-      markdown += `> NOTE: ${categoryName} are not active by default. Use the '${flagName}' flag\n\n`;
+      markdown += `> NOTE: The ${categoryName} category is not active by default. Use the '${flagName}' flag.\n\n`;
     }
 
     // Sort tools within category

--- a/skills/chrome-devtools-cli/SKILL.md
+++ b/skills/chrome-devtools-cli/SKILL.md
@@ -141,7 +141,7 @@ Experimental tools are disabled by default. Enable them with the corresponding f
 chrome-devtools click_at 100 200 # Clicks at the provided coordinates (requires --experimentalVision=true)
 chrome-devtools screencast_start # Starts a screencast recording (requires --experimentalScreencast=true and ffmpeg)
 chrome-devtools screencast_stop # Stops the active screencast
-chrome-devtools list_webmcp_tools # List all WebMCP tools (requires --experimentalWebmcp=true)
+chrome-devtools list_webmcp_tools # List all WebMCP tools (requires --categoryExperimentalWebmcp=true)
 ```
 
 ## Service Management

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -560,7 +560,7 @@ export class McpResponse implements Response {
     }
 
     let webmcpTools: WebMCPTool[] | undefined;
-    if (this.#listWebMcpTools && this.#args.experimentalWebmcp) {
+    if (this.#listWebMcpTools && this.#args.categoryExperimentalWebmcp) {
       const page = this.#page ?? context.getSelectedMcpPage();
       webmcpTools = page.getWebMcpTools();
     }

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -198,8 +198,8 @@ export const commands: Commands = {
   },
   execute_webmcp_tool: {
     description:
-      'Executes a WebMCP tool exposed by the page. (requires flag: --experimentalWebmcp=true)',
-    category: 'Debugging',
+      'Executes a WebMCP tool exposed by the page. (requires flag: --categoryExperimentalWebmcp=true)',
+    category: 'WebMCP',
     args: {
       toolName: {
         name: 'toolName',
@@ -510,8 +510,8 @@ export const commands: Commands = {
   },
   list_webmcp_tools: {
     description:
-      'Lists all WebMCP tools the page exposes. (requires flag: --experimentalWebmcp=true)',
-    category: 'Debugging',
+      'Lists all WebMCP tools the page exposes. (requires flag: --categoryExperimentalWebmcp=true)',
+    category: 'WebMCP',
     args: {},
   },
   load_memory_snapshot: {

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -200,7 +200,7 @@ export const cliOptions = {
     describe: 'Path to ffmpeg executable for screencast recording.',
     implies: 'experimentalScreencast',
   },
-  experimentalWebmcp: {
+  categoryExperimentalWebmcp: {
     type: 'boolean',
     describe:
       'Set to true to enable debugging WebMCP tools. Requires Chrome 149+ with the following flags: `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`',

--- a/src/telemetry/flag_usage_metrics.json
+++ b/src/telemetry/flag_usage_metrics.json
@@ -246,11 +246,13 @@
   },
   {
     "name": "experimental_webmcp",
-    "flagType": "boolean"
+    "flagType": "boolean",
+    "isDeprecated": true
   },
   {
     "name": "experimental_webmcp_present",
-    "flagType": "boolean"
+    "flagType": "boolean",
+    "isDeprecated": true
   },
   {
     "name": "redact_network_headers",
@@ -274,6 +276,14 @@
   },
   {
     "name": "category_experimental_in_page",
+    "flagType": "boolean"
+  },
+  {
+    "name": "category_experimental_webmcp_present",
+    "flagType": "boolean"
+  },
+  {
+    "name": "category_experimental_webmcp",
     "flagType": "boolean"
   }
 ]

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -14,6 +14,7 @@ export enum ToolCategory {
   EXTENSIONS = 'extensions',
   IN_PAGE = 'experimentalInPage',
   MEMORY = 'memory',
+  WEBMCP = 'experimentalWebmcp',
 }
 
 export const labels = {
@@ -26,9 +27,11 @@ export const labels = {
   [ToolCategory.EXTENSIONS]: 'Extensions',
   [ToolCategory.IN_PAGE]: 'In-page tools',
   [ToolCategory.MEMORY]: 'Memory',
+  [ToolCategory.WEBMCP]: 'WebMCP',
 };
 
 export const OFF_BY_DEFAULT_CATEGORIES = [
   ToolCategory.EXTENSIONS,
   ToolCategory.IN_PAGE,
+  ToolCategory.WEBMCP,
 ];

--- a/src/tools/webmcp.ts
+++ b/src/tools/webmcp.ts
@@ -13,9 +13,8 @@ export const listWebMcpTools = definePageTool({
   name: 'list_webmcp_tools',
   description: `Lists all WebMCP tools the page exposes.`,
   annotations: {
-    category: ToolCategory.DEBUGGING,
+    category: ToolCategory.WEBMCP,
     readOnlyHint: true,
-    conditions: ['experimentalWebmcp'],
   },
   schema: {},
   blockedByDialog: false,
@@ -28,9 +27,8 @@ export const executeWebMcpTool = definePageTool({
   name: 'execute_webmcp_tool',
   description: `Executes a WebMCP tool exposed by the page.`,
   annotations: {
-    category: ToolCategory.DEBUGGING,
+    category: ToolCategory.WEBMCP,
     readOnlyHint: false,
-    conditions: ['experimentalWebmcp'],
   },
   schema: {
     toolName: zod.string().describe('The name of the WebMCP tool to execute'),

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -1514,7 +1514,7 @@ describe('webmcp', () => {
   it('includes webmcp tools in list_pages response', async t => {
     await testIncludesWebmcpTools(
       t,
-      {experimentalWebmcp: true} as ParsedArguments,
+      {categoryExperimentalWebmcp: true} as ParsedArguments,
       async (response, context) => {
         await listPages().handler({params: {}}, response, context);
       },
@@ -1525,7 +1525,7 @@ describe('webmcp', () => {
   it('includes webmcp tools in select_page response', async t => {
     await testIncludesWebmcpTools(
       t,
-      {experimentalWebmcp: true} as ParsedArguments,
+      {categoryExperimentalWebmcp: true} as ParsedArguments,
       async (response, context) => {
         const pageId =
           context.getPageId(context.getSelectedMcpPage().pptrPage) ?? 1;
@@ -1538,7 +1538,7 @@ describe('webmcp', () => {
   it('includes webmcp tools in navigate_page response', async t => {
     await testIncludesWebmcpTools(
       t,
-      {experimentalWebmcp: true} as ParsedArguments,
+      {categoryExperimentalWebmcp: true} as ParsedArguments,
       async (response, context) => {
         await navigatePage().handler(
           {
@@ -1572,14 +1572,14 @@ describe('webmcp', () => {
         );
       },
       {args: ['--enable-features=WebMCPTesting,DevToolsWebMCPSupport']},
-      {experimentalWebmcp: true} as ParsedArguments,
+      {categoryExperimentalWebmcp: true} as ParsedArguments,
     );
   });
 
   it('list no webmcp tools if experimentalWebmcp is false', async t => {
     await testIncludesWebmcpTools(
       t,
-      {experimentalWebmcp: false} as ParsedArguments,
+      {categoryExperimentalWebmcp: false} as ParsedArguments,
       async (response, context) => {
         await navigatePage().handler(
           {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -166,7 +166,7 @@ describe('e2e', () => {
         assert.ok(listWebMcpTools);
         assert.ok(executeWebMcpTool);
       },
-      ['--experimental-webmcp'],
+      ['--categoryExperimentalWebmcp'],
     );
   });
 

--- a/tests/tools/webmcp.test.ts
+++ b/tests/tools/webmcp.test.ts
@@ -78,7 +78,7 @@ describe('webmcp', () => {
           );
         },
         {args: ['--enable-features=WebMCPTesting,DevToolsWebMCPSupport']},
-        {experimentalWebmcp: true} as ParsedArguments,
+        {categoryExperimentalWebmcp: true} as ParsedArguments,
       );
     });
 
@@ -100,7 +100,7 @@ describe('webmcp', () => {
           );
         },
         {args: ['--enable-features=WebMCPTesting,DevToolsWebMCPSupport']},
-        {experimentalWebmcp: true} as ParsedArguments,
+        {categoryExperimentalWebmcp: true} as ParsedArguments,
       );
     });
 
@@ -125,7 +125,7 @@ describe('webmcp', () => {
           );
         },
         {args: ['--enable-features=WebMCPTesting,DevToolsWebMCPSupport']},
-        {experimentalWebmcp: true} as ParsedArguments,
+        {categoryExperimentalWebmcp: true} as ParsedArguments,
       );
     });
   });


### PR DESCRIPTION
Extracting WebMCP tools into a separate category for better grouping in the docs. This changes `--experimentalWebmcp` to `--categoryExperimentalWebmcp` to align with other experimental categories. Debugging category was not a good fit since the tools provided by WebMCP are not necessarily used for debugging.

cc @beaufortfrancois 