### PR TITLE
fix: make pageId required

### DIFF
--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -361,7 +361,7 @@ export const CLOSE_PAGE_ERROR =
   'The last open page cannot be closed. It is fine to keep it open.';
 
 export const pageIdSchema = {
-  pageId: zod.number().optional().describe('Targets a specific page by ID.'),
+  pageId: zod.number().describe('Targets a specific page by ID.'),
 };
 
 export const timeoutSchema = {


### PR DESCRIPTION
Refs: #2052 

Without having pageId as required, when the flag experimentalPageIdRouting is enabled, the pageId field is not always populated. This was found while running eval scenarios.

We only add `pageIdSchema` when tool is page scoped and experimentalPageIdRouting is enabled, so it should be safe to make this change.