### PR TITLE
docs: clarify evaluate_script tool description for uids, selectors, and navigation

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -343,6 +343,8 @@
 
 **Description:** Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON,
 so returned values have to be JSON-serializable.
+The function runs in the current page context only; do not navigate by setting `window.location` inside it. Use [`navigate_page`](#navigate_page) or [`new_page`](#new_page) to change pages, then call [`evaluate_script`](#evaluate_script) again on the new page.
+When querying the DOM, use standard browser APIs and valid native CSS selectors only (no library-specific pseudo-classes such as `:contains()`). `uid`s from [`take_snapshot`](#take_snapshot) are MCP references, not DOM attributes; pass them via the `args` parameter when the function needs the referenced elements.
 
 **Parameters:**
 
@@ -355,8 +357,9 @@ so returned values have to be JSON-serializable.
   Example with arguments: `(el) => {
   return el.innerText;
 }`
+  Inside the function, use only standard DOM APIs and valid native CSS selectors. Do not use snapshot `uid`s in `querySelector` calls, and do not set `window.location` here to navigate across pages.
 
-- **args** (array) _(optional)_: An optional list of arguments to pass to the function.
+- **args** (array) _(optional)_: An optional list of element `uid`s from [`take_snapshot`](#take_snapshot). Each `uid` is resolved to a real element handle and passed to the function as a parameter; `uid`s are not DOM attributes and cannot be used in selector strings inside the function.
 - **dialogAction** (string) _(optional)_: Handle dialogs while execution. "accept", "dismiss", or string for response of window.prompt. Defaults to accept.
 - **filePath** (string) _(optional)_: The absolute or relative path to a file to save the script output to. If omitted, the output is returned inline.
 

--- a/skills/chrome-devtools/SKILL.md
+++ b/skills/chrome-devtools/SKILL.md
@@ -10,6 +10,10 @@ description: Uses Chrome DevTools via MCP for efficient debugging, troubleshooti
 
 **Element interaction**: Use `take_snapshot` to get page structure with element `uid`s. Each element has a unique `uid` for interaction. If an element isn't found, take a fresh snapshot - the element may have been removed or the page changed.
 
+**`uid` scope**: `uid`s from `take_snapshot` are MCP references, not DOM attributes. Do not use them in `querySelector()` or other selector strings. When a script needs one of these elements, pass the `uid` through `evaluate_script`'s `args` parameter so the tool can resolve it to a real element handle.
+
+**`evaluate_script` scope**: `evaluate_script` runs in the currently selected page or frame only. Do not try to navigate by setting `window.location` inside the evaluated function. Use `navigate_page` or `new_page`, wait for the destination page, then run another `evaluate_script`. Inside the function, use valid native CSS selectors only — library-specific pseudo-classes such as `:contains()` are not supported by browser `querySelector`.
+
 ## Workflow Patterns
 
 ### Before interacting with a page

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -178,20 +178,21 @@ export const commands: Commands = {
   },
   evaluate_script: {
     description:
-      'Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON,\nso returned values have to be JSON-serializable.',
+      'Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON,\nso returned values have to be JSON-serializable.\nThe function runs in the current page context only; do not navigate by setting `window.location` inside it. Use navigate_page or new_page to change pages, then call evaluate_script again on the new page.\nWhen querying the DOM, use standard browser APIs and valid native CSS selectors only (no library-specific pseudo-classes such as `:contains()`). `uid`s from take_snapshot are MCP references, not DOM attributes; pass them via the `args` parameter when the function needs the referenced elements.',
     category: 'Debugging',
     args: {
       function: {
         name: 'function',
         type: 'string',
         description:
-          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`\n',
+          'A JavaScript function declaration to be executed by the tool in the currently selected page.\nExample without arguments: `() => {\n  return document.title\n}` or `async () => {\n  return await fetch("example.com")\n}`.\nExample with arguments: `(el) => {\n  return el.innerText;\n}`\nInside the function, use only standard DOM APIs and valid native CSS selectors. Do not use snapshot `uid`s in `querySelector` calls, and do not set `window.location` here to navigate across pages.\n',
         required: true,
       },
       args: {
         name: 'args',
         type: 'array',
-        description: 'An optional list of arguments to pass to the function.',
+        description:
+          'An optional list of element `uid`s from take_snapshot. Each `uid` is resolved to a real element handle and passed to the function as a parameter; `uid`s are not DOM attributes and cannot be used in selector strings inside the function.',
         required: false,
       },
       filePath: {

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -18,7 +18,9 @@ export const evaluateScript = defineTool(cliArgs => {
   return {
     name: 'evaluate_script',
     description: `Evaluate a JavaScript function inside the currently selected page${cliArgs?.categoryExtensions ? ' or service worker' : ''}. Returns the response as JSON,
-so returned values have to be JSON-serializable.`,
+so returned values have to be JSON-serializable.
+The function runs in the current page context only; do not navigate by setting \`window.location\` inside it. Use navigate_page or new_page to change pages, then call evaluate_script again on the new page.
+When querying the DOM, use standard browser APIs and valid native CSS selectors only (no library-specific pseudo-classes such as \`:contains()\`). \`uid\`s from take_snapshot are MCP references, not DOM attributes; pass them via the \`args\` parameter when the function needs the referenced elements.`,
     annotations: {
       category: ToolCategory.DEBUGGING,
       readOnlyHint: false,
@@ -34,6 +36,7 @@ Example without arguments: \`() => {
 Example with arguments: \`(el) => {
   return el.innerText;
 }\`
+Inside the function, use only standard DOM APIs and valid native CSS selectors. Do not use snapshot \`uid\`s in \`querySelector\` calls, and do not set \`window.location\` here to navigate across pages.
 `,
       ),
       args: zod
@@ -45,7 +48,9 @@ Example with arguments: \`(el) => {
             ),
         )
         .optional()
-        .describe(`An optional list of arguments to pass to the function.`),
+        .describe(
+          `An optional list of element \`uid\`s from take_snapshot. Each \`uid\` is resolved to a real element handle and passed to the function as a parameter; \`uid\`s are not DOM attributes and cannot be used in selector strings inside the function.`,
+        ),
       filePath: zod
         .string()
         .optional()


### PR DESCRIPTION
## Summary

Three confirmed eval bugs — #1892, #1894, #1895 — share one root cause: the `evaluate_script` tool description does not warn agents away from common misuses observed in real agent runs:

- snapshot `uid`s being used inside `querySelector` (uids are MCP references, not DOM attributes) — #1892
- library-specific pseudo-classes such as `:contains()` being used inside `querySelector` (browser native APIs only) — #1895
- `window.location` being set inside the evaluated function to navigate to another page (the function runs in the current page context only; `navigate_page` / `new_page` must be used instead) — #1894

This PR adds concise guardrails to the canonical description in `src/tools/script.ts` and the hand-written `skills/chrome-devtools/SKILL.md`. `docs/tool-reference.md` and `src/bin/chrome-devtools-cli-options.ts` are regenerated via `npm run gen`.

## What changed

- `src/tools/script.ts`
  - Tool `description`: three guardrails added (page-context scope, native CSS selectors only, `uid`s as MCP references)
  - `function` parameter description: explicit prohibitions on uid-in-querySelector and `window.location` navigation from inside the function
  - `args` parameter description: clarify that uids are resolved to handles, not pass-through values; not usable as DOM attributes
- `skills/chrome-devtools/SKILL.md`: two new bullets under "Core Concepts" (uid scope, evaluate_script scope)
- Regenerated `docs/tool-reference.md` and `src/bin/chrome-devtools-cli-options.ts` via `npm run gen`

## Test plan

- `npm run typecheck` — clean
- `npm run test tests/tools/script.test.ts` — 16/16 passing
- `npx prettier --check` on touched files — clean
- `npm run gen` produces a clean tree (presubmit's autogenerated-diff check will pass)

## Related closed PR

A drive-by attempt at this same surface was opened as #1902 / #1904 on 2026-04-22 by @MukundaKatta and self-withdrawn the same day as "low-value drive-by". This PR is a fresh take focused exclusively on the documented agent failure modes from the three linked eval issues, with the generated artefacts kept in sync.

Closes #1892
Closes #1894
Closes #1895