### PR TITLE
fix: add missing validatePath call in getHeapSnapshotRetainers

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -855,6 +855,7 @@ export class McpContext implements Context {
     filePath: string,
     nodeId: number,
   ): Promise<DevTools.HeapSnapshotModel.HeapSnapshotModel.ItemsRange> {
+    this.validatePath(filePath);
     return await this.#heapSnapshotManager.getRetainers(filePath, nodeId);
   }
 }


### PR DESCRIPTION
All other getHeapSnapshot* methods in McpContext call this.validatePath(filePath) before delegating to HeapSnapshotManager, but getHeapSnapshotRetainers (added in b2b05a0) was missing it. Without this check, a path outside the workspace roots could bypass the access-control guard.

This aligns getHeapSnapshotRetainers with getHeapSnapshotAggregates, getHeapSnapshotStats, getHeapSnapshotStaticData, and getHeapSnapshotNodesById.