### PR TITLE
fix: use pinned version for plugins

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "chrome-devtools": {
       "command": "npx",
       "args": [
-        "chrome-devtools-mcp@latest"
+        "chrome-devtools-mcp@1.0.1"
       ]
     }
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -11,7 +11,7 @@
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["chrome-devtools-mcp@latest"]
+      "args": ["chrome-devtools-mcp@1.0.1"]
     }
   }
 }

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -6,7 +6,7 @@
     "chrome-devtools": {
       "command": "npx",
       "args": [
-        "chrome-devtools-mcp@latest"
+        "chrome-devtools-mcp@1.0.1"
       ]
     }
   }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,10 +1,10 @@
 {
   "name": "chrome-devtools-mcp",
-  "version": "latest",
+  "version": "1.0.1",
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["chrome-devtools-mcp@latest"]
+      "args": ["chrome-devtools-mcp@1.0.1"]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -42,13 +42,38 @@
         },
         {
           "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "mcpServers['chrome-devtools'].args[1]"
+        },
+        {
+          "type": "json",
           "path": ".cursor-plugin/plugin.json",
           "jsonpath": "version"
         },
         {
           "type": "json",
+          "path": ".cursor-plugin/plugin.json",
+          "jsonpath": "mcpServers.[['chrome-devtools']'].args[1]"
+        },
+        {
+          "type": "json",
+          "path": "gemini-extension.json",
+          "jsonpath": "version"
+        },
+        {
+          "type": "json",
+          "path": "gemini-extension.json",
+          "jsonpath": "mcpServers['chrome-devtools'].args[1]"
+        },
+        {
+          "type": "json",
           "path": ".github/plugin/plugin.json",
           "jsonpath": "version"
+        },
+        {
+          "type": "json",
+          "path": ".github/plugin/plugin.json",
+          "jsonpath": "mcpServers['chrome-devtools'].args[1]"
         }
       ]
     }


### PR DESCRIPTION
The regex used to match the versions is 
```js
const regex = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<preRelease>[\w.]+))?(\+(?<build>[-\w.]+))?/
```
And they replace what was matched.
Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/2121