### PR TITLE
docs: fix sensitive typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ The Chrome DevTools MCP server supports the following configuration option:
   - **Type:** boolean
 
 - **`--redactNetworkHeaders`/ `--redact-network-headers`**
-  If true, redacts some of the network headers considered senstive before returning to the client.
+  If true, redacts some of the network headers considered sensitive before returning to the client.
   - **Type:** boolean
   - **Default:** `false`
 


### PR DESCRIPTION
## Summary
- Fix a typo in the `--redactNetworkHeaders` option description

## Validation
- `typos --format brief README.md`
- `git diff --check`