### PR TITLE
docs: explain concurrent session options

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,34 @@ You can also run `npx chrome-devtools-mcp@latest --help` to see all available co
 
 ## Concepts
 
+### Concurrent sessions
+
+Most MCP clients start one Chrome DevTools MCP server per conversation. If your
+client shares a single server instance across concurrent agents or subagents,
+start the server with `--experimentalPageIdRouting`. This exposes `pageId` on
+page-scoped tools so each agent can route tool calls to the tab it is working
+with.
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest",
+        "--experimentalPageIdRouting"
+      ]
+    }
+  }
+}
+```
+
+If you run multiple independent MCP client sessions and want each session to
+launch its own temporary Chrome profile, also pass `--isolated`. This avoids
+sharing the default Chrome DevTools MCP user data directory between those
+server instances.
+
 ### User data directory
 
 `chrome-devtools-mcp` starts a Chrome's stable channel instance using the following user


### PR DESCRIPTION
## Summary
- Add a README section explaining how to configure concurrent MCP sessions
- Document when to use `--experimentalPageIdRouting` for shared server instances
- Point independent sessions at `--isolated` to avoid sharing the default user data directory

Refs #2052

## Testing
- `npm run check-format`