### PR TITLE
fix: pin chrome-devtools-mcp npx version in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "chrome-devtools": {
       "command": "npx",
       "args": [
-        "chrome-devtools-mcp@latest"
+        "chrome-devtools-mcp@1.0.1"
       ]
     }
   }


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `.claude-plugin/plugin.json` configures `npx chrome-devtools-mcp@latest`, so MCP clients pull the latest npm release on every restart — a floating version that can silently pick up a compromised or breaking release.

**Evidence**: Line 9 of `.claude-plugin/plugin.json` confirmed: `"chrome-devtools-mcp@latest"`; `package.json` declares `"version": "1.0.1"`.

**Fix**: Pins the npx invocation to `chrome-devtools-mcp@1.0.1`, matching the current release; update in lockstep with `package.json` version bumps.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:32ba60c0173cc7ca687047dbd351915f743b63f8a370da582839fc6e85e8d823"}]}
nlpm-metadata-end -->