### PR TITLE
feat: add disconnect_browser tool

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -9,6 +9,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 
+import {disconnectBrowser} from './browser.js';
 import type {TargetUniverse} from './DevtoolsUtils.js';
 import {UniverseManager} from './DevtoolsUtils.js';
 import {HeapSnapshotManager} from './HeapSnapshotManager.js';
@@ -144,6 +145,11 @@ export class McpContext implements Context {
     // Either the entire browser will be closed or we disconnect
     // without destroying browser state.
     this.#isolatedContexts.clear();
+  }
+
+  async disconnect(): Promise<void> {
+    this.dispose();
+    await disconnectBrowser();
   }
 
   static async from(

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -270,4 +270,16 @@ export async function ensureBrowserLaunched(
   return browser;
 }
 
+export async function disconnectBrowser(): Promise<void> {
+  const current = browser;
+  browser = undefined;
+  if (current?.connected) {
+    try {
+      await current.disconnect();
+    } catch (err) {
+      logger('Error while disconnecting browser', err);
+    }
+  }
+}
+
 export type Channel = 'stable' | 'canary' | 'beta' | 'dev';

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -179,6 +179,7 @@ export type Context = Readonly<{
   isCruxEnabled(): boolean;
   recordedTraces(): TraceResult[];
   storeTraceRecording(result: TraceResult): void;
+  disconnect(): Promise<void>;
   getPageById(pageId: number): ContextPage;
   newPage(
     background?: boolean,

--- a/src/tools/connection.ts
+++ b/src/tools/connection.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {ToolCategory} from './categories.js';
+import {defineTool} from './ToolDefinition.js';
+
+export const disconnectBrowser = defineTool({
+  name: 'disconnect_browser',
+  description:
+    'Release the current connection to Chrome without exiting the MCP server.',
+  annotations: {
+    category: ToolCategory.NAVIGATION,
+    readOnlyHint: false,
+  },
+  schema: {},
+  blockedByDialog: false,
+  handler: async (_request, response, context) => {
+    await context.disconnect();
+    response.appendResponseLine(
+      'Browser connection released. The next tool call will reconnect.',
+    );
+  },
+});

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -6,6 +6,7 @@
 
 import type {ParsedArguments} from '../bin/chrome-devtools-mcp-cli-options.js';
 
+import * as connectionTools from './connection.js';
 import * as consoleTools from './console.js';
 import * as emulationTools from './emulation.js';
 import * as extensionTools from './extensions.js';
@@ -28,6 +29,7 @@ export const createTools = (args: ParsedArguments) => {
   const rawTools = args.slim
     ? Object.values(slimTools)
     : [
+        ...Object.values(connectionTools),
         ...Object.values(consoleTools),
         ...Object.values(emulationTools),
         ...Object.values(extensionTools),


### PR DESCRIPTION
Adds a `disconnect_browser` tool that releases the current Chrome connection without exiting the MCP server.