### PR TITLE
fix(telemetry): re-run the update metrics script

### DIFF
--- a/src/telemetry/flag_usage_metrics.json
+++ b/src/telemetry/flag_usage_metrics.json
@@ -281,19 +281,19 @@
     "isDeprecated": true
   },
   {
-    "name": "category_experimental_third_party_present",
-    "flagType": "boolean"
-  },
-  {
-    "name": "category_experimental_third_party",
-    "flagType": "boolean"
-  },
-  {
     "name": "category_experimental_webmcp_present",
     "flagType": "boolean"
   },
   {
     "name": "category_experimental_webmcp",
+    "flagType": "boolean"
+  },
+  {
+    "name": "category_experimental_third_party_present",
+    "flagType": "boolean"
+  },
+  {
+    "name": "category_experimental_third_party",
     "flagType": "boolean"
   }
 ]

--- a/src/telemetry/tool_call_metrics.json
+++ b/src/telemetry/tool_call_metrics.json
@@ -115,7 +115,7 @@
     ]
   },
   {
-    "name": "execute_3p_developer_tool",
+    "name": "execute_in_page_tool",
     "args": [
       {
         "name": "tool_name_length",
@@ -125,7 +125,8 @@
         "name": "params_length",
         "argType": "number"
       }
-    ]
+    ],
+    "isDeprecated": true
   },
   {
     "name": "fill",
@@ -253,8 +254,9 @@
     "args": []
   },
   {
-    "name": "list_3p_developer_tools",
-    "args": []
+    "name": "list_in_page_tools",
+    "args": [],
+    "isDeprecated": true
   },
   {
     "name": "list_network_requests",
@@ -608,5 +610,22 @@
         "argType": "number"
       }
     ]
+  },
+  {
+    "name": "execute_3p_developer_tool",
+    "args": [
+      {
+        "name": "tool_name_length",
+        "argType": "number"
+      },
+      {
+        "name": "params_length",
+        "argType": "number"
+      }
+    ]
+  },
+  {
+    "name": "list_3p_developer_tools",
+    "args": []
   }
 ]


### PR DESCRIPTION
the updates made to these files from #1982 came out a bit weird. So I reverted changes on these files and re-run `npm run gen` (which includes `npm run update-metrics`) to correct them.

we'd always want old entries to be marked as deprecated and new entries to be added to the very last. Don't manually resolve conflicts in these files. When there are conflicts, just revert back to a clean state and `npm run gen` will take care of them 😉