### PR TITLE
feat: HTTP/Streamable transport, Tailscale installer, and --remote CLI flag

### DIFF
--- a/skills/chrome-devtools-remote/SKILL.md
+++ b/skills/chrome-devtools-remote/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: chrome-devtools-remote
+description: Run chrome-devtools-mcp as an always-on HTTP server on a remote machine (Mac mini, CI runner, tailnet host) and drive its browser from any AI agent on the same network. Covers server setup with --port and --tailscale, agent configuration for Claude Code / OpenCode / OpenClaw, and the chrome-devtools CLI --remote flag for scripting.
+---
+
+# chrome-devtools-remote
+
+Drive a `chrome-devtools-mcp` server running on another machine — no local Chrome needed.
+
+## Server setup (on the remote host, once)
+
+### Start over HTTP
+
+```bash
+# Stdio is the default. Add --port to expose a Streamable HTTP endpoint instead:
+chrome-devtools-mcp --port 3100
+# MCP endpoint is now at http://<host>:3100/mcp
+# Health probe:           http://<host>:3100/health
+```
+
+### Expose over Tailscale (recommended for multi-agent access)
+
+```bash
+npm install -g @vibebrowser/chrome-devtools-mcp   # or: npx chrome-devtools-mcp --port 3100
+chrome-devtools-mcp install --port 3100 --tailscale
+# Configures Tailscale Serve so the endpoint is at:
+#   https://<machine>.tailnet.ts.net/mcp
+# Installs a launchd (macOS) or systemd (Linux) service so it survives reboots.
+```
+
+The installer also prints the JSON snippet to paste into your agent config.
+
+## Agent configuration (on the client machine)
+
+**Claude Code / OpenClaw** — `~/.claude.json`:
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "type": "http",
+      "url": "https://<machine>.tailnet.ts.net/mcp"
+    }
+  }
+}
+```
+
+**OpenCode** — `~/.config/opencode/opencode.json`:
+```json
+{
+  "mcp": {
+    "chrome-devtools": {
+      "type": "remote",
+      "url": "https://<machine>.tailnet.ts.net/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+Once configured, the MCP tools (`navigate_page`, `take_screenshot`, `evaluate_script`, …) route to the remote browser automatically — no `--remote` flag needed.
+
+## CLI scripting with --remote
+
+For scripting or when an agent needs to call the CLI directly:
+
+```bash
+export CHROME_DEVTOOLS_MCP_REMOTE_URL="https://<machine>.tailnet.ts.net/mcp"
+
+# Verify the server is up
+chrome-devtools status --remote "$CHROME_DEVTOOLS_MCP_REMOTE_URL"
+# → remote=... status=ok http=200
+
+# Chain commands — same server-side tab throughout
+chrome-devtools navigate_page https://example.com --remote "$CHROME_DEVTOOLS_MCP_REMOTE_URL"
+chrome-devtools take_snapshot --remote "$CHROME_DEVTOOLS_MCP_REMOTE_URL" --output-format json
+chrome-devtools take_screenshot --remote "$CHROME_DEVTOOLS_MCP_REMOTE_URL"
+```
+
+Three flags for non-standard setups:
+- `--header "Authorization: Bearer $TOKEN"` — bearer/static auth, repeatable
+- `--insecure` — skip TLS verification for self-signed certs (or `CHROME_DEVTOOLS_MCP_REMOTE_INSECURE=1`)
+- Session ids are cached at `~/.cache/chrome-devtools-mcp/remote/` (0600) so chained calls reuse the same tab
+
+## Multiple agents, one server
+
+The HTTP transport supports concurrent sessions. Each agent (Claude Code, Cursor, OpenCode …) gets its own session and tab state; they share a single browser and one serialized tool mutex. Sessions idle-expire after 10 min (tunable via `CHROME_DEVTOOLS_MCP_SESSION_IDLE_TTL_MS`).
+
+## Failure modes
+
+| Symptom | Fix |
+| ------- | --- |
+| `Failed to reach remote` | Check Tailscale is up; verify the URL ends in `/mcp` |
+| `404 Session not found` | Server restarted; run `chrome-devtools stop --remote $URL` then retry |
+| TLS verify error | Add `--insecure` (self-signed cert) |
+| `chrome-devtools: command not found` | `npm install -g @vibebrowser/chrome-devtools-mcp` then add `$(npm config get prefix)/bin` to PATH |

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -281,6 +281,12 @@ export const cliOptions = {
       'If true, redacts some of the network headers considered sensitive before returning to the client.',
     default: false,
   },
+  port: {
+    type: 'number',
+    describe:
+      'If specified, starts a Streamable HTTP transport on the given port instead of stdio. Allows multiple agents to connect to the same MCP server instance over HTTP.',
+    alias: 'p',
+  },
 } satisfies Record<string, YargsOptions>;
 
 export type ParsedArguments = ReturnType<typeof parseArguments>;

--- a/src/bin/chrome-devtools-mcp-main.ts
+++ b/src/bin/chrome-devtools-mcp-main.ts
@@ -6,13 +6,21 @@
 
 import '../polyfill.js';
 
+import {randomUUID} from 'node:crypto';
+import {createServer, type ServerResponse} from 'node:http';
 import process from 'node:process';
 
 import {createMcpServer, logDisclaimers} from '../index.js';
 import {logger, saveLogsToFile} from '../logger.js';
+import {Mutex} from '../Mutex.js';
 import {ClearcutLogger} from '../telemetry/ClearcutLogger.js';
 import {computeFlagUsage} from '../telemetry/flagUtils.js';
-import {StdioServerTransport} from '../third_party/index.js';
+import {FilePersistence} from '../telemetry/persistence.js';
+import {
+  StdioServerTransport,
+  StreamableHTTPServerTransport,
+  isInitializeRequest,
+} from '../third_party/index.js';
 import {checkForUpdates} from '../utils/check-for-updates.js';
 import {VERSION} from '../version.js';
 
@@ -26,6 +34,20 @@ export const args = parseArguments(VERSION);
 
 const logFile = args.logFile ? saveLogsToFile(args.logFile) : undefined;
 
+// Telemetry is process-scoped, not server-scoped. Initialize it once here so
+// that in HTTP mode (where an McpServer is created per session) it is ready
+// before any session connects and the server-start event is recorded.
+if (args.usageStatistics) {
+  ClearcutLogger.initialize({
+    persistence: new FilePersistence(),
+    logFile: args.logFile,
+    appVersion: VERSION,
+    clearcutEndpoint: args.clearcutEndpoint,
+    clearcutForceFlushIntervalMs: args.clearcutForceFlushIntervalMs,
+    clearcutIncludePidHeader: args.clearcutIncludePidHeader,
+  });
+}
+
 if (process.env['CHROME_DEVTOOLS_MCP_CRASH_ON_UNCAUGHT'] !== 'true') {
   process.on('unhandledRejection', (reason, promise) => {
     logger('Unhandled promise rejection', promise, reason);
@@ -33,11 +55,351 @@ if (process.env['CHROME_DEVTOOLS_MCP_CRASH_ON_UNCAUGHT'] !== 'true') {
 }
 
 logger(`Starting Chrome DevTools MCP Server v${VERSION}`);
-const {server} = await createMcpServer(args, {
-  logFile,
-});
-const transport = new StdioServerTransport();
-await server.connect(transport);
+
+if (args.port) {
+  // Each MCP session owns its own McpServer + McpContext but shares one
+  // browser. `dispose` releases that session's collectors/listeners when it
+  // disconnects. Holding multiple entries concurrently is expected — a new
+  // session no longer evicts existing ones.
+  interface Session {
+    transport: StreamableHTTPServerTransport;
+    dispose: () => void;
+    /** Epoch ms of the last request routed to this session; drives reaping. */
+    lastActivity: number;
+    /**
+     * Requests currently being handled (POSTs in flight + the long-lived GET
+     * SSE stream while a client holds it open). The reaper must not touch a
+     * session with work in flight — that would dispose the McpContext under
+     * the handler's feet, or kill the notification stream of a client that is
+     * connected and just idle.
+     */
+    activeRequests: number;
+  }
+  const sessions = new Map<string, Session>();
+
+  // The Streamable HTTP client SDK does not send an MCP DELETE on close() — it
+  // just drops the connection. Without the old "evict on initialize" behaviour
+  // nothing would ever reclaim those sessions, so the server reaps them itself:
+  // idle sessions are terminated after a TTL, and a hard cap bounds memory even
+  // under a flood of connects. Both are overridable via env for tests/tuning.
+  function readPositiveIntEnv(name: string, fallback: number): number {
+    const raw = process.env[name];
+    const parsed = raw ? Number(raw) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+  const SESSION_IDLE_TTL_MS = readPositiveIntEnv(
+    'CHROME_DEVTOOLS_MCP_SESSION_IDLE_TTL_MS',
+    10 * 60_000,
+  );
+  const MAX_SESSIONS = readPositiveIntEnv(
+    'CHROME_DEVTOOLS_MCP_MAX_SESSIONS',
+    100,
+  );
+
+  // One mutex shared across every session. Sessions share a single browser,
+  // so tool execution must stay globally serialized even though each session
+  // has its own McpServer.
+  const toolMutex = new Mutex();
+
+  // Remove a session and release its resources. Idempotent: the map entry is
+  // deleted synchronously up front, so a re-entrant call (e.g. the transport's
+  // own onclose firing from the close() below) is a harmless no-op. This is
+  // the single place a session is torn down — reaping, capacity eviction and
+  // client-initiated DELETE all funnel through here.
+  function removeSession(id: string, reason: string): void {
+    const session = sessions.get(id);
+    if (!session) {
+      return;
+    }
+    sessions.delete(id);
+    console.error(
+      `[HTTP] session removed: ${id} (${reason}, remaining: ${sessions.size})`,
+    );
+    try {
+      session.dispose();
+    } catch (err) {
+      logger(`Error disposing session ${id}:`, err);
+    }
+    void session.transport.close().catch(err => {
+      logger(`Error closing transport for session ${id}:`, err);
+    });
+  }
+
+  // Periodically reap sessions with no traffic for longer than the TTL. This
+  // is the only thing that reclaims clients that vanished without an MCP
+  // DELETE (crash, network loss, SDK close()). unref() so it never keeps the
+  // process alive on its own.
+  const reaper = setInterval(
+    () => {
+      const cutoff = Date.now() - SESSION_IDLE_TTL_MS;
+      for (const [id, session] of sessions) {
+        // A session with work in flight (POST being handled, or the GET SSE
+        // stream still open) is NOT idle even if lastActivity is stale —
+        // skip it. Capacity eviction is the only path that can override this
+        // and still claim an active session, since the cap is a hard limit.
+        if (session.activeRequests === 0 && session.lastActivity < cutoff) {
+          removeSession(id, 'idle');
+        }
+      }
+    },
+    Math.min(SESSION_IDLE_TTL_MS, 60_000),
+  );
+  reaper.unref();
+
+  // Send a JSON-RPC 2.0 error response. Using the JSON-RPC envelope (rather
+  // than an ad-hoc {error: '...'} object) matches what StreamableHTTPServerTransport
+  // itself emits, so clients see a consistent shape on every failure path.
+  function sendJsonRpcError(
+    res: ServerResponse,
+    httpStatus: number,
+    code: number,
+    message: string,
+  ): void {
+    if (res.headersSent) {
+      return;
+    }
+    res.writeHead(httpStatus, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify({jsonrpc: '2.0', error: {code, message}, id: null}));
+  }
+
+  const httpServer = createServer(async (req, res) => {
+    const url = new URL(req.url || '/', `http://localhost:${args.port}`);
+    console.error(
+      `[HTTP] ${req.method} ${url.pathname} session=${req.headers['mcp-session-id'] ?? 'none'} accept=${req.headers['accept'] ?? 'none'}`,
+    );
+    if (url.pathname === '/mcp') {
+      const rawSessionId = req.headers['mcp-session-id'];
+      const sessionId = Array.isArray(rawSessionId)
+        ? rawSessionId[0]
+        : rawSessionId;
+
+      if (sessionId && sessions.has(sessionId)) {
+        const session = sessions.get(sessionId);
+        if (session) {
+          console.error(`[HTTP] routing to existing session ${sessionId}`);
+          // Track in-flight work so the reaper doesn't tear the session down
+          // mid-handler. Bumping lastActivity in finally too means a slow tool
+          // call doesn't get reaped just because its request arrived long ago.
+          session.lastActivity = Date.now();
+          session.activeRequests++;
+          try {
+            await session.transport.handleRequest(req, res);
+          } finally {
+            session.activeRequests--;
+            session.lastActivity = Date.now();
+          }
+          return;
+        }
+      }
+
+      // Requests for a known session were already routed above. Anything
+      // reaching here is either a fresh initialize or a request for a session
+      // we don't have. Parse the body defensively: GET (SSE) and DELETE
+      // (teardown) requests carry no body, and a malformed body must not throw
+      // out of this async handler — that would leave the request hanging with
+      // no response.
+      const body = await new Promise<string>(resolve => {
+        let data = '';
+        req.on('data', chunk => (data += chunk));
+        req.on('end', () => resolve(data));
+      });
+
+      let jsonBody: unknown;
+      let parseError = false;
+      try {
+        jsonBody = body.length > 0 ? JSON.parse(body) : undefined;
+      } catch {
+        parseError = true;
+      }
+
+      const isInitialize =
+        !parseError &&
+        (isInitializeRequest(jsonBody) ||
+          (Array.isArray(jsonBody) && jsonBody.some(isInitializeRequest)));
+
+      if (isInitialize) {
+        // Each initialize creates an independent session: its own McpServer
+        // and McpContext over the shared browser. Sessions no longer evict
+        // one another, so concurrent initializes need no serialization —
+        // browser launch stays serialized by the shared tool mutex.
+        try {
+          const {server, dispose} = await createMcpServer(args, {
+            logFile,
+            toolMutex,
+          });
+
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+          });
+          // Fires on a client-initiated DELETE or any transport-level close.
+          // removeSession is idempotent, so a close() we triggered ourselves
+          // (reaping/capacity) re-entering here is a safe no-op.
+          transport.onclose = () => {
+            const id = [...sessions.entries()].find(
+              ([, s]) => s.transport === transport,
+            )?.[0];
+            if (id) {
+              removeSession(id, 'client-closed');
+            }
+          };
+          await server.connect(transport);
+          await transport.handleRequest(req, res, jsonBody);
+          // transport.sessionId is a public getter on StreamableHTTPServerTransport
+          const respSessionId =
+            transport.sessionId ??
+            ((): string | undefined => {
+              const h = res.getHeader('mcp-session-id');
+              return typeof h === 'string' ? h : undefined;
+            })();
+          if (respSessionId) {
+            sessions.set(respSessionId, {
+              transport,
+              dispose,
+              lastActivity: Date.now(),
+              activeRequests: 0,
+            });
+            console.error(
+              `[HTTP] new session registered: ${respSessionId} (total: ${sessions.size})`,
+            );
+            // Enforce the cap by evicting the least-recently-active session.
+            // removeSession deletes synchronously, so the loop makes progress.
+            while (sessions.size > MAX_SESSIONS) {
+              let oldestId: string | undefined;
+              let oldest = Infinity;
+              for (const [id, s] of sessions) {
+                if (id !== respSessionId && s.lastActivity < oldest) {
+                  oldest = s.lastActivity;
+                  oldestId = id;
+                }
+              }
+              if (!oldestId) {
+                break;
+              }
+              removeSession(oldestId, 'capacity');
+            }
+          } else {
+            // No session ID was issued — the connection is unusable. Dispose
+            // immediately so the McpContext is not leaked.
+            dispose();
+            console.error(`[HTTP] WARNING: no session ID after initialize`);
+          }
+        } catch (err) {
+          logger('Error handling initialize request:', err);
+          if (!res.headersSent) {
+            res.writeHead(500, {'Content-Type': 'application/json'});
+            res.end(JSON.stringify({error: 'Internal server error'}));
+          }
+        }
+      } else if (sessionId) {
+        // Session ID present but unknown to this process — almost always a
+        // session that died with a server restart. 404 is the Streamable HTTP
+        // spec signal that tells a conformant client to start a new session.
+        console.error(
+          `[HTTP] 404 unknown session: ${sessionId} (known: ${[...sessions.keys()].join(', ')})`,
+        );
+        sendJsonRpcError(res, 404, -32001, 'Session not found');
+      } else if (parseError) {
+        console.error(
+          `[HTTP] 400 unparseable body (method=${req.method}, length=${body.length})`,
+        );
+        sendJsonRpcError(res, 400, -32700, 'Parse error: invalid JSON');
+      } else {
+        console.error(`[HTTP] 400 missing session id, method=${req.method}`);
+        sendJsonRpcError(
+          res,
+          400,
+          -32000,
+          'Bad Request: Mcp-Session-Id header is required',
+        );
+      }
+    } else if (url.pathname === '/health') {
+      // Health check: verify Chrome is still reachable
+      try {
+        let chromeRunning = false;
+
+        if (args.browserUrl) {
+          // When using --browserUrl, check Chrome's HTTP endpoint directly
+          const http = await import('node:http');
+          chromeRunning = await new Promise<boolean>(resolve => {
+            const checkUrl = new URL(
+              '/json/version',
+              args.browserUrl as string,
+            );
+            const checkReq = http.get(checkUrl, {timeout: 2000}, checkRes => {
+              resolve(checkRes.statusCode === 200);
+              checkRes.resume();
+            });
+            checkReq.on('error', () => resolve(false));
+            checkReq.on('timeout', () => {
+              checkReq.destroy();
+              resolve(false);
+            });
+          });
+        } else {
+          // Fallback: check DevToolsActivePort file
+          const fs = await import('node:fs');
+          const path = await import('node:path');
+          const homeDir = process.env['HOME'] || '/tmp';
+          const platform = process.platform;
+          let userDataDir: string;
+          if (platform === 'darwin') {
+            userDataDir = path.join(
+              homeDir,
+              'Library',
+              'Application Support',
+              'Google',
+              'Chrome',
+            );
+          } else {
+            userDataDir = path.join(homeDir, '.config', 'google-chrome');
+          }
+          const portFile = path.join(userDataDir, 'DevToolsActivePort');
+          chromeRunning = fs.existsSync(portFile);
+        }
+
+        const status = chromeRunning ? 'ok' : 'error';
+        res.writeHead(chromeRunning ? 200 : 503, {
+          'Content-Type': 'application/json',
+        });
+        res.end(
+          JSON.stringify({
+            status,
+            chrome_connected: chromeRunning,
+            sessions: sessions.size,
+            ...(chromeRunning ? {} : {error: 'Chrome is not reachable'}),
+          }),
+        );
+      } catch (err) {
+        res.writeHead(503, {'Content-Type': 'application/json'});
+        res.end(
+          JSON.stringify({
+            status: 'error',
+            chrome_connected: false,
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      }
+    } else {
+      res.writeHead(404);
+      res.end('Not found. Use /mcp endpoint.');
+    }
+  });
+
+  httpServer.listen(args.port, () => {
+    logger(
+      `Chrome DevTools MCP Server listening on http://localhost:${args.port}/mcp`,
+    );
+    console.error(
+      `Chrome DevTools MCP Server listening on http://localhost:${args.port}/mcp`,
+    );
+  });
+} else {
+  // Stdio mode is inherently single-session: one client, one McpServer.
+  const {server} = await createMcpServer(args, {logFile});
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
 logger('Chrome DevTools MCP Server connected');
 logDisclaimers(args);
 void ClearcutLogger.get()?.logDailyActiveIfNeeded();

--- a/src/bin/chrome-devtools-mcp.ts
+++ b/src/bin/chrome-devtools-mcp.ts
@@ -33,4 +33,20 @@ if (major < 20) {
   process.exit(1);
 }
 
-await import('./chrome-devtools-mcp-main.js');
+const subcommand = process.argv[2];
+if (
+  subcommand === 'install' ||
+  subcommand === 'uninstall' ||
+  subcommand === 'status'
+) {
+  // Pass remaining args after the subcommand, then append the action
+  process.argv = [
+    process.argv[0]!,
+    process.argv[1]!,
+    ...process.argv.slice(3),
+    subcommand,
+  ];
+  await import('./install-service.js');
+} else {
+  await import('./chrome-devtools-mcp-main.js');
+}

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -18,6 +18,13 @@ import {
   sendCommand,
   handleResponse,
 } from '../daemon/client.js';
+import {
+  fetchRemoteHealth,
+  invokeRemoteTool,
+  parseHeaderFlags,
+  stopRemoteSession,
+  type RemoteOptions,
+} from '../daemon/remote-client.js';
 import {isDaemonRunning, serializeArgs} from '../daemon/utils.js';
 import {logDisclaimers} from '../index.js';
 import {hideBin, yargs, type CallToolResult} from '../third_party/index.js';
@@ -74,11 +81,71 @@ const y = yargs(hideBin(process.argv))
     default: '',
     hidden: true,
   })
+  .option('remote', {
+    type: 'string',
+    description:
+      'Connect to a remote chrome-devtools-mcp HTTP endpoint (e.g. https://host.tailnet/mcp) instead of running a local daemon. Defaults to $CHROME_DEVTOOLS_MCP_REMOTE_URL.',
+    default: process.env['CHROME_DEVTOOLS_MCP_REMOTE_URL'],
+  })
+  .option('header', {
+    type: 'array',
+    string: true,
+    description:
+      'Header to attach to remote requests, e.g. --header "Authorization: Bearer ...". Repeatable. Only honored with --remote.',
+    default: [] as string[],
+  })
+  .option('insecure', {
+    type: 'boolean',
+    description:
+      'Disable TLS certificate verification for --remote. Useful for self-signed tailnet certs. Defaults to $CHROME_DEVTOOLS_MCP_REMOTE_INSECURE.',
+    default:
+      process.env['CHROME_DEVTOOLS_MCP_REMOTE_INSECURE'] === '1' ||
+      process.env['CHROME_DEVTOOLS_MCP_REMOTE_INSECURE'] === 'true',
+  })
   .demandCommand()
   .version(VERSION)
   .strict()
   .help(true)
   .wrap(120);
+
+/**
+ * Parse and validate top-level --remote flags into a RemoteOptions value.
+ * Returns undefined when --remote is not set (i.e. local daemon mode).
+ * Exits with a non-zero status on user-visible validation errors so the
+ * caller can stay in the happy path.
+ */
+function resolveRemoteOptions(argv: {
+  remote?: string;
+  header?: string[];
+  insecure?: boolean;
+}): RemoteOptions | undefined {
+  if (!argv.remote) {
+    return undefined;
+  }
+  let url: URL;
+  try {
+    url = new URL(argv.remote);
+  } catch {
+    console.error(
+      `Invalid --remote URL: ${JSON.stringify(argv.remote)}. Expected e.g. https://host.tailnet/mcp.`,
+    );
+    process.exit(2);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    console.error(
+      `Invalid --remote URL: ${url.toString()} (must use http:// or https://).`,
+    );
+    process.exit(2);
+  }
+  let headers: Record<string, string> | undefined;
+  try {
+    headers = parseHeaderFlags(argv.header);
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(2);
+  }
+  return {url, headers, insecure: argv.insecure};
+}
 
 y.command(
   'start',
@@ -92,6 +159,15 @@ y.command(
       )
       .strict(),
   async argv => {
+    if (argv.remote) {
+      console.error(
+        'start is not supported with --remote: the server lives on the remote host.',
+      );
+      console.error(
+        'Start chrome-devtools-mcp on the remote host directly (e.g. as a service or `npx chrome-devtools-mcp --port 3100`).',
+      );
+      process.exit(2);
+    }
     if (isDaemonRunning(argv.sessionId)) {
       await stopDaemon(argv.sessionId);
     }
@@ -113,6 +189,20 @@ y.command(
   'Checks if chrome-devtools-mcp is running',
   y => y,
   async argv => {
+    const remote = resolveRemoteOptions(argv);
+    if (remote) {
+      try {
+        const health = await fetchRemoteHealth(remote);
+        console.log(
+          `remote=${remote.url.toString()} status=${health.ok ? 'ok' : 'error'} http=${health.status}`,
+        );
+        console.log(JSON.stringify(health.body, null, 2));
+        process.exit(health.ok ? 0 : 1);
+      } catch (err) {
+        console.error('Failed to reach remote:', (err as Error).message);
+        process.exit(1);
+      }
+    }
     if (isDaemonRunning(argv.sessionId)) {
       console.log('chrome-devtools-mcp daemon is running.');
       const response = await sendCommand(
@@ -149,6 +239,11 @@ y.command(
   'Stop chrome-devtools-mcp if any',
   y => y,
   async argv => {
+    const remote = resolveRemoteOptions(argv);
+    if (remote) {
+      await stopRemoteSession(remote);
+      process.exit(0);
+    }
     const sessionId = argv.sessionId as string;
     if (!isDaemonRunning(sessionId)) {
       process.exit(0);
@@ -224,16 +319,31 @@ for (const [commandName, commandDef] of Object.entries(commands)) {
     },
     async argv => {
       const sessionId = argv.sessionId as string;
+      const remote = resolveRemoteOptions(argv);
+      const commandArgs: Record<string, unknown> = {};
+      for (const argName of Object.keys(args)) {
+        if (argName in argv) {
+          commandArgs[argName] = argv[argName];
+        }
+      }
       try {
-        if (!isDaemonRunning(sessionId)) {
-          await start([], sessionId);
+        if (remote) {
+          const result = await invokeRemoteTool({
+            ...remote,
+            tool: commandName,
+            args: commandArgs,
+          });
+          console.log(
+            await handleResponse(
+              result,
+              argv['output-format'] as 'json' | 'md',
+            ),
+          );
+          return;
         }
 
-        const commandArgs: Record<string, unknown> = {};
-        for (const argName of Object.keys(args)) {
-          if (argName in argv) {
-            commandArgs[argName] = argv[argName];
-          }
+        if (!isDaemonRunning(sessionId)) {
+          await start([], sessionId);
         }
 
         const response = await sendCommand(

--- a/src/bin/install-service.ts
+++ b/src/bin/install-service.ts
@@ -1,0 +1,554 @@
+#!/usr/bin/env node
+
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {execSync} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_PORT = 9333;
+
+function getNodePath(): string {
+  return process.execPath;
+}
+
+function getBinPath(): string {
+  return path.resolve(__dirname, 'chrome-devtools-mcp.js');
+}
+
+function commandExists(cmd: string): boolean {
+  try {
+    execSync(`which ${cmd}`, {stdio: 'pipe'});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write a JSON config file atomically: serialize to a temp file on the same
+ * directory, then rename over the target. rename(2) is atomic, so a reader (or
+ * a crash) never observes a half-written file.
+ */
+function writeJsonAtomic(filePath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), {recursive: true});
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2) + '\n');
+  fs.renameSync(tmpPath, filePath);
+}
+
+/**
+ * Configure the `chrome-devtools` MCP server in Claude Code via its CLI.
+ *
+ * `claude mcp add -s user` rewrites the whole ~/.claude.json. If a Claude Code
+ * session is running concurrently it also rewrites that file, and the two can
+ * race into a corrupted config. We can't lock the CLI, but we can back up the
+ * file first and restore it if the result is no longer valid JSON.
+ */
+function configureClaudeCode(url: string): boolean {
+  if (!commandExists('claude')) {
+    console.log(`  ⏭️  Claude Code — not installed`);
+    return false;
+  }
+
+  const claudeConfig = path.join(process.env['HOME'] || '', '.claude.json');
+  let backup: string | undefined;
+  if (fs.existsSync(claudeConfig)) {
+    backup = fs.readFileSync(claudeConfig, 'utf-8');
+    try {
+      JSON.parse(backup);
+    } catch {
+      console.log(
+        `  ⚠️  Claude Code — ~/.claude.json is already invalid JSON; skipping to avoid further damage`,
+      );
+      return false;
+    }
+  }
+
+  try {
+    execSync(`claude mcp remove chrome-devtools -s user 2>/dev/null`, {
+      stdio: 'pipe',
+    });
+  } catch {
+    /* ignore — server may not have been configured */
+  }
+
+  try {
+    execSync(`claude mcp add --transport http -s user chrome-devtools ${url}`, {
+      stdio: 'pipe',
+    });
+  } catch (e) {
+    console.log(`  ⚠️  Claude Code — failed: ${(e as Error).message}`);
+    return false;
+  }
+
+  // Verify the CLI did not corrupt ~/.claude.json.
+  if (backup !== undefined && fs.existsSync(claudeConfig)) {
+    try {
+      JSON.parse(fs.readFileSync(claudeConfig, 'utf-8'));
+    } catch {
+      fs.writeFileSync(claudeConfig, backup);
+      console.log(
+        `  ⚠️  Claude Code — ~/.claude.json was corrupted during the update and has been restored from backup.`,
+      );
+      console.log(
+        `     Quit all running Claude Code sessions, then re-run install:service.`,
+      );
+      return false;
+    }
+  }
+
+  console.log(`  ✅ Claude Code — configured`);
+  return true;
+}
+
+function configureAgents(url: string) {
+  console.log(`\n📋 Configuring agents...\n`);
+  let configured = 0;
+
+  // Claude Code
+  if (configureClaudeCode(url)) {
+    configured++;
+  }
+
+  // Copilot CLI
+  const copilotConfig = path.join(
+    process.env['HOME'] || '',
+    '.copilot',
+    'mcp-config.json',
+  );
+  try {
+    let config: Record<string, unknown> = {};
+    if (fs.existsSync(copilotConfig)) {
+      config = JSON.parse(fs.readFileSync(copilotConfig, 'utf-8'));
+    }
+    const servers = (config['mcpServers'] || {}) as Record<string, unknown>;
+    servers['chrome-devtools'] = {type: 'http', url};
+    config['mcpServers'] = servers;
+    writeJsonAtomic(copilotConfig, config);
+    console.log(`  ✅ Copilot CLI — configured (${copilotConfig})`);
+    configured++;
+  } catch (e) {
+    console.log(`  ⚠️  Copilot CLI — failed: ${(e as Error).message}`);
+  }
+
+  // OpenCode
+  const opencodeBin = commandExists('opencode');
+  const opencodeConfig = path.join(
+    process.env['HOME'] || '',
+    '.config',
+    'opencode',
+    'opencode.json',
+  );
+  if (opencodeBin || fs.existsSync(opencodeConfig)) {
+    try {
+      let config: Record<string, unknown> = {};
+      if (fs.existsSync(opencodeConfig)) {
+        config = JSON.parse(fs.readFileSync(opencodeConfig, 'utf-8'));
+      }
+      const mcp = (config['mcp'] || {}) as Record<string, unknown>;
+      mcp['chrome-devtools'] = {type: 'remote', url, enabled: true};
+      config['mcp'] = mcp;
+      writeJsonAtomic(opencodeConfig, config);
+      console.log(`  ✅ OpenCode — configured (${opencodeConfig})`);
+      configured++;
+    } catch (e) {
+      console.log(`  ⚠️  OpenCode — failed: ${(e as Error).message}`);
+    }
+  } else {
+    console.log(`  ⏭️  OpenCode — not installed`);
+  }
+
+  if (configured === 0) {
+    console.log(`\n  Manual config — add to your MCP client:`);
+    console.log(`  ${JSON.stringify({url})}\n`);
+  } else {
+    console.log(`\n  🎉 ${configured} agent(s) configured with ${url}\n`);
+  }
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let port = DEFAULT_PORT;
+  let tailscale = false;
+  let action: 'install' | 'uninstall' | 'status' = 'install';
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--port' || args[i] === '-p') {
+      port = parseInt(args[++i]!, 10);
+    } else if (args[i] === '--tailscale') {
+      tailscale = true;
+    } else if (args[i] === 'uninstall') {
+      action = 'uninstall';
+    } else if (args[i] === 'status') {
+      action = 'status';
+    }
+  }
+  return {port, action, tailscale};
+}
+
+function installMacOS(port: number) {
+  const templatePath = path.resolve(
+    __dirname,
+    'service',
+    'com.vibebrowser.chrome-devtools-mcp.plist.template',
+  );
+  const template = fs.readFileSync(templatePath, 'utf-8');
+
+  const logDir = path.join(
+    process.env['HOME'] || '/tmp',
+    'Library',
+    'Logs',
+    'chrome-devtools-mcp',
+  );
+  fs.mkdirSync(logDir, {recursive: true});
+
+  const plist = template
+    .replaceAll('{{NODE_PATH}}', getNodePath())
+    .replaceAll('{{BIN_PATH}}', getBinPath())
+    .replaceAll('{{PORT}}', String(port))
+    .replaceAll('{{LOG_DIR}}', logDir);
+
+  const plistDir = path.join(
+    process.env['HOME'] || '/tmp',
+    'Library',
+    'LaunchAgents',
+  );
+  fs.mkdirSync(plistDir, {recursive: true});
+
+  const plistPath = path.join(
+    plistDir,
+    'com.vibebrowser.chrome-devtools-mcp.plist',
+  );
+
+  // Unload if already loaded
+  try {
+    execSync(`launchctl unload "${plistPath}" 2>/dev/null`);
+  } catch {
+    // ignore
+  }
+
+  fs.writeFileSync(plistPath, plist);
+  execSync(`launchctl load "${plistPath}"`);
+
+  console.log(`✅ Installed and started launchd service`);
+  console.log(`   Plist: ${plistPath}`);
+  console.log(`   Logs:  ${logDir}/`);
+  console.log(`   URL:   http://localhost:${port}/mcp`);
+}
+
+function uninstallMacOS() {
+  const plistPath = path.join(
+    process.env['HOME'] || '/tmp',
+    'Library',
+    'LaunchAgents',
+    'com.vibebrowser.chrome-devtools-mcp.plist',
+  );
+
+  try {
+    execSync(`launchctl unload "${plistPath}" 2>/dev/null`);
+  } catch {
+    // ignore
+  }
+
+  if (fs.existsSync(plistPath)) {
+    fs.unlinkSync(plistPath);
+    console.log(`✅ Uninstalled launchd service`);
+  } else {
+    console.log(`⚠️  Service not installed`);
+  }
+}
+
+function statusMacOS() {
+  try {
+    const output = execSync(
+      'launchctl list com.vibebrowser.chrome-devtools-mcp 2>&1',
+      {encoding: 'utf-8'},
+    );
+    console.log(`Service status:\n${output}`);
+  } catch {
+    console.log('Service is not loaded');
+  }
+}
+
+function detectChromeConnectFlag(): string {
+  // If Chrome is running with --remote-debugging-port, use --browserUrl
+  try {
+    const output = execSync(
+      'ps aux | grep -E "remote-debugging-port" | grep -v grep',
+      {encoding: 'utf-8', stdio: 'pipe'},
+    );
+    const portMatch = output.match(/--remote-debugging-port=(\d+)/);
+    if (portMatch) {
+      const debugPort = portMatch[1];
+      return `--browserUrl http://127.0.0.1:${debugPort}`;
+    }
+  } catch {
+    // no Chrome with remote debugging found
+  }
+  // Fallback to autoConnect (requires DevToolsActivePort in default profile)
+  return '--autoConnect';
+}
+
+function installLinux(port: number) {
+  const templatePath = path.resolve(
+    __dirname,
+    'service',
+    'chrome-devtools-mcp.service.template',
+  );
+  const template = fs.readFileSync(templatePath, 'utf-8');
+
+  const connectFlag = detectChromeConnectFlag();
+  console.log(`   Chrome connection: ${connectFlag}`);
+
+  const service = template
+    .replaceAll('{{NODE_PATH}}', getNodePath())
+    .replaceAll('{{BIN_PATH}}', getBinPath())
+    .replaceAll('{{CONNECT_FLAG}}', connectFlag)
+    .replaceAll('{{PORT}}', String(port));
+
+  const serviceDir = path.join(
+    process.env['HOME'] || '/tmp',
+    '.config',
+    'systemd',
+    'user',
+  );
+  fs.mkdirSync(serviceDir, {recursive: true});
+
+  const servicePath = path.join(serviceDir, 'chrome-devtools-mcp.service');
+  fs.writeFileSync(servicePath, service);
+
+  execSync('systemctl --user daemon-reload');
+  execSync('systemctl --user enable chrome-devtools-mcp.service');
+  execSync('systemctl --user start chrome-devtools-mcp.service');
+
+  console.log(`✅ Installed and started systemd user service`);
+  console.log(`   Unit:  ${servicePath}`);
+  console.log(`   URL:   http://localhost:${port}/mcp`);
+  console.log(`   Logs:  journalctl --user -u chrome-devtools-mcp`);
+}
+
+function uninstallLinux() {
+  try {
+    execSync('systemctl --user stop chrome-devtools-mcp.service 2>/dev/null');
+    execSync(
+      'systemctl --user disable chrome-devtools-mcp.service 2>/dev/null',
+    );
+  } catch {
+    // ignore
+  }
+
+  const servicePath = path.join(
+    process.env['HOME'] || '/tmp',
+    '.config',
+    'systemd',
+    'user',
+    'chrome-devtools-mcp.service',
+  );
+
+  if (fs.existsSync(servicePath)) {
+    fs.unlinkSync(servicePath);
+    execSync('systemctl --user daemon-reload');
+    console.log(`✅ Uninstalled systemd service`);
+  } else {
+    console.log(`⚠️  Service not installed`);
+  }
+}
+
+function statusLinux() {
+  try {
+    const output = execSync(
+      'systemctl --user status chrome-devtools-mcp.service 2>&1',
+      {encoding: 'utf-8'},
+    );
+    console.log(output);
+  } catch (e) {
+    console.log((e as {stdout?: string}).stdout || 'Service is not installed');
+  }
+}
+
+function installTailscale(port: number) {
+  // Check tailscale is available
+  try {
+    execSync('tailscale version', {stdio: 'pipe'});
+  } catch {
+    console.error(
+      '❌ tailscale CLI not found. Install from https://tailscale.com/download',
+    );
+    process.exit(1);
+  }
+
+  // Check tailscale is connected
+  try {
+    const status = execSync('tailscale status --json', {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    const parsed = JSON.parse(status);
+    if (parsed.BackendState !== 'Running') {
+      console.error('❌ Tailscale is not connected. Run: tailscale up');
+      process.exit(1);
+    }
+  } catch {
+    console.error('❌ Could not get tailscale status. Is it running?');
+    process.exit(1);
+  }
+
+  // Expose via tailscale serve
+  try {
+    execSync(`tailscale serve --bg --https=443 http://localhost:${port}`, {
+      stdio: 'inherit',
+    });
+  } catch {
+    // Retry without --https (older tailscale versions)
+    try {
+      execSync(`tailscale serve --bg ${port}`, {stdio: 'inherit'});
+    } catch (e) {
+      console.error(
+        '❌ Failed to configure tailscale serve:',
+        (e as Error).message,
+      );
+      process.exit(1);
+    }
+  }
+
+  // Get the tailscale hostname
+  try {
+    const dnsName = execSync('tailscale status --json', {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    const parsed = JSON.parse(dnsName);
+    const self = parsed.Self;
+    const hostname =
+      self?.DNSName?.replace(/\.$/, '') || '<your-machine>.tailnet.ts.net';
+    console.log(`\n✅ Tailscale serve configured`);
+    console.log(`   Remote URL: https://${hostname}/mcp`);
+    console.log(`   Accessible from any device on your tailnet`);
+    configureAgents(`https://${hostname}/mcp`);
+  } catch {
+    console.log(`\n✅ Tailscale serve configured`);
+    console.log(`   Remote URL: https://<your-machine>.tailnet.ts.net/mcp`);
+    configureAgents('https://<your-machine>.tailnet.ts.net/mcp');
+  }
+}
+
+function uninstallTailscale() {
+  try {
+    execSync(`tailscale serve --remove / 2>/dev/null`, {stdio: 'pipe'});
+    console.log('✅ Removed tailscale serve');
+  } catch {
+    // ignore — might not have been configured
+  }
+}
+
+async function healthCheck(
+  port: number,
+  retries = 15,
+  delayMs = 2000,
+): Promise<boolean> {
+  const url = `http://localhost:${port}/health`;
+
+  process.stdout.write(
+    '⏳ Checking service health (verifying Chrome CDP connection)',
+  );
+
+  for (let i = 0; i < retries; i++) {
+    await new Promise(r => setTimeout(r, delayMs));
+    process.stdout.write('.');
+
+    try {
+      const res = await fetch(url, {
+        signal: AbortSignal.timeout(10000),
+      });
+
+      if (res.ok) {
+        const data = (await res.json()) as {
+          status: string;
+          chrome_connected?: boolean;
+        };
+        if (data.status === 'ok' && data.chrome_connected) {
+          console.log(' ✅ healthy (Chrome connected)');
+          return true;
+        }
+        if (data.status === 'degraded') {
+          console.log(' ⚠️  MCP running but Chrome not connected');
+          console.log(
+            '   Make sure Google Chrome is running and check the approval dialog.',
+          );
+          return false;
+        }
+      }
+    } catch {
+      // Service not ready yet
+    }
+  }
+
+  console.log(' ❌ failed');
+  console.log('   Could not verify Chrome DevTools connection.');
+  console.log(
+    '   Ensure Chrome is running. The MCP server needs the DevToolsActivePort file.',
+  );
+  return false;
+}
+
+// Main
+const {port, action, tailscale} = parseArgs();
+const platform = process.platform;
+
+if (platform === 'darwin') {
+  if (action === 'install') {
+    installMacOS(port);
+  } else if (action === 'uninstall') {
+    uninstallTailscale();
+    uninstallMacOS();
+  } else {
+    statusMacOS();
+  }
+} else if (platform === 'linux') {
+  if (action === 'install') {
+    installLinux(port);
+  } else if (action === 'uninstall') {
+    uninstallTailscale();
+    uninstallLinux();
+  } else {
+    statusLinux();
+  }
+} else {
+  console.error(`❌ Unsupported platform: ${platform}`);
+  console.error('   Supported: macOS (launchd), Linux (systemd)');
+  process.exit(1);
+}
+
+if (action === 'install') {
+  const healthy = await healthCheck(port);
+  if (!healthy) {
+    console.error(`\n⚠️  Service installed but health check failed.`);
+    console.error(`   Check logs for errors.`);
+    if (platform === 'darwin') {
+      const logDir = path.join(
+        process.env['HOME'] || '/tmp',
+        'Library',
+        'Logs',
+        'chrome-devtools-mcp',
+      );
+      console.error(`   Logs: cat ${logDir}/chrome-devtools-mcp.stderr.log`);
+    } else {
+      console.error(`   Logs: journalctl --user -u chrome-devtools-mcp`);
+    }
+    process.exit(1);
+  }
+
+  if (tailscale) {
+    installTailscale(port);
+  } else {
+    configureAgents(`http://localhost:${port}/mcp`);
+  }
+}

--- a/src/bin/service/chrome-devtools-mcp.service.template
+++ b/src/bin/service/chrome-devtools-mcp.service.template
@@ -1,0 +1,17 @@
+[Unit]
+Description=Chrome DevTools MCP Server (Streamable HTTP)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={{NODE_PATH}} --max-old-space-size=4096 {{BIN_PATH}} {{CONNECT_FLAG}} --experimentalPageIdRouting --port {{PORT}}
+Restart=on-failure
+RestartSec=5
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS=1
+Environment=CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS=1
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/src/bin/service/com.chromedvtools.chrome-devtools-mcp.plist.template
+++ b/src/bin/service/com.chromedvtools.chrome-devtools-mcp.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.vibebrowser.chrome-devtools-mcp</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{NODE_PATH}}</string>
+    <string>--max-old-space-size=4096</string>
+    <string>{{BIN_PATH}}</string>
+    <string>--autoConnect</string>
+    <string>--experimentalPageIdRouting</string>
+    <string>--port</string>
+    <string>{{PORT}}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>{{LOG_DIR}}/chrome-devtools-mcp.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{LOG_DIR}}/chrome-devtools-mcp.stderr.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    <key>CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS</key>
+    <string>1</string>
+    <key>CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS</key>
+    <string>1</string>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+</dict>
+</plist>

--- a/src/daemon/remote-client.ts
+++ b/src/daemon/remote-client.ts
@@ -1,0 +1,287 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {createHash} from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import {logger} from '../logger.js';
+import {
+  Client,
+  StreamableHTTPClientTransport,
+  type CallToolResult,
+} from '../third_party/index.js';
+import {VERSION} from '../version.js';
+
+const REMOTE_CLIENT_NAME = 'chrome-devtools-cli-remote';
+
+export interface RemoteOptions {
+  url: URL;
+  headers?: Record<string, string>;
+  insecure?: boolean;
+}
+
+interface RemoteInvocation extends RemoteOptions {
+  tool: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Sticky session storage path. Keying on a hash of the full URL (host + port +
+ * pathname) means multiple remotes on the same machine each get their own
+ * session and a host:port collision across schemes (http vs. https) cannot
+ * cross-contaminate.
+ */
+export function getRemoteSessionFilePath(url: URL): string {
+  const cacheRoot =
+    process.env['XDG_CACHE_HOME'] ||
+    path.join(os.homedir(), os.platform() === 'darwin' ? '.cache' : '.cache');
+  const dir = path.join(cacheRoot, 'chrome-devtools-mcp', 'remote');
+  // Hash the URL minus search/hash since query params are typically not part of
+  // the session identity.
+  const key = `${url.protocol}//${url.host}${url.pathname}`;
+  const hash = createHash('sha256').update(key).digest('hex').slice(0, 16);
+  return path.join(dir, `${hash}.session`);
+}
+
+export function loadStickySessionId(url: URL): string | undefined {
+  const file = getRemoteSessionFilePath(url);
+  try {
+    const content = fs.readFileSync(file, 'utf-8').trim();
+    return content || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveStickySessionId(url: URL, sessionId: string): void {
+  const file = getRemoteSessionFilePath(url);
+  try {
+    fs.mkdirSync(path.dirname(file), {recursive: true});
+    // Mode 0600 — session IDs are bearer-equivalent on the wire and should
+    // not be readable by other local users.
+    fs.writeFileSync(file, sessionId, {mode: 0o600});
+  } catch (err) {
+    logger('Failed to persist remote session id:', err);
+  }
+}
+
+export function clearStickySession(url: URL): void {
+  const file = getRemoteSessionFilePath(url);
+  try {
+    fs.unlinkSync(file);
+  } catch {
+    // ignore — already gone is fine
+  }
+}
+
+/**
+ * Apply the --insecure switch by disabling Node's TLS certificate verification
+ * for this process. Node prints its own stderr warning when this is set, which
+ * is intentional — the user asked for an insecure connection.
+ */
+function applyInsecureTlsIfRequested(insecure: boolean | undefined): void {
+  if (insecure) {
+    process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+  }
+}
+
+interface ConnectResult {
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+}
+
+async function connect(
+  opts: RemoteOptions,
+  sessionId: string | undefined,
+): Promise<ConnectResult> {
+  applyInsecureTlsIfRequested(opts.insecure);
+  const transport = new StreamableHTTPClientTransport(opts.url, {
+    sessionId,
+    requestInit: opts.headers ? {headers: opts.headers} : undefined,
+  });
+  const client = new Client(
+    {name: REMOTE_CLIENT_NAME, version: VERSION},
+    {capabilities: {}},
+  );
+  await client.connect(transport);
+  return {client, transport};
+}
+
+/**
+ * Cleanly tear down a remote connection. terminateSession() sends the MCP
+ * DELETE so the server frees its McpContext instead of waiting for the idle
+ * reaper — important when the CLI is the only client of a long-lived session.
+ *
+ * `force` controls whether to send DELETE: between CLI invocations we want the
+ * session to STAY ALIVE on the server (that is the entire point of sticky
+ * sessions), so the default is to skip DELETE and just close the local
+ * transport. Pass `force: true` for the explicit `stop` subcommand.
+ */
+async function disconnect(
+  client: Client,
+  transport: StreamableHTTPClientTransport,
+  force: boolean,
+): Promise<void> {
+  if (force) {
+    await transport.terminateSession().catch(() => undefined);
+  }
+  await client.close().catch(() => undefined);
+  await transport.close().catch(() => undefined);
+}
+
+/**
+ * Did the SDK reject because the server doesn't know our session? When
+ * Client.connect() sees a sticky sessionId pre-set on the transport it skips
+ * the initialize handshake (treating it as a reconnect) — so a server restart
+ * surfaces as a 404 on the first real call. Detect that and re-run with a
+ * fresh initialize.
+ */
+function isSessionNotFound(err: unknown): boolean {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+  const code = (err as {code?: unknown}).code;
+  return code === 404;
+}
+
+async function callOnce(
+  opts: RemoteInvocation,
+  sticky: string | undefined,
+): Promise<{result: CallToolResult; assignedSessionId?: string}> {
+  const {client, transport} = await connect(opts, sticky);
+  try {
+    const result = (await client.callTool({
+      name: opts.tool,
+      arguments: opts.args,
+    })) as CallToolResult;
+    return {result, assignedSessionId: transport.sessionId};
+  } finally {
+    await disconnect(client, transport, /* force */ false);
+  }
+}
+
+export async function invokeRemoteTool(
+  opts: RemoteInvocation,
+): Promise<CallToolResult> {
+  const sticky = loadStickySessionId(opts.url);
+  let outcome: Awaited<ReturnType<typeof callOnce>>;
+  try {
+    outcome = await callOnce(opts, sticky);
+  } catch (err) {
+    if (sticky && isSessionNotFound(err)) {
+      // Sticky pointed at a session the server no longer has (typical after a
+      // server restart). Wipe and reinitialize from scratch — the user's tab
+      // state on the server is lost, but the command itself still succeeds.
+      clearStickySession(opts.url);
+      outcome = await callOnce(opts, undefined);
+    } else {
+      throw err;
+    }
+  }
+  if (outcome.assignedSessionId && outcome.assignedSessionId !== sticky) {
+    saveStickySessionId(opts.url, outcome.assignedSessionId);
+  }
+  return outcome.result;
+}
+
+/**
+ * Explicitly terminate the sticky session on the server and remove the local
+ * pointer. Used by the `stop` subcommand under --remote.
+ */
+export async function stopRemoteSession(opts: RemoteOptions): Promise<void> {
+  const sticky = loadStickySessionId(opts.url);
+  if (!sticky) {
+    return;
+  }
+  try {
+    const {client, transport} = await connect(opts, sticky);
+    await disconnect(client, transport, /* force */ true);
+  } catch (err) {
+    logger(
+      'stopRemoteSession: server unreachable, dropping local pointer',
+      err,
+    );
+  } finally {
+    clearStickySession(opts.url);
+  }
+}
+
+export interface RemoteHealth {
+  ok: boolean;
+  status: number;
+  body: unknown;
+}
+
+/**
+ * GET <baseUrl>/health where baseUrl is derived from the --remote URL. The MCP
+ * endpoint is conventionally /mcp; replace it with /health and keep the rest.
+ */
+export async function fetchRemoteHealth(
+  opts: RemoteOptions,
+): Promise<RemoteHealth> {
+  applyInsecureTlsIfRequested(opts.insecure);
+  const healthUrl = new URL(opts.url.toString());
+  healthUrl.pathname = healthUrl.pathname.replace(/\/mcp\/?$/, '/health');
+  if (healthUrl.pathname === opts.url.pathname) {
+    // URL did not end in /mcp — assume the user passed a base URL and append.
+    healthUrl.pathname = healthUrl.pathname.replace(/\/?$/, '/health');
+  }
+  const res = await fetch(healthUrl, {
+    headers: opts.headers,
+  });
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    body = await res.text().catch(() => undefined);
+  }
+  return {ok: res.ok, status: res.status, body};
+}
+
+/**
+ * Parse a CLI --header value. Accepts both `Name: value` and `Name=value`
+ * forms. Throws on a missing separator so a typo surfaces immediately rather
+ * than silently dropping auth.
+ */
+export function parseHeaderFlag(raw: string): [string, string] {
+  const colon = raw.indexOf(':');
+  const eq = raw.indexOf('=');
+  let sepIdx: number;
+  if (colon >= 0 && (eq < 0 || colon < eq)) {
+    sepIdx = colon;
+  } else if (eq >= 0) {
+    sepIdx = eq;
+  } else {
+    throw new Error(
+      `Invalid --header value ${JSON.stringify(raw)}; expected "Name: value" or "Name=value"`,
+    );
+  }
+  const name = raw.slice(0, sepIdx).trim();
+  const value = raw.slice(sepIdx + 1).trim();
+  if (!name) {
+    throw new Error(
+      `Invalid --header value ${JSON.stringify(raw)}; empty header name`,
+    );
+  }
+  return [name, value];
+}
+
+export function parseHeaderFlags(
+  values: readonly string[] | undefined,
+): Record<string, string> | undefined {
+  if (!values || values.length === 0) {
+    return undefined;
+  }
+  const headers: Record<string, string> = {};
+  for (const v of values) {
+    const [name, value] = parseHeaderFlag(v);
+    headers[name] = value;
+  }
+  return headers;
+}

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -23,7 +23,10 @@ export type {Debugger} from 'debug';
 export {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 export {type ShapeOutput} from '@modelcontextprotocol/sdk/server/zod-compat.js';
 export {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
+export {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+export {isInitializeRequest} from '@modelcontextprotocol/sdk/types.js';
 export {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+export {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 export {Client} from '@modelcontextprotocol/sdk/client/index.js';
 export {
   type CallToolResult,

--- a/tests/daemon/remote-client.test.ts
+++ b/tests/daemon/remote-client.test.ts
@@ -1,0 +1,419 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import {createServer, type Server} from 'node:http';
+import * as net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import {after, afterEach, before, beforeEach, describe, it} from 'node:test';
+
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {isInitializeRequest} from '@modelcontextprotocol/sdk/types.js';
+import {z} from 'zod';
+
+import {
+  clearStickySession,
+  fetchRemoteHealth,
+  getRemoteSessionFilePath,
+  invokeRemoteTool,
+  loadStickySessionId,
+  parseHeaderFlag,
+  parseHeaderFlags,
+  saveStickySessionId,
+  stopRemoteSession,
+} from '../../src/daemon/remote-client.js';
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const addr = srv.address();
+      srv.close(() => {
+        if (addr !== null && typeof addr === 'object') {
+          resolve(addr.port);
+        } else {
+          reject(new Error('Could not determine free port'));
+        }
+      });
+    });
+  });
+}
+
+interface Session {
+  transport: StreamableHTTPServerTransport;
+  receivedHeaders: Record<string, string | string[] | undefined>;
+}
+
+interface FixtureServer {
+  url: URL;
+  /** Most-recent set of request headers — used to verify header forwarding. */
+  lastHeaders(): Record<string, string | string[] | undefined> | undefined;
+  /** Live sessions, observable by tests. */
+  sessions: Map<string, Session>;
+  stop(): Promise<void>;
+}
+
+/**
+ * In-process MCP server speaking the Streamable HTTP transport with a single
+ * `echo` tool. Mirrors the shape of chrome-devtools-mcp-main.ts but without
+ * any Chrome dependency.
+ */
+async function startFixtureServer(): Promise<FixtureServer> {
+  const port = await getFreePort();
+  const sessions = new Map<string, Session>();
+  let lastHeaders: Record<string, string | string[] | undefined> | undefined;
+
+  function buildMcpServer(): McpServer {
+    const server = new McpServer(
+      {name: 'remote-client-fixture', version: '0.0.0'},
+      {capabilities: {}},
+    );
+    server.tool(
+      'echo',
+      'Echo back the provided text',
+      {text: z.string()},
+      async ({text}) => ({content: [{type: 'text', text}]}),
+    );
+    return server;
+  }
+
+  const httpServer: Server = createServer(async (req, res) => {
+    lastHeaders = req.headers;
+    if (req.url?.startsWith('/health')) {
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({status: 'ok', sessions: sessions.size}));
+      return;
+    }
+    if (!req.url?.startsWith('/mcp')) {
+      res.writeHead(404);
+      res.end('not found');
+      return;
+    }
+    const rawId = req.headers['mcp-session-id'];
+    const sessionId = Array.isArray(rawId) ? rawId[0] : rawId;
+
+    if (sessionId && sessions.has(sessionId)) {
+      const s = sessions.get(sessionId)!;
+      s.receivedHeaders = req.headers;
+      await s.transport.handleRequest(req, res);
+      return;
+    }
+
+    const body = await new Promise<string>(resolve => {
+      let data = '';
+      req.on('data', c => (data += c));
+      req.on('end', () => resolve(data));
+    });
+    let parsed: unknown;
+    try {
+      parsed = body.length ? JSON.parse(body) : undefined;
+    } catch {
+      res.writeHead(400, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({error: 'bad json'}));
+      return;
+    }
+    const isInit =
+      isInitializeRequest(parsed) ||
+      (Array.isArray(parsed) && parsed.some(isInitializeRequest));
+    if (isInit) {
+      const mcp = buildMcpServer();
+      // Register the session inside onsessioninitialized — it fires BEFORE the
+      // response goes out, so the follow-up `initialized` notification (which
+      // may race the initialize response) always finds the session in the map.
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => crypto.randomUUID(),
+        onsessioninitialized: id => {
+          sessions.set(id, {transport, receivedHeaders: req.headers});
+        },
+      });
+      transport.onclose = () => {
+        if (transport.sessionId) {
+          sessions.delete(transport.sessionId);
+        }
+      };
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res, parsed);
+      return;
+    }
+    if (sessionId) {
+      res.writeHead(404, {'Content-Type': 'application/json'});
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: {code: -32001, message: 'Session not found'},
+          id: null,
+        }),
+      );
+      return;
+    }
+    res.writeHead(400, {'Content-Type': 'application/json'});
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {code: -32000, message: 'Bad Request'},
+        id: null,
+      }),
+    );
+  });
+
+  await new Promise<void>(resolve => httpServer.listen(port, resolve));
+
+  return {
+    url: new URL(`http://127.0.0.1:${port}/mcp`),
+    lastHeaders: () => lastHeaders,
+    sessions,
+    async stop() {
+      for (const [, s] of sessions) {
+        await s.transport.close().catch(() => undefined);
+      }
+      sessions.clear();
+      await new Promise<void>(resolve => httpServer.close(() => resolve()));
+    },
+  };
+}
+
+describe('remote-client helpers', () => {
+  describe('parseHeaderFlag', () => {
+    it('parses colon-separated headers', () => {
+      assert.deepStrictEqual(parseHeaderFlag('Authorization: Bearer xyz'), [
+        'Authorization',
+        'Bearer xyz',
+      ]);
+    });
+    it('parses equals-separated headers', () => {
+      assert.deepStrictEqual(parseHeaderFlag('X-Token=abc'), [
+        'X-Token',
+        'abc',
+      ]);
+    });
+    it('prefers the first separator (colon before equals)', () => {
+      assert.deepStrictEqual(parseHeaderFlag('X-Foo: a=b'), ['X-Foo', 'a=b']);
+    });
+    it('rejects values with no separator', () => {
+      assert.throws(() => parseHeaderFlag('no-separator'), /Invalid --header/);
+    });
+    it('rejects an empty header name', () => {
+      assert.throws(() => parseHeaderFlag(': value'), /empty header name/);
+    });
+  });
+
+  describe('parseHeaderFlags', () => {
+    it('returns undefined for an empty list', () => {
+      assert.strictEqual(parseHeaderFlags([]), undefined);
+      assert.strictEqual(parseHeaderFlags(undefined), undefined);
+    });
+    it('merges multiple values', () => {
+      const out = parseHeaderFlags(['Authorization: Bearer t', 'X-Trace: 42']);
+      assert.deepStrictEqual(out, {
+        Authorization: 'Bearer t',
+        'X-Trace': '42',
+      });
+    });
+  });
+
+  describe('sticky session storage', () => {
+    let cacheDir: string;
+    let originalCacheHome: string | undefined;
+
+    beforeEach(() => {
+      cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remote-cache-'));
+      originalCacheHome = process.env['XDG_CACHE_HOME'];
+      process.env['XDG_CACHE_HOME'] = cacheDir;
+    });
+
+    afterEach(() => {
+      if (originalCacheHome === undefined) {
+        delete process.env['XDG_CACHE_HOME'];
+      } else {
+        process.env['XDG_CACHE_HOME'] = originalCacheHome;
+      }
+      fs.rmSync(cacheDir, {recursive: true, force: true});
+    });
+
+    it('round-trips a session id', () => {
+      const url = new URL('https://example.test/mcp');
+      assert.strictEqual(loadStickySessionId(url), undefined);
+      saveStickySessionId(url, 'sess-1');
+      assert.strictEqual(loadStickySessionId(url), 'sess-1');
+    });
+
+    it('isolates sessions per remote URL', () => {
+      const a = new URL('https://a.test/mcp');
+      const b = new URL('https://b.test/mcp');
+      saveStickySessionId(a, 'A');
+      saveStickySessionId(b, 'B');
+      assert.strictEqual(loadStickySessionId(a), 'A');
+      assert.strictEqual(loadStickySessionId(b), 'B');
+      assert.notStrictEqual(
+        getRemoteSessionFilePath(a),
+        getRemoteSessionFilePath(b),
+      );
+    });
+
+    it('treats http and https as distinct', () => {
+      const http = new URL('http://x.test/mcp');
+      const https = new URL('https://x.test/mcp');
+      assert.notStrictEqual(
+        getRemoteSessionFilePath(http),
+        getRemoteSessionFilePath(https),
+      );
+    });
+
+    it('clearStickySession removes the file', () => {
+      const url = new URL('https://example.test/mcp');
+      saveStickySessionId(url, 'x');
+      clearStickySession(url);
+      assert.strictEqual(loadStickySessionId(url), undefined);
+    });
+
+    it('writes session files with restrictive permissions', () => {
+      if (process.platform === 'win32') {
+        return; // mode bits do not apply
+      }
+      const url = new URL('https://example.test/mcp');
+      saveStickySessionId(url, 'secret');
+      const stat = fs.statSync(getRemoteSessionFilePath(url));
+      assert.strictEqual(stat.mode & 0o777, 0o600);
+    });
+  });
+});
+
+describe('remote-client integration', () => {
+  let server: FixtureServer;
+  let cacheDir: string;
+  let originalCacheHome: string | undefined;
+
+  before(async () => {
+    server = await startFixtureServer();
+  });
+
+  after(async () => {
+    await server.stop();
+  });
+
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remote-cache-'));
+    originalCacheHome = process.env['XDG_CACHE_HOME'];
+    process.env['XDG_CACHE_HOME'] = cacheDir;
+  });
+
+  afterEach(async () => {
+    // Close any lingering sessions between tests so each test starts fresh.
+    for (const [, s] of server.sessions) {
+      await s.transport.close().catch(() => undefined);
+    }
+    server.sessions.clear();
+
+    if (originalCacheHome === undefined) {
+      delete process.env['XDG_CACHE_HOME'];
+    } else {
+      process.env['XDG_CACHE_HOME'] = originalCacheHome;
+    }
+    fs.rmSync(cacheDir, {recursive: true, force: true});
+  });
+
+  it('invokes a tool and persists the issued session id', async () => {
+    const result = await invokeRemoteTool({
+      url: server.url,
+      tool: 'echo',
+      args: {text: 'hello'},
+    });
+    const text =
+      Array.isArray(result.content) &&
+      result.content[0] &&
+      'text' in result.content[0]
+        ? (result.content[0] as {text: string}).text
+        : undefined;
+    assert.strictEqual(text, 'hello');
+    const persisted = loadStickySessionId(server.url);
+    assert.ok(persisted, 'session id should be persisted after invocation');
+    assert.ok(
+      server.sessions.has(persisted!),
+      'persisted id must match a live server session',
+    );
+  });
+
+  it('reuses the persisted session id across invocations', async () => {
+    await invokeRemoteTool({
+      url: server.url,
+      tool: 'echo',
+      args: {text: 'a'},
+    });
+    const firstId = loadStickySessionId(server.url);
+    assert.ok(firstId);
+    const sessionsBefore = server.sessions.size;
+
+    await invokeRemoteTool({
+      url: server.url,
+      tool: 'echo',
+      args: {text: 'b'},
+    });
+
+    assert.strictEqual(loadStickySessionId(server.url), firstId);
+    assert.strictEqual(
+      server.sessions.size,
+      sessionsBefore,
+      'sticky session should not create a new server session',
+    );
+  });
+
+  it('transparently re-initializes when the persisted session is stale', async () => {
+    // Write a bogus session id to disk so the first request lands with an
+    // unknown session header. The server must accept the initialize that the
+    // client sends, mint a fresh id, and the helper must persist the new one.
+    saveStickySessionId(server.url, 'does-not-exist');
+    await invokeRemoteTool({
+      url: server.url,
+      tool: 'echo',
+      args: {text: 'after-restart'},
+    });
+    const fresh = loadStickySessionId(server.url);
+    assert.ok(fresh);
+    assert.notStrictEqual(fresh, 'does-not-exist');
+    assert.ok(server.sessions.has(fresh!));
+  });
+
+  it('forwards configured headers to the server', async () => {
+    await invokeRemoteTool({
+      url: server.url,
+      headers: {'X-Test-Token': 'shibboleth'},
+      tool: 'echo',
+      args: {text: 'h'},
+    });
+    const seen = server.lastHeaders();
+    assert.ok(seen);
+    assert.strictEqual(seen!['x-test-token'], 'shibboleth');
+  });
+
+  it('stopRemoteSession terminates the server session and clears the local pointer', async () => {
+    await invokeRemoteTool({
+      url: server.url,
+      tool: 'echo',
+      args: {text: 'x'},
+    });
+    const id = loadStickySessionId(server.url);
+    assert.ok(id);
+    assert.ok(server.sessions.has(id!));
+
+    await stopRemoteSession({url: server.url});
+
+    assert.strictEqual(loadStickySessionId(server.url), undefined);
+    // Give the server a tick to process DELETE / onclose.
+    await new Promise(r => setTimeout(r, 50));
+    assert.ok(!server.sessions.has(id!));
+  });
+
+  it('fetchRemoteHealth derives /health from the /mcp endpoint', async () => {
+    const health = await fetchRemoteHealth({url: server.url});
+    assert.strictEqual(health.ok, true);
+    assert.strictEqual(health.status, 200);
+    assert.deepStrictEqual((health.body as {status: string}).status, 'ok');
+  });
+});

--- a/tests/e2e/http-transport.test.ts
+++ b/tests/e2e/http-transport.test.ts
@@ -1,0 +1,617 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {type ChildProcess, spawn} from 'node:child_process';
+import * as net from 'node:net';
+import {after, before, describe, it} from 'node:test';
+
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {executablePath} from 'puppeteer';
+
+/** Find a free TCP port by binding to :0 and reading the assigned port. */
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const addr = srv.address();
+      srv.close(() => {
+        if (addr !== null && typeof addr === 'object') {
+          resolve(addr.port);
+        } else {
+          reject(new Error('Could not determine free port'));
+        }
+      });
+    });
+  });
+}
+
+interface HealthResponse {
+  status: string;
+  chrome_connected: boolean;
+  sessions: number;
+}
+
+function assertHealthResponse(value: unknown): asserts value is HealthResponse {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('status' in value) ||
+    !('sessions' in value) ||
+    !('chrome_connected' in value)
+  ) {
+    throw new Error(`Invalid health response: ${JSON.stringify(value)}`);
+  }
+}
+
+interface JsonRpcErrorResponse {
+  error: {code: number; message: string};
+}
+
+function assertJsonRpcError(
+  value: unknown,
+): asserts value is JsonRpcErrorResponse {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('error' in value) ||
+    typeof value.error !== 'object' ||
+    value.error === null ||
+    !('code' in value.error)
+  ) {
+    throw new Error(
+      `Invalid JSON-RPC error response: ${JSON.stringify(value)}`,
+    );
+  }
+}
+
+interface TestServer {
+  mcpUrl: string;
+  healthUrl: string;
+  stop(): Promise<void>;
+}
+
+/** Spawn the MCP server in HTTP mode and wait until it is healthy. */
+async function spawnServer(
+  extraEnv: Record<string, string> = {},
+): Promise<TestServer> {
+  const port = await getFreePort();
+  const mcpUrl = `http://127.0.0.1:${port}/mcp`;
+  const healthUrl = `http://127.0.0.1:${port}/health`;
+
+  const proc: ChildProcess = spawn(
+    'node',
+    [
+      'build/src/bin/chrome-devtools-mcp.js',
+      '--headless',
+      '--isolated',
+      '--executable-path',
+      executablePath(),
+      '--port',
+      String(port),
+    ],
+    {
+      env: {
+        ...process.env,
+        CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+        CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS: 'true',
+        ...extraEnv,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+
+  let stderr = '';
+  proc.stderr?.on('data', chunk => {
+    stderr += String(chunk);
+  });
+  proc.on('error', err => {
+    console.error('Server process error:', err);
+  });
+
+  async function stop(): Promise<void> {
+    proc.kill('SIGTERM');
+    await new Promise<void>(resolve => {
+      proc.on('exit', () => resolve());
+      setTimeout(() => {
+        proc.kill('SIGKILL');
+        resolve();
+      }, 5000);
+    });
+  }
+
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(healthUrl);
+      if (res.ok) {
+        return {mcpUrl, healthUrl, stop};
+      }
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+  console.error('Server stderr:', stderr);
+  await stop();
+  throw new Error('Server did not start within 15000ms');
+}
+
+function createClient(): Client {
+  return new Client(
+    {name: 'http-transport-test', version: '1.0.0'},
+    {capabilities: {}},
+  );
+}
+
+function createTransport(mcpUrl: string): StreamableHTTPClientTransport {
+  return new StreamableHTTPClientTransport(new URL(mcpUrl));
+}
+
+async function getHealth(healthUrl: string): Promise<HealthResponse> {
+  const res = await fetch(healthUrl);
+  const data: unknown = await res.json();
+  assertHealthResponse(data);
+  return data;
+}
+
+/**
+ * Close a client cleanly. The SDK's client close() does not send an MCP
+ * DELETE, so terminateSession() is called first to release the server-side
+ * session immediately instead of leaving it for the idle reaper.
+ */
+async function closeClient(
+  client: Client,
+  transport: StreamableHTTPClientTransport,
+): Promise<void> {
+  await transport.terminateSession().catch(() => undefined);
+  await client.close().catch(() => undefined);
+}
+
+describe('HTTP transport session management', () => {
+  let server: TestServer;
+
+  before(async () => {
+    server = await spawnServer();
+  });
+
+  after(async () => {
+    await server?.stop();
+  });
+
+  it('single client can initialize and call tools', async () => {
+    const client = createClient();
+    const transport = createTransport(server.mcpUrl);
+    try {
+      await client.connect(transport);
+      const tools = await client.listTools();
+      assert.ok(tools.tools.length > 0, 'Should have tools available');
+    } finally {
+      await closeClient(client, transport);
+    }
+  });
+
+  it('second client can connect after first disconnects cleanly', async () => {
+    const client1 = createClient();
+    const transport1 = createTransport(server.mcpUrl);
+    await client1.connect(transport1);
+    const tools1 = await client1.listTools();
+    assert.ok(tools1.tools.length > 0);
+    await closeClient(client1, transport1);
+
+    const client2 = createClient();
+    const transport2 = createTransport(server.mcpUrl);
+    await client2.connect(transport2);
+    const tools2 = await client2.listTools();
+    assert.ok(tools2.tools.length > 0);
+    await closeClient(client2, transport2);
+  });
+
+  it('second client can connect after first drops the HTTP connection without MCP session teardown', async () => {
+    // Simulate an abrupt client loss: close the transport-level HTTP connection
+    // without going through an MCP DELETE. The server keeps that session until
+    // the idle reaper collects it — meanwhile a new client must still connect.
+    const client1 = createClient();
+    const transport1 = createTransport(server.mcpUrl);
+    await client1.connect(transport1);
+    const tools1 = await client1.listTools();
+    assert.ok(tools1.tools.length > 0);
+
+    // Drop the transport without sending MCP session DELETE.
+    transport1.close().catch(() => undefined);
+    await new Promise(r => setTimeout(r, 500));
+
+    // A new client must still be able to initialize and use the server.
+    const client2 = createClient();
+    const transport2 = createTransport(server.mcpUrl);
+    await client2.connect(transport2);
+    const tools2 = await client2.listTools();
+    assert.ok(tools2.tools.length > 0);
+    await closeClient(client2, transport2);
+  });
+
+  it('handles rapid sequential reconnections', async () => {
+    for (let i = 0; i < 5; i++) {
+      const client = createClient();
+      const transport = createTransport(server.mcpUrl);
+      await client.connect(transport);
+      const tools = await client.listTools();
+      assert.ok(
+        tools.tools.length > 0,
+        `Connection ${i + 1} should have tools`,
+      );
+      await closeClient(client, transport);
+    }
+  });
+
+  it('serves multiple concurrent sessions without evicting any', async () => {
+    // Launch several clients simultaneously. They share one browser but each
+    // gets its own session — every one must connect AND remain usable after
+    // the others have connected. Under the old single-session model each new
+    // initialize evicted its predecessors and this would fail.
+    const NUM_CONCURRENT = 3;
+    const before = (await getHealth(server.healthUrl)).sessions;
+    const connections = await Promise.all(
+      Array.from({length: NUM_CONCURRENT}, async (_, i) => {
+        const client = createClient();
+        const transport = createTransport(server.mcpUrl);
+        await client.connect(transport);
+        const tools = await client.listTools();
+        assert.ok(tools.tools.length > 0, `Client ${i} should get tools`);
+        return {client, transport};
+      }),
+    );
+
+    // All sessions are registered at the same time — none evicted the others.
+    const health = await getHealth(server.healthUrl);
+    assert.ok(
+      health.sessions >= before + NUM_CONCURRENT,
+      `Expected at least ${before + NUM_CONCURRENT} sessions, got ${health.sessions}`,
+    );
+    assert.strictEqual(health.status, 'ok', 'Server should still be healthy');
+
+    // Every client is still independently usable after all peers connected.
+    for (const [i, {client}] of connections.entries()) {
+      const tools = await client.listTools();
+      assert.ok(
+        tools.tools.length > 0,
+        `Client ${i} must still work after peer clients connected`,
+      );
+    }
+
+    for (const {client, transport} of connections) {
+      await closeClient(client, transport);
+    }
+  });
+
+  it('an earlier session survives a later session connecting', async () => {
+    // Deterministic no-eviction check: connect A, then B, then prove A still
+    // works. Connecting B must not tear down A's session.
+    const clientA = createClient();
+    const transportA = createTransport(server.mcpUrl);
+    await clientA.connect(transportA);
+    assert.ok((await clientA.listTools()).tools.length > 0);
+
+    const clientB = createClient();
+    const transportB = createTransport(server.mcpUrl);
+    await clientB.connect(transportB);
+    assert.ok((await clientB.listTools()).tools.length > 0);
+
+    const toolsA = await clientA.listTools();
+    assert.ok(
+      toolsA.tools.length > 0,
+      'Client A must still work — connecting client B must not evict it',
+    );
+
+    await closeClient(clientA, transportA);
+    await closeClient(clientB, transportB);
+  });
+
+  it('multiple sessions can call tools concurrently without interference', async () => {
+    // The multi-agent core scenario: N independent sessions firing tool calls
+    // in parallel. They share one browser and one tool mutex, so calls are
+    // serialized server-side — every call must still complete successfully and
+    // the burst must not deadlock or leave the server unhealthy. Under a
+    // per-session mutex (a tempting "optimization") concurrent tools would
+    // race the shared browser state and this would flake.
+    const NUM_CLIENTS = 3;
+    const CALLS_PER_CLIENT = 4;
+    const conns = await Promise.all(
+      Array.from({length: NUM_CLIENTS}, async () => {
+        const c = createClient();
+        const t = createTransport(server.mcpUrl);
+        await c.connect(t);
+        return {c, t};
+      }),
+    );
+
+    const results = await Promise.all(
+      conns.flatMap(({c}, i) =>
+        Array.from({length: CALLS_PER_CLIENT}, async (_, k) => {
+          const r = await c.callTool({name: 'list_pages', arguments: {}});
+          return {clientIndex: i, callIndex: k, result: r};
+        }),
+      ),
+    );
+
+    assert.strictEqual(
+      results.length,
+      NUM_CLIENTS * CALLS_PER_CLIENT,
+      'every concurrent tool call should complete',
+    );
+    for (const {clientIndex, callIndex, result} of results) {
+      assert.ok(
+        Array.isArray(result.content) && result.content.length > 0,
+        `client ${clientIndex} call ${callIndex} should return content`,
+      );
+    }
+
+    const health = await getHealth(server.healthUrl);
+    assert.strictEqual(
+      health.status,
+      'ok',
+      'server must stay healthy under concurrent multi-session load',
+    );
+
+    for (const {c, t} of conns) {
+      await closeClient(c, t);
+    }
+  });
+
+  it('health endpoint reflects sessions appearing and being reclaimed', async () => {
+    const before = (await getHealth(server.healthUrl)).sessions;
+
+    const client = createClient();
+    const transport = createTransport(server.mcpUrl);
+    await client.connect(transport);
+
+    const during = await getHealth(server.healthUrl);
+    assert.strictEqual(
+      during.sessions,
+      before + 1,
+      'connecting a client must add exactly one session',
+    );
+    assert.strictEqual(during.status, 'ok');
+
+    await closeClient(client, transport);
+    await new Promise(r => setTimeout(r, 300));
+
+    const restored = (await getHealth(server.healthUrl)).sessions;
+    assert.strictEqual(
+      restored,
+      before,
+      'a clean MCP DELETE must remove the session',
+    );
+  });
+
+  it('client can call tools after reconnecting to a recovered server', async () => {
+    const client1 = createClient();
+    const transport1 = createTransport(server.mcpUrl);
+    await client1.connect(transport1);
+    const result1 = await client1.callTool({name: 'list_pages', arguments: {}});
+    assert.ok(
+      Array.isArray(result1.content) && result1.content.length > 0,
+      'First tool call should return content',
+    );
+
+    // Drop without MCP teardown.
+    transport1.close().catch(() => undefined);
+    await new Promise(r => setTimeout(r, 500));
+
+    const client2 = createClient();
+    const transport2 = createTransport(server.mcpUrl);
+    await client2.connect(transport2);
+    const result2 = await client2.callTool({name: 'list_pages', arguments: {}});
+    assert.ok(
+      Array.isArray(result2.content) && result2.content.length > 0,
+      'Second tool call should return content after reconnect',
+    );
+    await closeClient(client2, transport2);
+  });
+
+  it('rejects an unknown session ID with 404 and a JSON-RPC error', async () => {
+    // A request carrying a session ID this process never issued — the typical
+    // shape after a server restart wiped the in-memory session map.
+    const res = await fetch(server.mcpUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'mcp-session-id': 'does-not-exist',
+      },
+      body: JSON.stringify({jsonrpc: '2.0', method: 'tools/list', id: 1}),
+    });
+    assert.strictEqual(res.status, 404, 'Stale session must return 404');
+    const data: unknown = await res.json();
+    assertJsonRpcError(data);
+    assert.strictEqual(data.error.code, -32001);
+  });
+
+  it('rejects a non-initialize request with no session ID as 400', async () => {
+    const res = await fetch(server.mcpUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({jsonrpc: '2.0', method: 'tools/list', id: 1}),
+    });
+    assert.strictEqual(res.status, 400);
+    const data: unknown = await res.json();
+    assertJsonRpcError(data);
+    assert.strictEqual(data.error.code, -32000);
+  });
+
+  it('rejects a malformed body with 400 instead of hanging', async () => {
+    // Before the fix, an unparseable body threw out of the async request
+    // handler and the connection hung with no response. Bound the wait so a
+    // regression fails fast instead of stalling the suite.
+    const res = await fetch(server.mcpUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: '{not valid json',
+      signal: AbortSignal.timeout(5000),
+    });
+    assert.strictEqual(res.status, 400);
+    const data: unknown = await res.json();
+    assertJsonRpcError(data);
+    assert.strictEqual(data.error.code, -32700);
+  });
+
+  it('clean DELETE shutdown reclaims sessions without leaking', async () => {
+    const before = (await getHealth(server.healthUrl)).sessions;
+    const CYCLES = 20;
+    for (let i = 0; i < CYCLES; i++) {
+      const client = createClient();
+      const transport = createTransport(server.mcpUrl);
+      await client.connect(transport);
+      await client.listTools();
+      await closeClient(client, transport);
+    }
+    await new Promise(r => setTimeout(r, 300));
+
+    const health = await getHealth(server.healthUrl);
+    assert.strictEqual(health.status, 'ok');
+    assert.strictEqual(
+      health.sessions,
+      before,
+      `Session count should return to ${before} after clean cycles, got ${health.sessions}`,
+    );
+  });
+});
+
+describe('HTTP transport idle session reaping', () => {
+  let server: TestServer;
+
+  before(async () => {
+    // A short idle TTL so the reaper can be observed within the test.
+    server = await spawnServer({
+      CHROME_DEVTOOLS_MCP_SESSION_IDLE_TTL_MS: '2000',
+    });
+  });
+
+  after(async () => {
+    await server?.stop();
+  });
+
+  it('reaps a session whose client went away without DELETE', async () => {
+    // The real abandoned-client case: client crashed / lost network. The SDK
+    // never sends DELETE; the server only knows because the GET SSE stream
+    // socket eventually closes, dropping activeRequests to 0. Then the idle
+    // TTL has to reclaim what's left. Simulate it by aborting the transport
+    // (no DELETE) before waiting.
+    const before = (await getHealth(server.healthUrl)).sessions;
+
+    const client = createClient();
+    const transport = createTransport(server.mcpUrl);
+    await client.connect(transport);
+    assert.strictEqual(
+      (await getHealth(server.healthUrl)).sessions,
+      before + 1,
+      'session should be registered after connect',
+    );
+
+    // Abrupt transport-level close — no MCP DELETE, just drop the socket.
+    await transport.close().catch(() => undefined);
+
+    // Stay past the 2s TTL and at least one reaper sweep.
+    await new Promise(r => setTimeout(r, 7000));
+
+    assert.strictEqual(
+      (await getHealth(server.healthUrl)).sessions,
+      before,
+      'an abandoned session must be reaped once it passes the TTL',
+    );
+  });
+
+  it('does not reap a connected client even when lastActivity is older than the TTL', async () => {
+    // A client that is connected and just idle is NOT a dead client — its GET
+    // SSE stream is still open, so activeRequests > 0 and the reaper must
+    // leave it alone. Otherwise legitimate idle clients would silently lose
+    // their notification channel as soon as they stop sending POSTs.
+    const before = (await getHealth(server.healthUrl)).sessions;
+
+    const client = createClient();
+    const transport = createTransport(server.mcpUrl);
+    await client.connect(transport);
+    assert.strictEqual(
+      (await getHealth(server.healthUrl)).sessions,
+      before + 1,
+    );
+
+    // Sit on the connection past the TTL with no POSTs. The GET stream alone
+    // keeps activeRequests at 1, so the reaper must skip this session.
+    await new Promise(r => setTimeout(r, 5000));
+
+    assert.strictEqual(
+      (await getHealth(server.healthUrl)).sessions,
+      before + 1,
+      'connected idle client must survive the reaper',
+    );
+    // Confirm the session is still functional after surviving the TTL.
+    assert.ok((await client.listTools()).tools.length > 0);
+
+    await closeClient(client, transport);
+  });
+});
+
+describe('HTTP transport capacity limit', () => {
+  let server: TestServer;
+
+  before(async () => {
+    server = await spawnServer({CHROME_DEVTOOLS_MCP_MAX_SESSIONS: '2'});
+  });
+
+  after(async () => {
+    await server?.stop();
+  });
+
+  it('evicts the least-recently-active session when MAX_SESSIONS is exceeded', async () => {
+    // With cap=2, the third initialize must force eviction of the oldest.
+    // Capacity is a HARD limit, so even an "active" session (open GET stream)
+    // is fair game once the cap is breached — that's what protects the server
+    // from a flood of connects pinning the map open.
+    const c1 = createClient();
+    const t1 = createTransport(server.mcpUrl);
+    await c1.connect(t1);
+
+    const c2 = createClient();
+    const t2 = createTransport(server.mcpUrl);
+    await c2.connect(t2);
+
+    // Connecting c3 must trigger removal of c1 (oldest lastActivity).
+    const c3 = createClient();
+    const t3 = createTransport(server.mcpUrl);
+    await c3.connect(t3);
+
+    const health = await getHealth(server.healthUrl);
+    assert.ok(
+      health.sessions <= 2,
+      `cap=2 must be enforced; got ${health.sessions} sessions`,
+    );
+
+    // c1 was evicted: its session id is unknown to the server now, so a
+    // request carrying it must reject. The exact error shape is up to the SDK
+    // — what matters is the call doesn't silently succeed.
+    await assert.rejects(
+      c1.listTools(),
+      'evicted session must reject subsequent requests',
+    );
+
+    // c2 and c3 must still work — eviction only touched the oldest.
+    assert.ok((await c2.listTools()).tools.length > 0);
+    assert.ok((await c3.listTools()).tools.length > 0);
+
+    await closeClient(c2, t2);
+    await closeClient(c3, t3);
+    // c1's transport is dead server-side; just drop the local socket.
+    await t1.close().catch(() => undefined);
+  });
+});


### PR DESCRIPTION

**Problem:** `chrome-devtools-mcp` runs as a one-shot stdio process. One agent, one session, gone when the terminal closes. On a multi-agent setup this means constant restarts, lost browser state, and no way to share a single browser across concurrent agents.

**This PR makes the server work as a proper persistent daemon:**
<img width="1521" height="797" alt="image" src="https://github.com/user-attachments/assets/a8366d41-1fb7-4256-b608-bbdd16646fdb" />

- Runs as a **system service** (launchd on macOS, systemd on Linux) — survives reboots, no terminal required
- **N agents can connect simultaneously** — each gets its own session and tab state over the same browser; no more single-agent limit
- **Memory doesn't leak** — idle sessions expire (10 min TTL, configurable) and a hard session cap guards against runaway growth
- **Tailscale** — one flag wires up Tailscale Serve so the endpoint is reachable at `https://<machine>.tailnet.ts.net/mcp` from any device on the tailnet, TLS included. So you could use your local browser from cloud-hosted agents, like openclaw, or as I use opencode server hosted on vm and sometimes need to do stuff to configure api keys, etc from agent. 

---

## Usage

### Start the service

```bash
# HTTP mode (any agent can connect)
chrome-devtools-mcp --port 3100

# Install as a system service + expose over Tailscale
chrome-devtools-mcp install --port 3100 --tailscale
# → https://<machine>.tailnet.ts.net/mcp is live, survives reboots
```

### Connect your agents

**Claude Code / OpenClaw** — `~/.claude.json`:
```json
{
  "mcpServers": {
    "chrome-devtools": {
      "type": "http",
      "url": "https://macbook13-pro.tail3ce7a.ts.net/mcp"
    }
  }
}
```

**OpenCode** — `~/.config/opencode/opencode.json`:
```json
{
  "mcp": {
    "chrome-devtools": {
      "type": "remote",
      "url": "https://macbook13-pro.tail3ce7a.ts.net/mcp",
      "enabled": true
    }
  }
}
```

Once configured, all MCP tools (`navigate_page`, `take_screenshot`, `evaluate_script`, …) route to the remote browser — no extra flags.

### CLI scripting

```bash
export CHROME_DEVTOOLS_MCP_REMOTE_URL="https://macbook13-pro.tail3ce7a.ts.net/mcp"
chrome-devtools status    --remote "$CHROME_DEVTOOLS_MCP_REMOTE_URL"   # health check
chrome-devtools navigate_page https://example.com --remote "$CHROME_DEVTOOLS_MCP_REMOTE_URL"
chrome-devtools take_screenshot --remote "$CHROME_DEVTOOLS_MCP_REMOTE_URL"
```

Extra flags: `--header "Authorization: Bearer $TOKEN"` (auth gateways), `--insecure` (self-signed certs).

### Agent skill

```bash
npx skills add ChromeDevTools/chrome-devtools-mcp/skills/chrome-devtools-remote
```

Installs a `SKILL.md` so Claude Code, OpenClaw, OpenCode, and other skills.sh-compatible agents can auto-discover the server setup and config format.

---

## Files changed

| File | Change |
|------|--------|
| `src/bin/chrome-devtools-mcp-cli-options.ts` | `--port` flag |
| `src/bin/chrome-devtools-mcp-main.ts` | HTTP transport + `/health` + concurrent sessions + idle reaper |
| `src/bin/chrome-devtools-mcp.ts` | `install`/`uninstall`/`status` routing |
| `src/bin/install-service.ts` | Service installer + Tailscale Serve wiring *(new)* |
| `src/bin/service/*.template` | launchd plist + systemd unit *(new)* |
| `src/bin/chrome-devtools.ts` | `--remote`, `--header`, `--insecure` flags |
| `src/daemon/remote-client.ts` | HTTP MCP client + sticky session cache *(new)* |
| `src/third_party/index.ts` | Re-export HTTP server/client transports |
| `tests/daemon/remote-client.test.ts` | 18 unit tests — in-process server fixture *(new)* |
| `tests/e2e/http-transport.test.ts` | E2E HTTP transport tests *(new)* |
| `skills/chrome-devtools-remote/SKILL.md` | Agent discovery skill *(new)* |

Happy to split into smaller PRs if preferred (HTTP transport / installer / CLI client separately).