### PR TITLE
fix: pin npx version in plugin.json to avoid supply-chain drift

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "chrome-devtools": {
       "command": "npx",
       "args": [
-        "chrome-devtools-mcp@latest"
+        "chrome-devtools-mcp@1.0.1"
       ]
     }
   }


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm-for-claude), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `.claude-plugin/plugin.json` runs `npx chrome-devtools-mcp@latest`, so the resolved version floats on every MCP client restart — any future `latest` tag (including a compromised one) is picked up automatically.

**Evidence**: `"args": ["chrome-devtools-mcp@latest"]` confirmed at line 9; `package.json` declares `"version": "1.0.1"`, so a matching pinned version is available.

**Fix**: Replaces `chrome-devtools-mcp@latest` with `chrome-devtools-mcp@1.0.1` to lock to the current release; update in lockstep with future version bumps.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:32ba60c0173cc7ca687047dbd351915f743b63f8a370da582839fc6e85e8d823"}]}
nlpm-metadata-end -->