### PR TITLE
fix: only require a page in page-scoped tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -291,17 +291,17 @@ export async function createMcpServer(
 
           response.setRedactNetworkHeaders(serverArgs.redactNetworkHeaders);
           try {
-            const page =
-              serverArgs.experimentalPageIdRouting &&
-              params.pageId &&
-              !serverArgs.slim
-                ? context.getPageById(params.pageId)
-                : context.getSelectedMcpPage();
-            response.setPage(page);
-            if (tool.blockedByDialog) {
-              page.throwIfDialogOpen();
-            }
             if ('pageScoped' in tool && tool.pageScoped) {
+              const page =
+                serverArgs.experimentalPageIdRouting &&
+                params.pageId &&
+                !serverArgs.slim
+                  ? context.getPageById(params.pageId)
+                  : context.getSelectedMcpPage();
+              response.setPage(page);
+              if (tool.blockedByDialog) {
+                page.throwIfDialogOpen();
+              }
               await tool.handler(
                 {
                   params,

--- a/tests/McpResponse.test.js.snapshot
+++ b/tests/McpResponse.test.js.snapshot
@@ -1206,36 +1206,6 @@ exports[`extensions > lists extensions 2`] = `
 }
 `;
 
-exports[`third-party developer tools > lists third-party developer tools 1`] = `
-## Third-party developer tools
-My Tool Group: A group of tools
-Available tools:
-name="myTool", description="Does something", inputSchema={"type":"object","properties":{"foo":{"type":"string"}}}
-`;
-
-exports[`third-party developer tools > lists third-party developer tools 2`] = `
-{
-  "thirdPartyDeveloperTools": {
-    "name": "My Tool Group",
-    "description": "A group of tools",
-    "tools": [
-      {
-        "name": "myTool",
-        "description": "Does something",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "foo": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    ]
-  }
-}
-`;
-
 exports[`lighthouse > includes lighthouse report paths 1`] = `
 ## Lighthouse Audit Results
 Mode: navigation
@@ -1277,6 +1247,36 @@ exports[`lighthouse > includes lighthouse report paths 2`] = `
     "reports": [
       "/tmp/report.json",
       "/tmp/report.html"
+    ]
+  }
+}
+`;
+
+exports[`third-party developer tools > lists third-party developer tools 1`] = `
+## Third-party developer tools
+My Tool Group: A group of tools
+Available tools:
+name="myTool", description="Does something", inputSchema={"type":"object","properties":{"foo":{"type":"string"}}}
+`;
+
+exports[`third-party developer tools > lists third-party developer tools 2`] = `
+{
+  "thirdPartyDeveloperTools": {
+    "name": "My Tool Group",
+    "description": "A group of tools",
+    "tools": [
+      {
+        "name": "myTool",
+        "description": "Does something",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          }
+        }
+      }
     ]
   }
 }

--- a/tests/index.test.js.snapshot
+++ b/tests/index.test.js.snapshot
@@ -7,7 +7,7 @@ exports[`e2e > Dialogs > when dialog is open and tool is blocked, returns an err
 `;
 
 exports[`e2e > Dialogs > when dialog is open and tool is not blocked, executes tool 1`] = `
-{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank\\n2: data:text/html,<button id=\\"test\\" onclick=\\"alert('test dialog')\\">Click me</button>\\n3: data:text/html,<h1>New</h1> [selected]"}]}
+{"content":[{"type":"text","text":"## Pages\\n1: about:blank\\n2: data:text/html,<button id=\\"test\\" onclick=\\"alert('test dialog')\\">Click me</button>\\n3: data:text/html,<h1>New</h1> [selected]"}]}
 `;
 
 exports[`e2e > calls a tool 1`] = `


### PR DESCRIPTION
getSelectedMcpPage and getPageById throw if the page is not found, so these should only be called for page-scoped tools.