### PR TITLE
fix(browser): raise protocolTimeout to 10min for heavy pages

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -20,6 +20,17 @@ import {puppeteer} from './third_party/index.js';
 
 let browser: Browser | undefined;
 
+// Heavy pages (e.g. dev bundles >100MB) cannot ack `Network.enable` and
+// other auto-attached domain calls within puppeteer's default 180s.
+// Once that fires, the CDP connection is marked dead and every
+// subsequent call throws — only daemon restart recovers. Bumping the
+// ceiling to 10min covers realistic loads; override via env for power
+// users.
+const PROTOCOL_TIMEOUT_MS = parseInt(
+  process.env.CHROME_DEVTOOLS_PROTOCOL_TIMEOUT_MS ?? '600000',
+  10,
+);
+
 function makeTargetFilter(enableExtensions = false) {
   const ignoredPrefixes = new Set(['chrome://', 'chrome-untrusted://']);
   if (!enableExtensions) {
@@ -61,6 +72,7 @@ export async function ensureBrowserConnected(options: {
     targetFilter: makeTargetFilter(enableExtensions),
     defaultViewport: null,
     handleDevToolsAsPage: true,
+    protocolTimeout: PROTOCOL_TIMEOUT_MS,
   };
 
   let autoConnect = false;
@@ -228,6 +240,7 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
       ignoreDefaultArgs: ignoreDefaultArgs,
       acceptInsecureCerts: options.acceptInsecureCerts,
       handleDevToolsAsPage: true,
+      protocolTimeout: PROTOCOL_TIMEOUT_MS,
       enableExtensions: options.enableExtensions,
     });
     if (options.logFile) {


### PR DESCRIPTION
## Summary

Heavy pages (e.g. dev bundles >100MB) cannot ack `Network.enable` and other auto-attached CDP domain calls within puppeteer's default 180s. Once the timeout fires, puppeteer marks the connection dead and every subsequent call throws `Network.enable timed out` — only daemon restart recovers.

Set `protocolTimeout: 600000` on both `puppeteer.connect()` and `puppeteer.launch()`. Env-overridable via `CHROME_DEVTOOLS_PROTOCOL_TIMEOUT_MS` for power users.

## Repro

Hit during real-world testing against a Brightcove Studio dev bundle (~160MB JS):

```
$ chrome-devtools-mcp start --browserUrl http://127.0.0.1:9222
$ chrome-devtools-mcp list_pages
[{"type":"text","text":"Network.enable timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed."}]
```

After the failure, every subsequent call returned the same timeout. The daemon process was alive (`process.kill(pid, 0)` returned true), so client retries reused the wedged connection until manually killed.

## Why 10min

Puppeteer's 180s default is calibrated for small pages and CI runners. For real-world dev work (HMR-enabled webpack bundles, large React apps), 10min is comfortable headroom while still bounded enough to surface genuine deadlocks. Env-overridable so power users with even-larger workloads aren't blocked.

## Testing

- [x] `npm run build` clean
- [ ] Verify on a real heavy-page session that `Network.enable timed out` no longer surfaces

## Note

A previous PR (#2009) was opened from a downstream fork and accidentally pulled in 9 fork-specific commits — closed and re-submitted as this clean single-commit PR branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)