### PR TITLE
docs: align coding agent examples with Antigravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm chrome-devtools-mcp package](https://img.shields.io/npm/v/chrome-devtools-mcp.svg)](https://npmjs.org/package/chrome-devtools-mcp)
 
-Chrome DevTools for agents (`chrome-devtools-mcp`) lets your coding agent (such as Gemini, Claude, Cursor or Copilot)
+Chrome DevTools for agents (`chrome-devtools-mcp`) lets your coding agent (such as Antigravity, Claude, Cursor or Copilot)
 control and inspect a live Chrome browser. It acts as a Model-Context-Protocol
 (MCP) server, giving your AI coding assistant access to the full power of
 Chrome DevTools for reliable automation, in-depth debugging, and performance analysis.


### PR DESCRIPTION
## Description

Updates the README example list of coding agents for terminology consistency.

Google recently [announced](https://antigravity.google/blog/introducing-google-antigravity-cli) the transition from Gemini CLI to Antigravity CLI, positioning Antigravity as the primary agent-first development platform and coding agent experience going forward. ([Google Developers Blog](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/?utm_source=chatgpt.com))

This PR updates:

> "such as Gemini, Claude, Cursor or Copilot"

to:

> "such as Antigravity, Claude Code, Cursor, or Copilot"

The updated wording aligns the README with current product naming and makes the examples more consistent by referencing agent/tool products instead of model families.