### PR TITLE
chore: fix two typos in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,5 +1,5 @@
 name: Feature
-description: Suggest an idea for for chrome-devtools-mcp
+description: Suggest an idea for chrome-devtools-mcp
 title: '<short description of the feature request>'
 type: 'Feature'
 labels:

--- a/.github/ISSUE_TEMPLATE/03-task.yml
+++ b/.github/ISSUE_TEMPLATE/03-task.yml
@@ -1,5 +1,5 @@
 name: Task
-description: Work tracking for mainainers only!
+description: Work tracking for maintainers only!
 title: '[Task]:'
 type: 'Task'
 body:


### PR DESCRIPTION
## Summary

Two small typo fixes in `.github/ISSUE_TEMPLATE/`:

- `02-feature.yml`: "Suggest an idea for for chrome-devtools-mcp" had a duplicate "for".
- `03-task.yml`: "mainainers only" was missing the first `t`.

Both strings appear on the GitHub issue picker when a user clicks "New issue", so they're user-facing.