### PR TITLE
fix: improve geolocation emulation

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -256,7 +256,7 @@
 
 - **colorScheme** (enum: "dark", "light", "auto") _(optional)_: [`Emulate`](#emulate) the dark or the light mode. Set to "auto" to reset to the default.
 - **cpuThrottlingRate** (number) _(optional)_: Represents the CPU slowdown factor. Omit or set the rate to 1 to disable throttling
-- **geolocation** (string) _(optional)_: Geolocation (`&lt;latitude&gt;x&lt;longitude&gt;`) to [`emulate`](#emulate). Latitude between -90 and 90. Longitude between -180 and 180. Omit to clear the geolocation override.
+- **geolocation** (string) _(optional)_: Geolocation (`&lt;latitude&gt;,&lt;longitude&gt;`) to [`emulate`](#emulate). Latitude between -90 and 90. Longitude between -180 and 180. Omit to clear the geolocation override.
 - **networkConditions** (enum: "Offline", "Slow 3G", "Fast 3G", "Slow 4G", "Fast 4G") _(optional)_: Throttle network. Omit to disable throttling.
 - **userAgent** (string) _(optional)_: User agent to [`emulate`](#emulate). Set to empty string to clear the user agent override.
 - **viewport** (string) _(optional)_: [`Emulate`](#emulate) device viewports '&lt;width&gt;x&lt;height&gt;x&lt;devicePixelRatio&gt;[,mobile][,touch][,landscape]'. 'touch' and 'mobile' to [`emulate`](#emulate) mobile devices. 'landscape' to [`emulate`](#emulate) landscape mode.

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -746,6 +746,7 @@ export class McpResponse implements Response {
       extensionPages?: object[];
       errorMessage?: string;
       navigatedToUrl?: string;
+      geolocation?: {latitude: number; longitude: number};
     } = {};
 
     const response = [];
@@ -771,6 +772,14 @@ export class McpResponse implements Response {
       response.push(`Default navigation timeout set to ${timeout} ms`);
       structuredContent.networkConditions = networkConditions;
       structuredContent.navigationTimeout = timeout;
+    }
+
+    const geolocation = this.#page?.geolocation;
+    if (geolocation) {
+      response.push(
+        `Emulating geolocation: latitude=${geolocation.latitude}, longtitude=${geolocation.longitude}`,
+      );
+      structuredContent.geolocation = geolocation;
     }
 
     const viewport = this.#page?.viewport;

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -142,7 +142,7 @@ export const commands: Commands = {
         name: 'geolocation',
         type: 'string',
         description:
-          'Geolocation (`<latitude>x<longitude>`) to emulate. Latitude between -90 and 90. Longitude between -180 and 180. Omit to clear the geolocation override.',
+          'Geolocation (`<latitude>,<longitude>`) to emulate. Latitude between -90 and 90. Longitude between -180 and 180. Omit to clear the geolocation override.',
         required: false,
       },
       userAgent: {

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -417,7 +417,7 @@ export function geolocationTransform(arg: string | undefined) {
   if (!arg) {
     return undefined;
   }
-  const [latitude, longitude] = arg.split('x').map(Number) as [number, number];
+  const [latitude, longitude] = arg.split(',').map(Number) as [number, number];
   return {
     latitude,
     longitude,

--- a/src/tools/emulation.ts
+++ b/src/tools/emulation.ts
@@ -44,7 +44,7 @@ export const emulate = definePageTool({
       .optional()
       .transform(geolocationTransform)
       .describe(
-        'Geolocation (`<latitude>x<longitude>`) to emulate. Latitude between -90 and 90. Longitude between -180 and 180. Omit to clear the geolocation override.',
+        'Geolocation (`<latitude>,<longitude>`) to emulate. Latitude between -90 and 90. Longitude between -180 and 180. Omit to clear the geolocation override.',
       ),
     userAgent: zod
       .string()
@@ -67,8 +67,9 @@ export const emulate = definePageTool({
       ),
   },
   blockedByDialog: true,
-  handler: async (request, _response, context) => {
+  handler: async (request, response, context) => {
     const page = request.page;
     await context.emulate(request.params, page.pptrPage);
+    response.appendResponseLine('Emulation configured successfully');
   },
 });

--- a/tests/tools/emulation.test.ts
+++ b/tests/tools/emulation.test.ts
@@ -75,7 +75,7 @@ describe('emulation', () => {
       });
 
       it('parses latitude and longitude', () => {
-        assert.deepStrictEqual(geolocationTransform('48.137154x11.576124'), {
+        assert.deepStrictEqual(geolocationTransform('48.137154,11.576124'), {
           latitude: 48.137154,
           longitude: 11.576124,
         });


### PR DESCRIPTION
- add a message about successful configuration
- add a message about the currently emulated geolocation
- switch to comma separate format instead of `x` separator.

Tested with https://www.audero.it/demo/geolocation-api-demo.html