### PR TITLE
fix(cli): have pageId as first argument

### DIFF
--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -163,7 +163,7 @@ export class ToolHandler {
       tool.pageScoped &&
       serverArgs.experimentalPageIdRouting &&
       !serverArgs.slim
-        ? {...tool.schema, ...pageIdSchema}
+        ? {...pageIdSchema, ...tool.schema}
         : tool.schema;
     this.registeredInputSchema = zod.object(this.inputSchema).passthrough();
   }

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -24,6 +24,7 @@ so returned values have to be JSON-serializable.`,
       readOnlyHint: false,
     },
     schema: {
+      ...(cliArgs?.experimentalPageIdRouting ? pageIdSchema : {}),
       function: zod.string().describe(
         `A JavaScript function declaration to be executed by the tool in the currently selected page.
 Example without arguments: \`() => {
@@ -58,7 +59,6 @@ Example with arguments: \`(el) => {
         .describe(
           'Handle dialogs while execution. "accept", "dismiss", or string for response of window.prompt. Defaults to accept.',
         ),
-      ...(cliArgs?.experimentalPageIdRouting ? pageIdSchema : {}),
       ...(cliArgs?.categoryExtensions
         ? {
             serviceWorkerId: zod


### PR DESCRIPTION
Refs #1777 

This change makes pageId as the first argument for CLI if experimentalPageIdRouting flag is enabled