### PR TITLE
docs: clarify CLI evaluate_script usage and shell quoting

### DIFF
--- a/skills/chrome-devtools-cli/SKILL.md
+++ b/skills/chrome-devtools-cli/SKILL.md
@@ -30,6 +30,34 @@ chrome-devtools <tool> [arguments] [flags]
 
 Use `--help` on any command. Output defaults to Markdown, use `--output-format=json` for JSON.
 
+### Passing JavaScript to `evaluate_script`
+
+The JavaScript function for `evaluate_script` is a **positional argument**, not a flag. There is no `--expression` / `--script` flag — passing one will fail with `Unknown arguments` or `Not enough non-option arguments`.
+
+```bash
+# correct: function is a single positional argument
+chrome-devtools evaluate_script '() => document.title'
+
+# wrong: --expression is not a flag
+chrome-devtools evaluate_script --expression '() => document.title'
+```
+
+Quote the function with **outer single quotes** so the shell does not interpret `$`, backticks, or parentheses inside it. Use double quotes inside the function for string literals:
+
+```bash
+chrome-devtools evaluate_script '() => document.querySelector("h1").innerText'
+```
+
+For multi-line or large scripts, assign to a shell variable first to keep quoting simple:
+
+```bash
+script='async () => {
+  const r = await fetch("/api/items");
+  return (await r.json()).length;
+}'
+chrome-devtools evaluate_script "$script"
+```
+
 ## Input Automation (<uid> from snapshot)
 
 ```bash
@@ -108,6 +136,7 @@ chrome-devtools list_network_requests --includePreservedRequests true # Include 
 ```bash
 chrome-devtools evaluate_script "() => document.title" # Evaluate a JavaScript function on the page
 chrome-devtools evaluate_script "(a) => a.innerText" --args 1_4 # Evaluate JS with UID arguments
+chrome-devtools evaluate_script 'async () => { const r = await fetch("/api"); return await r.json(); }' # Multi-statement async function; outer single quotes keep the inner double quotes intact
 chrome-devtools get_console_message 1 # Gets a console message by its ID
 chrome-devtools lighthouse_audit --mode "navigation" # Run Lighthouse audit for navigation
 chrome-devtools lighthouse_audit --mode "snapshot" --device "mobile" # Run Lighthouse audit for a snapshot on mobile


### PR DESCRIPTION
## Summary

#1896 documents an agent making six consecutive failed attempts to call the CLI's `evaluate_script`: inventing a non-existent `--expression` flag (the function is positional), and then mangling the JavaScript through bad shell quoting.

This PR adds a focused **Passing JavaScript to `evaluate_script`** subsection to the CLI skill that:

- explicitly states the function is a positional argument and there is no `--expression` / `--script` flag
- shows the outer-single / inner-double quoting pattern that survives bash
- shows the shell-variable pattern for multi-line scripts (since assembling complex JS as a single string is the bigger source of agent confusion)

It also adds one async-fetch example to the existing Debugging & Inspection block so the most common non-trivial use is visible inline.

## What changed

- `skills/chrome-devtools-cli/SKILL.md` (one file, +29 lines)
  - New `### Passing JavaScript to evaluate_script` subsection under "Command Usage"
  - One extra example line in the existing Debugging & Inspection bash block

No source/code changes; no auto-generated artefacts touched.

## Test plan

- `npm run typecheck` — clean
- `npx prettier --check skills/chrome-devtools-cli/SKILL.md` — clean
- `npm run gen` produces a clean tree (no autogenerated drift)

## Related closed PR

A drive-by attempt at this same surface was opened as #1904 on 2026-04-22 by @MukundaKatta and self-withdrawn the same day as "low-value drive-by". This PR is a fresh, focused take aimed at the specific agent failure modes documented in the issue (invented `--expression` flag + shell-quoting collapse).

This PR is independent of and does not conflict with #2098, which addresses the sibling `evaluate_script` MCP tool-description bugs (#1892 / #1894 / #1895).

Fixes #1896