### PR TITLE
docs: Fix Claude Code instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ To install Chrome DevTools MCP with skills, add the marketplace registry in Clau
 Then, install the plugin:
 
 ```sh
-/plugin install chrome-devtools-mcp
+/plugin install chrome-devtools-mcp@chrome-devtools-plugins
 ```
 
 Restart Claude Code to have the MCP server and skills load (check with `/skills`).


### PR DESCRIPTION
This makes sure that the plugin installation command in Claude Code actually use our own marketplace in order to ship the latest release.