### PR TITLE
feat: add --protocol-timeout CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,10 @@ The Chrome DevTools MCP server supports the following configuration option:
   If enabled, ignores errors relative to self-signed and expired certificates. Use with caution.
   - **Type:** boolean
 
+- **`--protocolTimeout`/ `--protocol-timeout`**
+  Override the Puppeteer protocol timeout (in milliseconds) applied to both `puppeteer.launch` and `puppeteer.connect`. Pass `0` to disable the timeout. Useful when long-running CDP commands such as `Network.emulateNetworkConditions` (used by the `lighthouse_audit` and `emulate` tools) hit the default timeout on slow targets. Can also be set via the `CHROME_DEVTOOLS_MCP_PROTOCOL_TIMEOUT` environment variable. When omitted, Puppeteer uses its default.
+  - **Type:** number
+
 - **`--experimentalVision`/ `--experimental-vision`**
   Whether to enable coordinate-based tools such as click_at(x,y). Usually requires a computer-use model able to produce accurate coordinates by looking at screenshots.
   - **Type:** boolean

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -147,6 +147,11 @@ export const cliOptions = {
     type: 'boolean',
     description: `If enabled, ignores errors relative to self-signed and expired certificates. Use with caution.`,
   },
+  protocolTimeout: {
+    type: 'number',
+    description:
+      'Override the Puppeteer protocol timeout (in milliseconds) applied to both `puppeteer.launch` and `puppeteer.connect`. Pass `0` to disable the timeout. Useful when long-running CDP commands such as `Network.emulateNetworkConditions` (used by the `lighthouse_audit` and `emulate` tools) hit the default timeout on slow targets. Can also be set via the `CHROME_DEVTOOLS_MCP_PROTOCOL_TIMEOUT` environment variable. When omitted, Puppeteer uses its default.',
+  },
   experimentalPageIdRouting: {
     type: 'boolean',
     describe:
@@ -316,6 +321,34 @@ export function parseArguments(
           "turning off usage statistics. process.env['CI'] || process.env['CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS'] is set.",
         );
         args.usageStatistics = false;
+      }
+      if (
+        args.protocolTimeout === undefined &&
+        env['CHROME_DEVTOOLS_MCP_PROTOCOL_TIMEOUT']
+      ) {
+        const raw = env['CHROME_DEVTOOLS_MCP_PROTOCOL_TIMEOUT'];
+        const parsed = Number(raw);
+        if (
+          !Number.isFinite(parsed) ||
+          parsed < 0 ||
+          !Number.isInteger(parsed)
+        ) {
+          throw new Error(
+            `CHROME_DEVTOOLS_MCP_PROTOCOL_TIMEOUT must be a non-negative integer, received '${raw}'.`,
+          );
+        }
+        args.protocolTimeout = parsed;
+        args['protocol-timeout'] = parsed;
+      }
+      if (
+        args.protocolTimeout !== undefined &&
+        (!Number.isFinite(args.protocolTimeout) ||
+          args.protocolTimeout < 0 ||
+          !Number.isInteger(args.protocolTimeout))
+      ) {
+        throw new Error(
+          `--protocol-timeout must be a non-negative integer (in milliseconds), received '${args.protocolTimeout}'.`,
+        );
       }
       return true;
     })

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -51,6 +51,7 @@ export async function ensureBrowserConnected(options: {
   channel?: Channel;
   userDataDir?: string;
   enableExtensions?: boolean;
+  protocolTimeout?: number;
 }) {
   const {channel, enableExtensions} = options;
   if (browser?.connected) {
@@ -62,6 +63,9 @@ export async function ensureBrowserConnected(options: {
     defaultViewport: null,
     handleDevToolsAsPage: true,
   };
+  if (options.protocolTimeout !== undefined) {
+    connectOptions.protocolTimeout = options.protocolTimeout;
+  }
 
   let autoConnect = false;
   if (options.wsEndpoint) {
@@ -150,6 +154,7 @@ interface McpLaunchOptions {
   devtools: boolean;
   enableExtensions?: boolean;
   viaCli?: boolean;
+  protocolTimeout?: number;
 }
 
 export function detectDisplay(): void {
@@ -229,6 +234,7 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
       acceptInsecureCerts: options.acceptInsecureCerts,
       handleDevToolsAsPage: true,
       enableExtensions: options.enableExtensions,
+      protocolTimeout: options.protocolTimeout,
     });
     if (options.logFile) {
       // FIXME: we are probably subscribing too late to catch startup logs. We

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,7 @@ export async function createMcpServer(
               : undefined,
             userDataDir: serverArgs.userDataDir,
             devtools,
+            protocolTimeout: serverArgs.protocolTimeout,
           })
         : await ensureBrowserLaunched({
             headless: serverArgs.headless,
@@ -225,6 +226,7 @@ export async function createMcpServer(
             devtools,
             enableExtensions: serverArgs.categoryExtensions,
             viaCli: serverArgs.viaCli,
+            protocolTimeout: serverArgs.protocolTimeout,
           });
 
     if (context?.browser !== browser) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -326,6 +326,44 @@ describe('cli args parsing', () => {
     assert.strictEqual(disabledArgs.usageStatistics, false);
   });
 
+  it('parses protocol timeout flag', async () => {
+    // Default is undefined — Puppeteer uses its built-in default.
+    const defaultArgs = parseArguments('1.0.0', ['node', 'main.js'], {});
+    assert.strictEqual(defaultArgs.protocolTimeout, undefined);
+
+    const flagArgs = parseArguments(
+      '1.0.0',
+      ['node', 'main.js', '--protocol-timeout', '600000'],
+      {},
+    );
+    assert.strictEqual(flagArgs.protocolTimeout, 600000);
+
+    // 0 means "disable protocol timeout" (Puppeteer convention).
+    const zeroArgs = parseArguments(
+      '1.0.0',
+      ['node', 'main.js', '--protocol-timeout', '0'],
+      {},
+    );
+    assert.strictEqual(zeroArgs.protocolTimeout, 0);
+  });
+
+  it('parses protocol timeout from env variable', async () => {
+    const envArgs = parseArguments('1.0.0', ['node', 'main.js'], {
+      CHROME_DEVTOOLS_MCP_PROTOCOL_TIMEOUT: '450000',
+    });
+    assert.strictEqual(envArgs.protocolTimeout, 450000);
+
+    // CLI flag wins over env when both are set.
+    const overrideArgs = parseArguments(
+      '1.0.0',
+      ['node', 'main.js', '--protocol-timeout', '600000'],
+      {
+        CHROME_DEVTOOLS_MCP_PROTOCOL_TIMEOUT: '450000',
+      },
+    );
+    assert.strictEqual(overrideArgs.protocolTimeout, 600000);
+  });
+
   it('parses performance crux flag', async () => {
     const defaultArgs = parseArguments('1.0.0', ['node', 'main.js']);
     assert.strictEqual(defaultArgs.performanceCrux, true);


### PR DESCRIPTION
## Summary

Expose Puppeteer's `protocolTimeout` option as a configurable CLI flag and environment variable on the MCP server, plumbed through to both `puppeteer.connect` and `puppeteer.launch`.

- New CLI flag: `--protocol-timeout <ms>` (camelCase alias `--protocolTimeout`)
- New env var: `CHROME_DEVTOOLS_MCP_PROTOCOL_TIMEOUT` (CLI flag wins when both are set)
- Default behavior unchanged: when omitted, Puppeteer's built-in default applies

## Motivation

Long-running CDP commands such as `Network.emulateNetworkConditions` (used by the `emulate` and `lighthouse_audit` tools) can exceed Puppeteer's default protocol timeout on slow real-world targets, surfacing as:

```
Network.emulateNetworkConditions timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.
```

Repro: running `lighthouse_audit` against [https://oleanarestaurant.com](https://oleanarestaurant.com) (a small WordPress site over a residential link) reliably triggers the timeout. Today there is no way to extend the timeout without forking or hand-patching `node_modules`. We are currently shipping a wrapper script that idempotently rewrites `build/src/browser.js` after every install — this PR removes the need for that.

## Implementation

- [`src/bin/chrome-devtools-mcp-cli-options.ts`](src/bin/chrome-devtools-mcp-cli-options.ts): new yargs option, env-var fallback, and integer/non-negative validation. `0` is permitted and disables the timeout (Puppeteer convention).
- [`src/browser.ts`](src/browser.ts): forwards `protocolTimeout` into both the `puppeteer.connect` options and the `McpLaunchOptions` -> `puppeteer.launch` path.
- [`src/index.ts`](src/index.ts): passes `serverArgs.protocolTimeout` through both the connect and launch branches.
- [`tests/cli.test.ts`](tests/cli.test.ts): covers default (undefined), explicit flag value, env-var fallback, env+flag override precedence, and `0`.
- `README.md`: regenerated by `post-build.ts` to document the new option (consistent with how other flags are documented).

## Test plan

- [x] `npm run typecheck` clean
- [x] `node scripts/test.mjs tests/cli.test.ts` — all 19 tests pass
- [x] `npx prettier --check` + `npx eslint` clean on the touched files
- [x] Manual: with `CHROME_DEVTOOLS_MCP_PROTOCOL_TIMEOUT=600000` set, `lighthouse_audit https://oleanarestaurant.com` completes without the `Network.emulateNetworkConditions timed out` error

## Notes

- Conventional Commits format used (`feat:`).
- Google CLA: signing in progress on my end.
- Happy to split the env-var fallback into a separate commit or drop it if the maintainers prefer flag-only — let me know.