### PR TITLE
fix: preserve screenshot background behind transparent canvas

### DIFF
--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -6,6 +6,7 @@
 
 import {zod} from '../third_party/index.js';
 import type {ElementHandle, Page} from '../third_party/index.js';
+import {captureWithPageBackground} from '../utils/screenshot-background.js';
 
 import {ToolCategory} from './categories.js';
 import {definePageTool} from './ToolDefinition.js';
@@ -67,12 +68,17 @@ export const screenshot = definePageTool({
     const format = request.params.format;
     const quality = format === 'png' ? undefined : request.params.quality;
 
-    const screenshot = await pageOrHandle.screenshot({
-      type: format,
-      fullPage: request.params.fullPage,
-      quality,
-      optimizeForSpeed: true, // Bonus: optimize encoding for speed
-    });
+    const screenshot = await captureWithPageBackground(
+      request.page.pptrPage,
+      async () => {
+        return await pageOrHandle.screenshot({
+          type: format,
+          fullPage: request.params.fullPage,
+          quality,
+          optimizeForSpeed: true, // Bonus: optimize encoding for speed
+        });
+      },
+    );
 
     if (request.params.uid) {
       response.appendResponseLine(

--- a/src/tools/slim/tools.ts
+++ b/src/tools/slim/tools.ts
@@ -6,6 +6,7 @@
 
 import type {Dialog} from '../../third_party/index.js';
 import {zod} from '../../third_party/index.js';
+import {captureWithPageBackground} from '../../utils/screenshot-background.js';
 import {ToolCategory} from '../categories.js';
 import {definePageTool} from '../ToolDefinition.js';
 
@@ -21,10 +22,15 @@ export const screenshot = definePageTool({
   blockedByDialog: true,
   handler: async (request, response, context) => {
     const page = request.page;
-    const screenshot = await page.pptrPage.screenshot({
-      type: 'png',
-      optimizeForSpeed: true,
-    });
+    const screenshot = await captureWithPageBackground(
+      page.pptrPage,
+      async () => {
+        return await page.pptrPage.screenshot({
+          type: 'png',
+          optimizeForSpeed: true,
+        });
+      },
+    );
     const {filepath} = await context.saveTemporaryFile(
       screenshot,
       `screenshot.png`,

--- a/src/utils/screenshot-background.ts
+++ b/src/utils/screenshot-background.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {Page} from '../third_party/index.js';
+
+interface RgbaColor {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+export async function captureWithPageBackground<T>(
+  page: Page,
+  capture: () => Promise<T>,
+): Promise<T> {
+  const backgroundColor = await getVisiblePageBackground(page);
+  if (!backgroundColor) {
+    return await capture();
+  }
+
+  const client = await page.createCDPSession();
+  try {
+    await client.send('Emulation.setDefaultBackgroundColorOverride', {
+      color: backgroundColor,
+    });
+    return await capture();
+  } finally {
+    try {
+      await client.send('Emulation.setDefaultBackgroundColorOverride', {});
+    } finally {
+      await client.detach();
+    }
+  }
+}
+
+async function getVisiblePageBackground(
+  page: Page,
+): Promise<RgbaColor | undefined> {
+  return await page.evaluate(() => {
+    function parseCssRgbColor(value: string) {
+      const match =
+        /^rgba?\(\s*(?<red>[\d.]+)\s*,\s*(?<green>[\d.]+)\s*,\s*(?<blue>[\d.]+)(?:\s*,\s*(?<alpha>[\d.]+))?\s*\)$/u.exec(
+          value,
+        );
+      if (!match?.groups) {
+        return;
+      }
+
+      const red = Number(match.groups.red);
+      const green = Number(match.groups.green);
+      const blue = Number(match.groups.blue);
+      const alpha =
+        match.groups.alpha === undefined ? 1 : Number(match.groups.alpha);
+      if (
+        !Number.isFinite(red) ||
+        !Number.isFinite(green) ||
+        !Number.isFinite(blue) ||
+        !Number.isFinite(alpha) ||
+        alpha <= 0
+      ) {
+        return;
+      }
+
+      return {
+        r: Math.round(red),
+        g: Math.round(green),
+        b: Math.round(blue),
+        a: alpha,
+      };
+    }
+
+    function findBackgroundColor(startElement: Element | null) {
+      let element = startElement;
+      while (element) {
+        const color = parseCssRgbColor(
+          getComputedStyle(element).backgroundColor,
+        );
+        if (color) {
+          return color;
+        }
+        element = element.parentElement;
+      }
+      return;
+    }
+
+    const samplePoints = [
+      [1, 1],
+      [Math.max(1, window.innerWidth / 2), Math.max(1, window.innerHeight / 2)],
+    ];
+    for (const [x, y] of samplePoints) {
+      const color = findBackgroundColor(document.elementFromPoint(x, y));
+      if (color) {
+        return color;
+      }
+    }
+
+    return (
+      findBackgroundColor(document.body) ??
+      findBackgroundColor(document.documentElement)
+    );
+  });
+}

--- a/tests/tools/screenshot.test.ts
+++ b/tests/tools/screenshot.test.ts
@@ -11,9 +11,45 @@ import {join} from 'node:path';
 import {describe, it} from 'node:test';
 
 import {TextSnapshot} from '../../src/TextSnapshot.js';
+import type {Page} from '../../src/third_party/index.js';
 import {screenshot} from '../../src/tools/screenshot.js';
 import {screenshots} from '../snapshot.js';
 import {html, withMcpContext} from '../utils.js';
+
+async function getScreenshotPixel(
+  page: Page,
+  image: string | Uint8Array,
+  x: number,
+  y: number,
+) {
+  const data =
+    typeof image === 'string' ? image : Buffer.from(image).toString('base64');
+  return await page.evaluate(
+    async ({data, x, y}) => {
+      const image = new Image();
+      image.src = `data:image/png;base64,${data}`;
+      await image.decode();
+
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      const context = canvas.getContext('2d');
+      if (!context) {
+        throw new Error('Could not read screenshot pixels.');
+      }
+
+      context.drawImage(image, 0, 0);
+      const pixel = context.getImageData(x, y, 1, 1).data;
+      return {
+        red: pixel[0],
+        green: pixel[1],
+        blue: pixel[2],
+        alpha: pixel[3],
+      };
+    },
+    {data, x, y},
+  );
+}
 
 describe('screenshot', () => {
   describe('browser_take_screenshot', () => {
@@ -110,6 +146,153 @@ describe('screenshot', () => {
           response.responseLines.at(0),
           'Took a screenshot of the full current page.',
         );
+      });
+    });
+
+    it('preserves the visible background behind transparent canvas content', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+        const backgroundOverrides: unknown[] = [];
+        const originalCreateCDPSession = page.createCDPSession.bind(page);
+        page.createCDPSession = async () => {
+          const session = await originalCreateCDPSession();
+          const originalSend = session.send.bind(session);
+          const sendWithTracking: typeof session.send = async (
+            method,
+            params,
+            options,
+          ) => {
+            if (method === 'Emulation.setDefaultBackgroundColorOverride') {
+              backgroundOverrides.push(params ?? {});
+            }
+            return await originalSend(method, params, options);
+          };
+          Object.defineProperty(session, 'send', {value: sendWithTracking});
+          return session;
+        };
+        await page.setContent(html`
+          <style>
+            html,
+            body {
+              background: transparent;
+              height: 100%;
+              margin: 0;
+              width: 100%;
+            }
+
+            canvas {
+              display: block;
+              height: 80px;
+              width: 80px;
+            }
+          </style>
+          <canvas
+            width="80"
+            height="80"
+          ></canvas>
+        `);
+        const defaultScreenshot = await page.screenshot({
+          type: 'png',
+          optimizeForSpeed: true,
+        });
+        const defaultPixel = await getScreenshotPixel(
+          page,
+          defaultScreenshot,
+          10,
+          10,
+        );
+
+        await page.setContent(html`
+          <style>
+            html,
+            body {
+              height: 100%;
+              margin: 0;
+              width: 100%;
+            }
+
+            #container {
+              background: rgb(12, 34, 56);
+              height: 120px;
+              width: 120px;
+            }
+
+            canvas {
+              display: block;
+              height: 120px;
+              width: 120px;
+            }
+          </style>
+          <div id="container">
+            <canvas
+              width="120"
+              height="120"
+            ></canvas>
+          </div>
+        `);
+
+        await screenshot.handler(
+          {params: {format: 'png'}, page: context.getSelectedMcpPage()},
+          response,
+          context,
+        );
+
+        const pixel = await getScreenshotPixel(
+          page,
+          response.images[0].data,
+          10,
+          10,
+        );
+        assert.deepEqual(pixel, {
+          red: 12,
+          green: 34,
+          blue: 56,
+          alpha: 255,
+        });
+        assert.deepEqual(backgroundOverrides, [
+          {
+            color: {
+              r: 12,
+              g: 34,
+              b: 56,
+              a: 1,
+            },
+          },
+          {},
+        ]);
+
+        await page.setContent(html`
+          <style>
+            html,
+            body {
+              background: transparent;
+              height: 100%;
+              margin: 0;
+              width: 100%;
+            }
+
+            canvas {
+              display: block;
+              height: 80px;
+              width: 80px;
+            }
+          </style>
+          <canvas
+            width="80"
+            height="80"
+          ></canvas>
+        `);
+        const resetScreenshot = await page.screenshot({
+          type: 'png',
+          optimizeForSpeed: true,
+        });
+        const resetPixel = await getScreenshotPixel(
+          page,
+          resetScreenshot,
+          10,
+          10,
+        );
+        assert.deepEqual(resetPixel, defaultPixel);
       });
     });
 

--- a/tests/tools/slim/tools.test.ts
+++ b/tests/tools/slim/tools.test.ts
@@ -11,7 +11,7 @@ import {describe, it} from 'node:test';
 
 import {evaluate, navigate, screenshot} from '../../../src/tools/slim/tools.js';
 import {screenshots} from '../../snapshot.js';
-import {withMcpContext} from '../../utils.js';
+import {html, withMcpContext} from '../../utils.js';
 
 describe('slim', () => {
   it('evaluates', async t => {
@@ -78,6 +78,78 @@ describe('slim', () => {
       );
       assert(path.isAbsolute(response.responseLines.at(0)!));
       assert(fs.existsSync(response.responseLines.at(0)!));
+    });
+  });
+
+  it('sets and resets the visible page background for screenshots', async () => {
+    await withMcpContext(async (response, context) => {
+      const page = context.getSelectedPptrPage();
+      const backgroundOverrides: unknown[] = [];
+      const originalCreateCDPSession = page.createCDPSession.bind(page);
+      page.createCDPSession = async () => {
+        const session = await originalCreateCDPSession();
+        const originalSend = session.send.bind(session);
+        const sendWithTracking: typeof session.send = async (
+          method,
+          params,
+          options,
+        ) => {
+          if (method === 'Emulation.setDefaultBackgroundColorOverride') {
+            backgroundOverrides.push(params ?? {});
+          }
+          return await originalSend(method, params, options);
+        };
+        Object.defineProperty(session, 'send', {value: sendWithTracking});
+        return session;
+      };
+      await page.setContent(html`
+        <style>
+          html,
+          body {
+            height: 100%;
+            margin: 0;
+            width: 100%;
+          }
+
+          #container {
+            background: rgb(12, 34, 56);
+            height: 120px;
+            width: 120px;
+          }
+
+          canvas {
+            display: block;
+            height: 120px;
+            width: 120px;
+          }
+        </style>
+        <div id="container">
+          <canvas
+            width="120"
+            height="120"
+          ></canvas>
+        </div>
+      `);
+
+      await screenshot.handler(
+        {params: {}, page: context.getSelectedMcpPage()},
+        response,
+        context,
+      );
+
+      assert(path.isAbsolute(response.responseLines.at(0)!));
+      assert(fs.existsSync(response.responseLines.at(0)!));
+      assert.deepEqual(backgroundOverrides, [
+        {
+          color: {
+            r: 12,
+            g: 34,
+            b: 56,
+            a: 1,
+          },
+        },
+        {},
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #806.

Screenshots now infer the visible page background before capture and temporarily set Chrome's default background color override while Puppeteer captures the image. This preserves CSS backgrounds behind transparent canvas content for both `take_screenshot` and the slim `screenshot` tool, then resets the override in `finally`.

## Changes

- Add a shared screenshot background helper that samples visible CSS backgrounds and wraps screenshot capture with `Emulation.setDefaultBackgroundColorOverride`.
- Use the helper from both `take_screenshot` and slim `screenshot` without changing screenshot parameters or file-saving behavior.
- Add regression coverage for transparent canvas screenshots, background pixels, and override reset behavior.

## Testing

- `npm ci`
- `npm run build`
- `npm run test tests/tools/screenshot.test.ts` (pre-fix failed because no `Emulation.setDefaultBackgroundColorOverride` call was made)
- `npm run test tests/tools/screenshot.test.ts`
- `npm run test tests/tools/slim/tools.test.ts`
- `npm run check-format`
- `git diff --check`
- `npm run test`

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.