### PR TITLE
fix: improve large-profile page handling and incognito pages

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -98,6 +98,15 @@ Possible workarounds include:
   3. Start `chrome-devtools-mcp` with:
      `npx chrome-devtools-mcp --browser-url http://127.0.0.1:9222`
 
+- **Connect to Windows Chrome 144+ remote debugging from WSL:**
+  `--auto-connect` only discovers Chrome through the local OS user data
+  directory, so it cannot find a Windows-hosted Chrome profile from inside WSL.
+  If you enabled remote debugging through `chrome://inspect/#remote-debugging`
+  on Windows, use the full WebSocket endpoint instead:
+  `npx chrome-devtools-mcp --ws-endpoint ws://127.0.0.1:9222/devtools/browser/<id>`.
+  The `/json/version` endpoint may return 404 for that Chrome flow; in that
+  case `--browser-url` cannot discover the WebSocket endpoint automatically.
+
 - **Use PowerShell or Git Bash** instead of WSL.
 
 ### Windows 10: Error during discovery for MCP server 'chrome-devtools': MCP error -32000: Connection closed

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -59,6 +59,7 @@ interface McpContextOptions {
 
 const DEFAULT_TIMEOUT = 5_000;
 const NAVIGATION_TIMEOUT = 10_000;
+const DEVTOOLS_DETECTION_CONCURRENCY = 10;
 
 export class McpContext implements Context {
   browser: Browser;
@@ -644,27 +645,30 @@ export class McpContext implements Context {
     this.logger('Detecting open DevTools windows');
     const {pages} = await this.#getAllPages();
 
-    await Promise.all(
-      pages.map(async page => {
-        const mcpPage = this.#mcpPages.get(page);
-        if (!mcpPage) {
-          return;
-        }
+    for (let i = 0; i < pages.length; i += DEVTOOLS_DETECTION_CONCURRENCY) {
+      const batch = pages.slice(i, i + DEVTOOLS_DETECTION_CONCURRENCY);
+      await Promise.all(
+        batch.map(async page => {
+          const mcpPage = this.#mcpPages.get(page);
+          if (!mcpPage) {
+            return;
+          }
 
-        // Prior to Chrome 144.0.7559.59, the command fails,
-        // Some Electron apps still use older version
-        // Fall back to not exposing DevTools at all.
-        try {
-          if (await page.hasDevTools()) {
-            mcpPage.devToolsPage = await page.openDevTools();
-          } else {
+          // Prior to Chrome 144.0.7559.59, the command fails,
+          // Some Electron apps still use older version
+          // Fall back to not exposing DevTools at all.
+          try {
+            if (await page.hasDevTools()) {
+              mcpPage.devToolsPage = await page.openDevTools();
+            } else {
+              mcpPage.devToolsPage = undefined;
+            }
+          } catch {
             mcpPage.devToolsPage = undefined;
           }
-        } catch {
-          mcpPage.devToolsPage = undefined;
-        }
-      }),
-    );
+        }),
+      );
+    }
   }
 
   getExtensionServiceWorkers(): ExtensionServiceWorker[] {

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -527,7 +527,9 @@ export class McpContext implements Context {
   async createPagesSnapshot(): Promise<Page[]> {
     const {pages: allPages, isolatedContextNames} = await this.#getAllPages();
 
-    for (const page of allPages) {
+    const openPages = allPages.filter(page => !page.isClosed());
+
+    for (const page of openPages) {
       let mcpPage = this.#mcpPages.get(page);
       if (!mcpPage) {
         mcpPage = new McpPage(page, this.#nextPageId++);
@@ -541,7 +543,7 @@ export class McpContext implements Context {
     }
 
     // Prune orphaned #mcpPages entries (pages that no longer exist).
-    const currentPages = new Set(allPages);
+    const currentPages = new Set(openPages);
     for (const [page, mcpPage] of this.#mcpPages) {
       if (!currentPages.has(page)) {
         mcpPage.dispose();
@@ -549,7 +551,7 @@ export class McpContext implements Context {
       }
     }
 
-    this.#pages = allPages.filter(page => {
+    this.#pages = openPages.filter(page => {
       return (
         this.#options.experimentalDevToolsDebugging ||
         !page.url().startsWith('devtools://')

--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -12,7 +12,7 @@ import type {Mutex} from './Mutex.js';
 import {SlimMcpResponse} from './SlimMcpResponse.js';
 import {ClearcutLogger} from './telemetry/ClearcutLogger.js';
 import {bucketizeLatency} from './telemetry/transformation.js';
-import type {CallToolResult, zod} from './third_party/index.js';
+import {type CallToolResult, zod} from './third_party/index.js';
 import type {ToolCategory} from './tools/categories.js';
 import {labels, OFF_BY_DEFAULT_CATEGORIES} from './tools/categories.js';
 import type {DefinedPageTool, ToolDefinition} from './tools/ToolDefinition.js';
@@ -123,8 +123,10 @@ function isPageScopedTool(
 
 export class ToolHandler {
   readonly inputSchema: zod.ZodRawShape;
+  readonly registrationInputSchema: zod.ZodObject<zod.ZodRawShape>;
   readonly shouldRegister: boolean;
   private readonly disabledReason?: string;
+  private readonly paramsSchema: zod.ZodObject<zod.ZodRawShape>;
 
   constructor(
     private readonly tool: ToolDefinition | DefinedPageTool,
@@ -143,6 +145,8 @@ export class ToolHandler {
       !serverArgs.slim
         ? {...tool.schema, ...pageIdSchema}
         : tool.schema;
+    this.paramsSchema = zod.object(this.inputSchema);
+    this.registrationInputSchema = this.paramsSchema.passthrough();
   }
 
   async handle(params: Record<string, unknown>): Promise<CallToolResult> {
@@ -165,6 +169,7 @@ export class ToolHandler {
       logger(
         `${this.tool.name} request: ${JSON.stringify(params, null, '  ')}`,
       );
+      params = this.paramsSchema.parse(params);
       const context = await this.getContext();
       logger(`${this.tool.name} context: resolved`);
       await context.detectOpenDevToolsWindows();

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -178,7 +178,7 @@ export const commands: Commands = {
         name: 'function',
         type: 'string',
         description:
-          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`.\nDo not use jQuery-only selector extensions like `:contains()`; use standard DOM APIs such as `querySelector`, `querySelectorAll`, and text filtering with `Array.from(...).find(...)` instead.\nSnapshot `uid` values are not DOM attributes. To pass a snapshot element to this function, include its `uid` in `args` and receive it as an argument. Do not query for it with selectors like `[uid="..."]`.\nDo not navigate to new URLs by assigning to `window.location`, `location.href`, or similar from inside this function. Use the `navigate_page` tool to navigate instead, then run `evaluate_script` again after navigation.\nWhen using the CLI, pass the function as the first positional argument: `chrome-devtools evaluate_script \'() => document.title\'`. Do not use a `--expression` flag.\n',
+          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`.\nDo not use jQuery-only selector extensions like `:contains()`; use standard DOM APIs such as `querySelector`, `querySelectorAll`, and text filtering with `Array.from(...).find(...)` instead.\nSnapshot `uid` values are not DOM attributes. To pass a snapshot element to this function, include its `uid` in `args` and receive it as an argument. Do not query for it with selectors like `[uid="..."]`.\nDo not navigate to new URLs by assigning to `window.location`, `location.href`, or similar from inside this function. Use the `navigate_page` tool to navigate instead, then run `evaluate_script` again after navigation.\nSome restricted pages, including Google Docs, Google Sheets, Google Accounts, Chrome Web Store, and browser-internal pages, may block script execution. If this happens, use `take_snapshot` or other non-script tools instead of trying to bypass the restriction.\nWhen using the CLI, pass the function as the first positional argument: `chrome-devtools evaluate_script \'() => document.title\'`. Do not use a `--expression` flag.\n',
         required: true,
       },
       args: {
@@ -633,6 +633,13 @@ export const commands: Commands = {
         type: 'string',
         description:
           'If specified, the page is created in an isolated browser context with the given name. Pages in the same browser context share cookies and storage. Pages in different browser contexts are fully isolated.',
+        required: false,
+      },
+      incognito: {
+        name: 'incognito',
+        type: 'boolean',
+        description:
+          'If true, open the page in a new temporary isolated browser context. Cannot be used together with isolatedContext.',
         required: false,
       },
       timeout: {

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -178,13 +178,14 @@ export const commands: Commands = {
         name: 'function',
         type: 'string',
         description:
-          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`\n',
+          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`.\nDo not use jQuery-only selector extensions like `:contains()`; use standard DOM APIs such as `querySelector`, `querySelectorAll`, and text filtering with `Array.from(...).find(...)` instead.\nSnapshot `uid` values are not DOM attributes. To pass a snapshot element to this function, include its `uid` in `args` and receive it as an argument. Do not query for it with selectors like `[uid="..."]`.\nDo not navigate to new URLs by assigning to `window.location`, `location.href`, or similar from inside this function. Use the `navigate_page` tool to navigate instead, then run `evaluate_script` again after navigation.\nWhen using the CLI, pass the function as the first positional argument: `chrome-devtools evaluate_script \'() => document.title\'`. Do not use a `--expression` flag.\n',
         required: true,
       },
       args: {
         name: 'args',
         type: 'array',
-        description: 'An optional list of arguments to pass to the function.',
+        description:
+          'An optional list of snapshot element uids to pass to the function as arguments. These uids are not DOM attributes and cannot be queried with selectors like [uid="..."].',
         required: false,
       },
       filePath: {

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -154,16 +154,29 @@ export async function handleResponse(
   if (response.isError) {
     return JSON.stringify(response.content);
   }
+  const hasBinaryContent = response.content.some(content => {
+    return content.type === 'image';
+  });
   if (format === 'json') {
-    if (response.structuredContent) {
+    if (response.structuredContent && !hasBinaryContent) {
       return JSON.stringify(response.structuredContent);
     }
     // Fall-through to text for backward compatibility.
   }
-  const chunks = [];
+  const chunks: string[] = [];
+  const jsonChunks: Array<
+    | string
+    | {
+        type: 'image';
+        mimeType: string;
+        filepath: string;
+        bytes: number;
+      }
+  > = [];
   for (const content of response.content) {
     if (content.type === 'text') {
       chunks.push(content.text);
+      jsonChunks.push(content.text);
     } else if (content.type === 'image') {
       const imageData = content.data;
       const mimeType = content.mimeType;
@@ -182,9 +195,15 @@ export async function handleResponse(
       const filepath = await getTempFilePath(`${name}${extension}`);
       fs.writeFileSync(filepath, data);
       chunks.push(`Saved to ${filepath}.`);
+      jsonChunks.push({
+        type: 'image',
+        mimeType,
+        filepath,
+        bytes: data.byteLength,
+      });
     } else {
       throw new Error('Not supported response content type');
     }
   }
-  return format === 'md' ? chunks.join(' ') : JSON.stringify(chunks);
+  return format === 'md' ? chunks.join(' ') : JSON.stringify(jsonChunks);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ export async function createMcpServer(
       tool.name,
       {
         description: tool.description,
-        inputSchema: toolHandler.inputSchema,
+        inputSchema: toolHandler.registrationInputSchema,
         annotations: tool.annotations,
       },
       async (params): Promise<CallToolResult> => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,19 +15,29 @@ const namespacesToEnable = [
   ...(process.env['DEBUG'] ? [process.env['DEBUG']] : []),
 ];
 
+function formatLogLine(chunks: unknown[]): string {
+  const prefix = `[pid=${process.pid} ppid=${process.ppid}]`;
+  return `${prefix} ${chunks.join(' ')}`.replace(/\n/g, `\n${prefix} `);
+}
+
 export function saveLogsToFile(fileName: string): fs.WriteStream {
   // Enable overrides everything so we need to add them
   debug.enable(namespacesToEnable.join(','));
 
   const logFile = fs.createWriteStream(fileName, {flags: 'a+'});
   debug.log = function (...chunks: any[]) {
-    logFile.write(`${chunks.join(' ')}\n`);
+    logFile.write(`${formatLogLine(chunks)}\n`);
   };
   logFile.on('error', function (error) {
     console.error(`Error when opening/writing to log file: ${error.message}`);
     logFile.end();
     process.exit(1);
   });
+  logFile.write(
+    `${formatLogLine([
+      `Chrome DevTools MCP log started argv=${JSON.stringify(process.argv)}`,
+    ])}\n`,
+  );
   return logFile;
 }
 

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -250,6 +250,43 @@ function hasOptionChildren(aXNode: TextSnapshotNode) {
   return aXNode.children.some(child => child.role === 'option');
 }
 
+async function verifyTextControlValue(
+  handle: ElementHandle<Element>,
+  expectedValue: string,
+) {
+  const result = await handle.evaluate(el => {
+    if (el instanceof HTMLTextAreaElement) {
+      return {
+        actualValue: el.value,
+      };
+    }
+    if (
+      el instanceof HTMLInputElement &&
+      ['', 'email', 'password', 'search', 'tel', 'text', 'url'].includes(
+        el.type,
+      )
+    ) {
+      return {
+        actualValue: el.value,
+        maxLength: el.maxLength > -1 ? el.maxLength : undefined,
+      };
+    }
+    return undefined;
+  });
+
+  if (!result || result.actualValue === expectedValue) {
+    return;
+  }
+
+  const maxLengthNote =
+    result.maxLength !== undefined
+      ? ` The element maxlength is ${result.maxLength}.`
+      : '';
+  throw new Error(
+    `The element value was truncated or normalized after filling. Expected ${expectedValue.length} characters, but the element contains ${result.actualValue.length}.${maxLengthNote}`,
+  );
+}
+
 async function fillFormElement(
   uid: string,
   value: string,
@@ -286,6 +323,7 @@ async function fillFormElement(
         const fillTimeout =
           page.pptrPage.getDefaultTimeout() + value.length * timeoutPerChar;
         await handle.asLocator().setTimeout(fillTimeout).fill(value);
+        await verifyTextControlValue(handle, value);
       }
     }
   } catch (error) {

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import crypto from 'node:crypto';
+
 import {logger} from '../logger.js';
 import type {CdpPage, Dialog, HTTPRequest} from '../third_party/index.js';
 import {zod} from '../third_party/index.js';
@@ -176,6 +178,12 @@ export const newPage = defineTool(args => {
             'Pages in the same browser context share cookies and storage. ' +
             'Pages in different browser contexts are fully isolated.',
         ),
+      incognito: zod
+        .boolean()
+        .optional()
+        .describe(
+          'If true, open the page in a new temporary isolated browser context. Cannot be used together with isolatedContext.',
+        ),
       ...(args?.experimentalNavigationAllowlist
         ? {
             allowList: zod
@@ -190,9 +198,17 @@ export const newPage = defineTool(args => {
     },
     blockedByDialog: false,
     handler: async (request, response, context) => {
+      if (request.params.incognito && request.params.isolatedContext) {
+        throw new Error(
+          'Specify either incognito or isolatedContext, not both.',
+        );
+      }
+      const isolatedContextName = request.params.incognito
+        ? `incognito-${crypto.randomUUID()}`
+        : request.params.isolatedContext;
       const page = await context.newPage(
         request.params.background,
-        request.params.isolatedContext,
+        isolatedContextName,
       );
 
       await navigateWithInterception(

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -35,6 +35,9 @@ Example with arguments: \`(el) => {
   return el.innerText;
 }\`.
 Do not use jQuery-only selector extensions like \`:contains()\`; use standard DOM APIs such as \`querySelector\`, \`querySelectorAll\`, and text filtering with \`Array.from(...).find(...)\` instead.
+Snapshot \`uid\` values are not DOM attributes. To pass a snapshot element to this function, include its \`uid\` in \`args\` and receive it as an argument. Do not query for it with selectors like \`[uid="..."]\`.
+Do not navigate to new URLs by assigning to \`window.location\`, \`location.href\`, or similar from inside this function. Use the \`navigate_page\` tool to navigate instead, then run \`evaluate_script\` again after navigation.
+When using the CLI, pass the function as the first positional argument: \`chrome-devtools evaluate_script '() => document.title'\`. Do not use a \`--expression\` flag.
 `,
       ),
       args: zod
@@ -46,7 +49,9 @@ Do not use jQuery-only selector extensions like \`:contains()\`; use standard DO
             ),
         )
         .optional()
-        .describe(`An optional list of arguments to pass to the function.`),
+        .describe(
+          `An optional list of snapshot element uids to pass to the function as arguments. These uids are not DOM attributes and cannot be queried with selectors like [uid="..."].`,
+        ),
       filePath: zod
         .string()
         .optional()

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -37,6 +37,7 @@ Example with arguments: \`(el) => {
 Do not use jQuery-only selector extensions like \`:contains()\`; use standard DOM APIs such as \`querySelector\`, \`querySelectorAll\`, and text filtering with \`Array.from(...).find(...)\` instead.
 Snapshot \`uid\` values are not DOM attributes. To pass a snapshot element to this function, include its \`uid\` in \`args\` and receive it as an argument. Do not query for it with selectors like \`[uid="..."]\`.
 Do not navigate to new URLs by assigning to \`window.location\`, \`location.href\`, or similar from inside this function. Use the \`navigate_page\` tool to navigate instead, then run \`evaluate_script\` again after navigation.
+Some restricted pages, including Google Docs, Google Sheets, Google Accounts, Chrome Web Store, and browser-internal pages, may block script execution. If this happens, use \`take_snapshot\` or other non-script tools instead of trying to bypass the restriction.
 When using the CLI, pass the function as the first positional argument: \`chrome-devtools evaluate_script '() => document.title'\`. Do not use a \`--expression\` flag.
 `,
       ),

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -33,7 +33,8 @@ Example without arguments: \`() => {
 }\`.
 Example with arguments: \`(el) => {
   return el.innerText;
-}\`
+}\`.
+Do not use jQuery-only selector extensions like \`:contains()\`; use standard DOM APIs such as \`querySelector\`, \`querySelectorAll\`, and text filtering with \`Array.from(...).find(...)\` instead.
 `,
       ),
       args: zod

--- a/src/trace-processing/parse.ts
+++ b/src/trace-processing/parse.ts
@@ -79,12 +79,77 @@ ${DevTools.PerformanceTraceFormatter.networkDataFormatDescription}`;
 export function getTraceSummary(result: TraceResult): string {
   const focus = DevTools.AgentFocus.fromParsedTrace(result.parsedTrace);
   const formatter = new DevTools.PerformanceTraceFormatter(focus);
-  const summaryText = formatter.formatTraceSummary();
+  const summaryText = addFieldMetricRatings(formatter.formatTraceSummary());
   return `## Summary of Performance trace findings:
 ${summaryText}
 
 ## Details on call tree & network request formats:
 ${extraFormatDescriptions}`;
+}
+
+type MetricRating = 'good' | 'needs improvement' | 'poor';
+
+const FIELD_METRIC_THRESHOLDS = new Map<
+  string,
+  {good: number; needsImprovement: number}
+>([
+  ['LCP', {good: 2500, needsImprovement: 4000}],
+  ['INP', {good: 200, needsImprovement: 500}],
+  ['CLS', {good: 0.1, needsImprovement: 0.25}],
+  ['FCP', {good: 1800, needsImprovement: 3000}],
+  ['TTFB', {good: 800, needsImprovement: 1800}],
+]);
+
+function rateMetric(
+  metricName: string,
+  value: number,
+): MetricRating | undefined {
+  const thresholds = FIELD_METRIC_THRESHOLDS.get(metricName);
+  if (!thresholds) {
+    return;
+  }
+  if (value <= thresholds.good) {
+    return 'good';
+  }
+  if (value <= thresholds.needsImprovement) {
+    return 'needs improvement';
+  }
+  return 'poor';
+}
+
+export function addFieldMetricRatings(summaryText: string): string {
+  const lines = summaryText.split('\n');
+  let inFieldMetrics = false;
+
+  return lines
+    .map(line => {
+      if (line.startsWith('Metrics (field / real users):')) {
+        inFieldMetrics = true;
+        return line;
+      }
+      if (inFieldMetrics && line.startsWith('Available insights:')) {
+        inFieldMetrics = false;
+        return line;
+      }
+      if (!inFieldMetrics) {
+        return line;
+      }
+
+      const match = line.match(
+        /^(\s*-\s+)(LCP|INP|CLS|FCP|TTFB): ([\d.]+)(\s*ms)?(.*)$/,
+      );
+      if (!match) {
+        return line;
+      }
+
+      const [, prefix, metricName, rawValue, unit = '', suffix] = match;
+      const rating = rateMetric(metricName, Number(rawValue));
+      if (!rating || suffix.includes('rating:')) {
+        return line;
+      }
+      return `${prefix}${metricName}: ${rawValue}${unit} (${rating})${suffix}`;
+    })
+    .join('\n');
 }
 
 export type InsightName =

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -134,6 +134,20 @@ describe('McpContext', () => {
     });
   });
 
+  it('selects an open page when the selected page is closed externally', async () => {
+    await withMcpContext(async (_response, context) => {
+      const closedPage = context.getSelectedMcpPage();
+      const openPage = await context.newPage();
+      context.selectPage(closedPage);
+
+      await closedPage.pptrPage.close({runBeforeUnload: false});
+      await context.createPagesSnapshot();
+
+      assert.strictEqual(context.getSelectedMcpPage(), openPage);
+      assert.ok(!context.getPages().includes(closedPage.pptrPage));
+    });
+  });
+
   it('should include network requests in structured content', async t => {
     await withMcpContext(async (response, context) => {
       const mockRequest = getMockRequest({

--- a/tests/ToolHandler.test.ts
+++ b/tests/ToolHandler.test.ts
@@ -13,6 +13,7 @@ import {parseArguments} from '../src/bin/chrome-devtools-mcp-cli-options.js';
 import {McpContext} from '../src/McpContext.js';
 import {McpPage} from '../src/McpPage.js';
 import {Mutex} from '../src/Mutex.js';
+import {zod} from '../src/third_party/index.js';
 import {ToolHandler} from '../src/ToolHandler.js';
 import {ToolCategory} from '../src/tools/categories.js';
 import type {
@@ -104,6 +105,60 @@ describe('ToolHandler', () => {
     assert.strictEqual(mockContext.getPageById.called, false);
     assert.strictEqual(handlerCalled, true);
     assert.strictEqual(result.isError, undefined);
+  });
+
+  it('accepts extra MCP arguments but strips them before calling a tool', async () => {
+    let receivedParams: Record<string, unknown> | undefined;
+    const tool: ToolDefinition = {
+      name: 'global_tool',
+      description: 'A global tool',
+      annotations: {
+        category: ToolCategory.NAVIGATION,
+        readOnlyHint: true,
+      },
+      schema: {
+        url: zod.string(),
+      },
+      blockedByDialog: false,
+      handler: async request => {
+        receivedParams = request.params;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    mockContext.detectOpenDevToolsWindows.resolves();
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const registrationParse = toolHandler.registrationInputSchema.safeParse({
+      url: 'https://example.com',
+      description: 'extra agent commentary',
+    });
+    assert.strictEqual(registrationParse.success, true);
+    assert.deepStrictEqual(registrationParse.data, {
+      url: 'https://example.com',
+      description: 'extra agent commentary',
+    });
+
+    const result = await toolHandler.handle({
+      url: 'https://example.com',
+      description: 'extra agent commentary',
+    });
+
+    assert.strictEqual(result.isError, undefined);
+    assert.deepStrictEqual(receivedParams, {
+      url: 'https://example.com',
+    });
   });
 
   it('sets shouldRegister to false and returns disabled reason when category is disabled', async () => {

--- a/tests/daemon/client.test.ts
+++ b/tests/daemon/client.test.ts
@@ -127,6 +127,31 @@ describe('daemon client', () => {
       assert.ok(response.includes('.png'));
     });
 
+    it('returns image file metadata when json format is requested', async () => {
+      const imageResponse = {
+        content: [
+          {
+            type: 'image' as const,
+            data: Buffer.from('image-data').toString('base64'),
+            mimeType: 'image/png',
+          },
+        ],
+        structuredContent: {},
+      };
+      const response = await handleResponse(imageResponse, 'json');
+      const parsed = JSON.parse(response);
+
+      assert.deepStrictEqual(parsed, [
+        {
+          type: 'image',
+          mimeType: 'image/png',
+          filepath: parsed[0].filepath,
+          bytes: 10,
+        },
+      ]);
+      assert.match(parsed[0].filepath, /\.png$/);
+    });
+
     it('uses the webp extension for WebP images', async () => {
       const webpContentResponse = {
         content: [

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {describe, it} from 'node:test';
+
+import {flushLogs, logger, saveLogsToFile} from '../src/logger.js';
+
+describe('logger', () => {
+  it('prefixes log file lines with process identity', async () => {
+    const logPath = path.join(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'cdt-mcp-log-')),
+      'shared.log',
+    );
+    const logFile = saveLogsToFile(logPath);
+
+    logger('first line\nsecond line');
+    await flushLogs(logFile);
+
+    const log = await fs.readFile(logPath, 'utf8');
+    assert.match(
+      log,
+      new RegExp(
+        `\\[pid=${process.pid} ppid=${process.ppid}\\] Chrome DevTools MCP log started`,
+      ),
+    );
+    assert.match(
+      log,
+      new RegExp(`\\[pid=${process.pid} ppid=${process.ppid}\\].*first line`),
+    );
+    assert.match(
+      log,
+      new RegExp(`\\[pid=${process.pid} ppid=${process.ppid}\\] second line`),
+    );
+  });
+});

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -653,6 +653,37 @@ describe('input', () => {
       });
     });
 
+    it('reports an error when a text input truncates the requested value', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+        await page.setContent(html`<input maxlength="5" />`);
+        context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
+          context.getSelectedMcpPage(),
+        );
+
+        await assert.rejects(
+          fill.handler(
+            {
+              params: {
+                uid: '1_1',
+                value: '123456',
+              },
+              page: context.getSelectedMcpPage(),
+            },
+            response,
+            context,
+          ),
+          (error: Error & {cause?: Error}) => {
+            assert.match(
+              error.cause?.message ?? '',
+              /Expected 6 characters, but the element contains 5/,
+            );
+            return true;
+          },
+        );
+      });
+    });
+
     it('types text', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -347,6 +347,50 @@ describe('pages', () => {
       });
     });
 
+    it('creates a one-off isolated context when incognito is true', async () => {
+      await withMcpContext(async (response, context) => {
+        await newPage().handler(
+          {params: {url: 'about:blank', incognito: true}},
+          response,
+          context,
+        );
+        const pageA = context.getSelectedPptrPage();
+        const contextNameA = context.getIsolatedContextName(pageA);
+
+        await newPage().handler(
+          {params: {url: 'about:blank', incognito: true}},
+          response,
+          context,
+        );
+        const pageB = context.getSelectedPptrPage();
+        const contextNameB = context.getIsolatedContextName(pageB);
+
+        assert.match(contextNameA ?? '', /^incognito-/);
+        assert.match(contextNameB ?? '', /^incognito-/);
+        assert.notStrictEqual(contextNameA, contextNameB);
+        assert.notStrictEqual(pageA.browserContext(), pageB.browserContext());
+      });
+    });
+
+    it('rejects new_page with both incognito and isolatedContext', async () => {
+      await withMcpContext(async (response, context) => {
+        await assert.rejects(
+          newPage().handler(
+            {
+              params: {
+                url: 'about:blank',
+                incognito: true,
+                isolatedContext: 'session-a',
+              },
+            },
+            response,
+            context,
+          ),
+          /Specify either incognito or isolatedContext/,
+        );
+      });
+    });
+
     it('does not set isolatedContext for pages in the default context', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -29,6 +29,13 @@ describe('script', () => {
   const server = serverHooks();
 
   describe('browser_evaluate_script', () => {
+    it('describes that functions run with standard DOM selectors', () => {
+      const functionDescription = evaluateScript().schema.function.description;
+
+      assert.match(functionDescription ?? '', /Do not use jQuery-only/);
+      assert.match(functionDescription ?? '', /querySelectorAll/);
+    });
+
     it('evaluates', async () => {
       await withMcpContext(async (response, context) => {
         await evaluateScript().handler(

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -36,6 +36,19 @@ describe('script', () => {
       assert.match(functionDescription ?? '', /querySelectorAll/);
     });
 
+    it('describes snapshot uid, navigation, and CLI limits', () => {
+      const tool = evaluateScript();
+      const functionDescription = tool.schema.function.description ?? '';
+      const argsDescription = tool.schema.args.description ?? '';
+
+      assert.match(functionDescription, /uid.*not DOM attributes/);
+      assert.match(functionDescription, /\[uid="\.\.\."\]/);
+      assert.match(functionDescription, /window\.location/);
+      assert.match(functionDescription, /navigate_page/);
+      assert.match(functionDescription, /--expression/);
+      assert.match(argsDescription, /not DOM attributes/);
+    });
+
     it('evaluates', async () => {
       await withMcpContext(async (response, context) => {
         await evaluateScript().handler(

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -45,6 +45,8 @@ describe('script', () => {
       assert.match(functionDescription, /\[uid="\.\.\."\]/);
       assert.match(functionDescription, /window\.location/);
       assert.match(functionDescription, /navigate_page/);
+      assert.match(functionDescription, /Google Sheets/);
+      assert.match(functionDescription, /take_snapshot/);
       assert.match(functionDescription, /--expression/);
       assert.match(argsDescription, /not DOM attributes/);
     });

--- a/tests/trace-processing/parse.test.ts
+++ b/tests/trace-processing/parse.test.ts
@@ -8,6 +8,7 @@ import assert from 'node:assert';
 import {describe, it} from 'node:test';
 
 import {
+  addFieldMetricRatings,
   getTraceSummary,
   parseRawTraceBuffer,
 } from '../../src/trace-processing/parse.js';
@@ -38,6 +39,24 @@ describe('Trace parsing', async () => {
 
     const output = getTraceSummary(result);
     t.assert.snapshot?.(output);
+  });
+
+  it('adds ratings to field metrics only', () => {
+    const summary = addFieldMetricRatings(`Metrics (lab / observed):
+  - LCP: 129 ms
+Metrics (field / real users):
+  - LCP: 1404 ms (scope: url)
+  - LCP breakdown:
+    - TTFB: 209 ms (scope: url)
+  - INP: 65 ms (scope: url)
+  - CLS: 0.26 (scope: url)
+Available insights:`);
+
+    assert.match(summary, /- LCP: 129 ms/);
+    assert.match(summary, /- LCP: 1404 ms \(good\)/);
+    assert.match(summary, /- TTFB: 209 ms \(good\)/);
+    assert.match(summary, /- INP: 65 ms \(good\)/);
+    assert.match(summary, /- CLS: 0.26 \(poor\)/);
   });
 
   it('will return a message if there is an error', async () => {


### PR DESCRIPTION
## Summary
- Improve large-profile page handling and incognito pages

## Changed files
- `docs/troubleshooting.md`
- `src/McpContext.ts`
- `src/ToolHandler.ts`
- `src/bin/chrome-devtools-cli-options.ts`
- `src/daemon/client.ts`
- `src/index.ts`
- `src/logger.ts`
- `src/tools/input.ts`
- `src/tools/pages.ts`
- `src/tools/script.ts`
- `src/trace-processing/parse.ts`
- `tests/McpContext.test.ts`
- `tests/ToolHandler.test.ts`
- `tests/daemon/client.test.ts`
- `tests/logger.test.ts`
- `tests/tools/input.test.ts`
- `tests/tools/pages.test.ts`
- `tests/tools/script.test.ts`
- `tests/trace-processing/parse.test.ts`

## Tests
- Not run in this publishing pass; local branch was clean before opening the PR.
