### PR TITLE
feat: Handle multiple providers of third-party developer tools

### DIFF
--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -14,7 +14,7 @@ import type {
   WebMCPTool,
 } from './third_party/index.js';
 import {takeSnapshot} from './tools/snapshot.js';
-import type {ToolGroup, ToolDefinition} from './tools/thirdPartyDeveloper.js';
+import type {ToolGroups} from './tools/thirdPartyDeveloper.js';
 import type {
   ContextPage,
   DevToolsData,
@@ -59,7 +59,7 @@ export class McpPage implements ContextPage {
   #dialog?: Dialog;
   #dialogHandler: (dialog: Dialog) => void;
 
-  thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>> = [];
+  thirdPartyDeveloperTools: ToolGroups = [];
 
   constructor(page: Page, id: number) {
     this.pptrPage = page;
@@ -90,7 +90,7 @@ export class McpPage implements ContextPage {
     }
   }
 
-  getThirdPartyDeveloperTools(): Array<ToolGroup<ToolDefinition>> {
+  getThirdPartyDeveloperTools(): ToolGroups {
     return this.thirdPartyDeveloperTools;
   }
 

--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -59,7 +59,9 @@ export class McpPage implements ContextPage {
   #dialog?: Dialog;
   #dialogHandler: (dialog: Dialog) => void;
 
-  thirdPartyDeveloperTools: ToolGroup<ToolDefinition> | undefined;
+  thirdPartyDeveloperTools:
+    | Array<Partial<ToolGroup<ToolDefinition>>>
+    | undefined;
 
   constructor(page: Page, id: number) {
     this.pptrPage = page;
@@ -90,7 +92,9 @@ export class McpPage implements ContextPage {
     }
   }
 
-  getThirdPartyDeveloperTools(): ToolGroup<ToolDefinition> | undefined {
+  getThirdPartyDeveloperTools():
+    | Array<Partial<ToolGroup<ToolDefinition>>>
+    | undefined {
     return this.thirdPartyDeveloperTools;
   }
 

--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -59,9 +59,7 @@ export class McpPage implements ContextPage {
   #dialog?: Dialog;
   #dialogHandler: (dialog: Dialog) => void;
 
-  thirdPartyDeveloperTools:
-    | Array<Partial<ToolGroup<ToolDefinition>>>
-    | undefined;
+  thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>> | undefined;
 
   constructor(page: Page, id: number) {
     this.pptrPage = page;
@@ -92,9 +90,7 @@ export class McpPage implements ContextPage {
     }
   }
 
-  getThirdPartyDeveloperTools():
-    | Array<Partial<ToolGroup<ToolDefinition>>>
-    | undefined {
+  getThirdPartyDeveloperTools(): Array<ToolGroup<ToolDefinition>> | undefined {
     return this.thirdPartyDeveloperTools;
   }
 

--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -59,7 +59,7 @@ export class McpPage implements ContextPage {
   #dialog?: Dialog;
   #dialogHandler: (dialog: Dialog) => void;
 
-  thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>> | undefined;
+  thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>> = [];
 
   constructor(page: Page, id: number) {
     this.pptrPage = page;
@@ -90,7 +90,7 @@ export class McpPage implements ContextPage {
     }
   }
 
-  getThirdPartyDeveloperTools(): Array<ToolGroup<ToolDefinition>> | undefined {
+  getThirdPartyDeveloperTools(): Array<ToolGroup<ToolDefinition>> {
     return this.thirdPartyDeveloperTools;
   }
 

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -101,7 +101,7 @@ export function replaceHtmlElementsWithUids(schema: JSONSchema7Definition) {
 
 async function getToolGroups(
   page: McpPage,
-): Promise<Array<ToolGroup<ToolDefinition>> | undefined | null> {
+): Promise<Array<ToolGroup<ToolDefinition>>> {
   // Check if there is a `devtoolstooldiscovery` event listener
   const windowHandle = await page.pptrPage.evaluateHandle(() => window);
   // @ts-expect-error internal API
@@ -111,7 +111,7 @@ async function getToolGroups(
       objectId: windowHandle.remoteObject().objectId,
     });
   if (listeners.find(l => l.type === 'devtoolstooldiscovery') === undefined) {
-    return;
+    return [];
   }
 
   const toolGroups = await page.pptrPage.evaluate(() => {
@@ -120,7 +120,7 @@ async function getToolGroups(
       //   execute: (args: Record<string, unknown>) => unknown;
       // }
       ToolDefinition>
-    > | null>(resolve => {
+    >>(resolve => {
       const event = new CustomEvent('devtoolstooldiscovery');
       // const groups: Array<
       //   ToolGroup<
@@ -130,6 +130,7 @@ async function getToolGroups(
       //   >
       // > = [];
       const groups: Array<ToolGroup<ToolDefinition>> = [];
+      // @ts-expect-error Adding custom property
       event.respondWith = toolGroup => {
         if (!window.__dtmcp) {
           window.__dtmcp = {};
@@ -137,6 +138,14 @@ async function getToolGroups(
         if (!window.__dtmcp.toolGroups) {
           window.__dtmcp.toolGroups = [];
         }
+
+        // Verify toolGroup
+        if (!toolGroup.name || !toolGroup.description || !toolGroup.tools) {
+          console.error('Invalid toolGroup:', toolGroup);
+          return;
+        }
+
+
         window.__dtmcp.toolGroups.push(toolGroup);
 
         // When receiving a toolGroup for the first time, expose a simple execution helper
@@ -170,7 +179,7 @@ async function getToolGroups(
           if (groups.length > 0) {
             resolve(groups);
           } else {
-            resolve(null);
+            resolve([]);
           }
         }, 0);
       }

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -127,11 +127,24 @@ async function getToolGroups(
           window.__dtmcp.toolGroups = [];
         }
 
-        // Verify toolGroup
-        // TODO: verify tools
-        if (!toolGroup.name || !toolGroup.description || !toolGroup.tools) {
+        if (
+          typeof toolGroup.name !== 'string' ||
+          typeof toolGroup.description !== 'string' ||
+          !Array.isArray(toolGroup.tools)
+        ) {
           console.error('Invalid toolGroup:', toolGroup);
           return;
+        }
+        for (const tool of toolGroup.tools) {
+          if (
+            typeof tool.name !== 'string' ||
+            typeof tool.description !== 'string' ||
+            typeof tool.inputSchema !== 'object' ||
+            typeof tool.execute !== 'function'
+          ) {
+            console.error('Invalid tool:', tool);
+            return;
+          }
         }
 
         window.__dtmcp.toolGroups.push(toolGroup);
@@ -160,7 +173,6 @@ async function getToolGroups(
       window.dispatchEvent(event);
       // If at least one toolGroup was added synchronously, resolve with the array.
       // Otherwise, use setTimeout to allow for any microtask/asynchronous respondWith calls, or resolve with an empty array.
-      // TODO: needed?
       if (groups.length > 0) {
         resolve(groups);
       } else {

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -115,12 +115,14 @@ async function getToolGroups(
   }
 
   const toolGroups = await page.pptrPage.evaluate(() => {
-    return new Promise<Array<
-      ToolGroup<// ToolDefinition & {
-      //   execute: (args: Record<string, unknown>) => unknown;
-      // }
-      ToolDefinition>
-    >>(resolve => {
+    return new Promise<
+      Array<
+        ToolGroup<// ToolDefinition & {
+        //   execute: (args: Record<string, unknown>) => unknown;
+        // }
+        ToolDefinition>
+      >
+    >(resolve => {
       const event = new CustomEvent('devtoolstooldiscovery');
       // const groups: Array<
       //   ToolGroup<
@@ -144,7 +146,6 @@ async function getToolGroups(
           console.error('Invalid toolGroup:', toolGroup);
           return;
         }
-
 
         window.__dtmcp.toolGroups.push(toolGroup);
 
@@ -186,10 +187,11 @@ async function getToolGroups(
     });
   });
 
-  if (toolGroups === undefined || toolGroups === null) {
-    return toolGroups;
-  }
+  // if (toolGroups === undefined || toolGroups === null) {
+  //   return toolGroups;
+  // }
 
+  // SIMPLIFY?
   const groupsArray = Array.isArray(toolGroups) ? toolGroups : [toolGroups];
 
   for (const group of groupsArray) {
@@ -604,11 +606,9 @@ export class McpResponse implements Response {
       extensions = await context.listExtensions();
     }
 
+    // TODO: fix comment
     // Null indicates no tools.
-    let thirdPartyDeveloperTools:
-      | Array<ToolGroup<ToolDefinition>>
-      | undefined
-      | null;
+    let thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>> = [];
     if (
       this.#args.categoryExperimentalThirdParty &&
       this.#listThirdPartyDeveloperTools &&
@@ -752,7 +752,7 @@ export class McpResponse implements Response {
       traceInsight?: TraceInsightData;
       extensions?: Map<string, Extension>;
       lighthouseResult?: LighthouseData;
-      thirdPartyDeveloperTools?: Array<ToolGroup<ToolDefinition>> | null;
+      thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>>;
       webmcpTools?: WebMCPTool[];
       errorMessage?: string;
     },
@@ -1097,30 +1097,21 @@ Call ${handleDialog.name} to handle it before continuing.`);
       }
     }
 
-    if (data.thirdPartyDeveloperTools !== undefined) {
-      if (data.thirdPartyDeveloperTools) {
-        structuredContent.thirdPartyDeveloperTools =
-          data.thirdPartyDeveloperTools;
-      }
+    if (data.thirdPartyDeveloperTools.length) {
+      structuredContent.thirdPartyDeveloperTools =
+        data.thirdPartyDeveloperTools;
       response.push('## Third-party developer tools');
-      if (
-        data.thirdPartyDeveloperTools === null ||
-        data.thirdPartyDeveloperTools.length === 0
-      ) {
-        response.push('No third-party developer tools available.');
-      } else {
-        for (const toolGroup of data.thirdPartyDeveloperTools) {
-          response.push(`${toolGroup.name}: ${toolGroup.description}`);
-          response.push('Available tools:');
-          const toolDefinitionsMessage = toolGroup.tools
-            .map(tool => {
-              return `name="${tool.name}", description="${tool.description}", inputSchema=${JSON.stringify(
-                tool.inputSchema,
-              )}`;
-            })
-            .join('\n');
-          response.push(toolDefinitionsMessage);
-        }
+      for (const toolGroup of data.thirdPartyDeveloperTools) {
+        response.push(`${toolGroup.name}: ${toolGroup.description}`);
+        response.push('Available tools:');
+        const toolDefinitionsMessage = toolGroup.tools
+          .map(tool => {
+            return `name="${tool.name}", description="${tool.description}", inputSchema=${JSON.stringify(
+              tool.inputSchema,
+            )}`;
+          })
+          .join('\n');
+        response.push(toolDefinitionsMessage);
       }
     }
 

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -101,7 +101,7 @@ export function replaceHtmlElementsWithUids(schema: JSONSchema7Definition) {
 
 async function getToolGroups(
   page: McpPage,
-): Promise<Array<Partial<ToolGroup<ToolDefinition>>> | undefined | null> {
+): Promise<Array<ToolGroup<ToolDefinition>> | undefined | null> {
   // Check if there is a `devtoolstooldiscovery` event listener
   const windowHandle = await page.pptrPage.evaluateHandle(() => window);
   // @ts-expect-error internal API
@@ -116,24 +116,20 @@ async function getToolGroups(
 
   const toolGroups = await page.pptrPage.evaluate(() => {
     return new Promise<Array<
-      Partial<
-        ToolGroup<
-          ToolDefinition & {
-            execute: (args: Record<string, unknown>) => unknown;
-          }
-        >
-      >
+      ToolGroup<// ToolDefinition & {
+      //   execute: (args: Record<string, unknown>) => unknown;
+      // }
+      ToolDefinition>
     > | null>(resolve => {
       const event = new CustomEvent('devtoolstooldiscovery');
-      const groups: Array<
-        Partial<
-          ToolGroup<
-            ToolDefinition & {
-              execute: (args: Record<string, unknown>) => unknown;
-            }
-          >
-        >
-      > = [];
+      // const groups: Array<
+      //   ToolGroup<
+      //     ToolDefinition & {
+      //       execute: (args: Record<string, unknown>) => unknown;
+      //     }
+      //   >
+      // > = [];
+      const groups: Array<ToolGroup<ToolDefinition>> = [];
       event.respondWith = toolGroup => {
         if (!window.__dtmcp) {
           window.__dtmcp = {};
@@ -601,7 +597,7 @@ export class McpResponse implements Response {
 
     // Null indicates no tools.
     let thirdPartyDeveloperTools:
-      | Array<Partial<ToolGroup<ToolDefinition>>>
+      | Array<ToolGroup<ToolDefinition>>
       | undefined
       | null;
     if (
@@ -747,9 +743,7 @@ export class McpResponse implements Response {
       traceInsight?: TraceInsightData;
       extensions?: Map<string, Extension>;
       lighthouseResult?: LighthouseData;
-      thirdPartyDeveloperTools?: Array<
-        Partial<ToolGroup<ToolDefinition>>
-      > | null;
+      thirdPartyDeveloperTools?: Array<ToolGroup<ToolDefinition>> | null;
       webmcpTools?: WebMCPTool[];
       errorMessage?: string;
     },
@@ -1107,11 +1101,9 @@ Call ${handleDialog.name} to handle it before continuing.`);
         response.push('No third-party developer tools available.');
       } else {
         for (const toolGroup of data.thirdPartyDeveloperTools) {
-          response.push(
-            `${toolGroup.name ?? ''}: ${toolGroup.description ?? ''}`,
-          );
+          response.push(`${toolGroup.name}: ${toolGroup.description}`);
           response.push('Available tools:');
-          const toolDefinitionsMessage = (toolGroup.tools ?? [])
+          const toolDefinitionsMessage = toolGroup.tools
             .map(tool => {
               return `name="${tool.name}", description="${tool.description}", inputSchema=${JSON.stringify(
                 tool.inputSchema,

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -28,7 +28,7 @@ import type {
   Extension,
 } from './third_party/index.js';
 import {handleDialog} from './tools/pages.js';
-import type {ToolGroup, ToolDefinition} from './tools/thirdPartyDeveloper.js';
+import type {ToolGroups} from './tools/thirdPartyDeveloper.js';
 import type {
   DevToolsData,
   ImageContentData,
@@ -99,9 +99,7 @@ export function replaceHtmlElementsWithUids(schema: JSONSchema7Definition) {
   }
 }
 
-async function getToolGroups(
-  page: McpPage,
-): Promise<Array<ToolGroup<ToolDefinition>>> {
+async function getToolGroups(page: McpPage): Promise<ToolGroups> {
   // Check if there is a `devtoolstooldiscovery` event listener
   const windowHandle = await page.pptrPage.evaluateHandle(() => window);
   // @ts-expect-error internal API
@@ -115,9 +113,9 @@ async function getToolGroups(
   }
 
   const toolGroups = await page.pptrPage.evaluate(() => {
-    return new Promise<Array<ToolGroup<ToolDefinition>>>(resolve => {
+    return new Promise<ToolGroups>(resolve => {
       const event = new CustomEvent('devtoolstooldiscovery');
-      const groups: Array<ToolGroup<ToolDefinition>> = [];
+      const groups: ToolGroups = [];
       // @ts-expect-error Adding custom property
       event.respondWith = toolGroup => {
         if (!window.__dtmcp) {
@@ -599,7 +597,7 @@ export class McpResponse implements Response {
       extensions = await context.listExtensions();
     }
 
-    let thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>> = [];
+    let thirdPartyDeveloperTools: ToolGroups = [];
     if (
       this.#args.categoryExperimentalThirdParty &&
       this.#listThirdPartyDeveloperTools &&
@@ -743,7 +741,7 @@ export class McpResponse implements Response {
       traceInsight?: TraceInsightData;
       extensions?: Map<string, Extension>;
       lighthouseResult?: LighthouseData;
-      thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>>;
+      thirdPartyDeveloperTools: ToolGroups;
       webmcpTools?: WebMCPTool[];
       errorMessage?: string;
     },

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -99,9 +99,9 @@ export function replaceHtmlElementsWithUids(schema: JSONSchema7Definition) {
   }
 }
 
-async function getToolGroup(
+async function getToolGroups(
   page: McpPage,
-): Promise<ToolGroup<ToolDefinition> | undefined | null> {
+): Promise<Array<Partial<ToolGroup<ToolDefinition>>> | undefined | null> {
   // Check if there is a `devtoolstooldiscovery` event listener
   const windowHandle = await page.pptrPage.evaluateHandle(() => window);
   // @ts-expect-error internal API
@@ -114,48 +114,85 @@ async function getToolGroup(
     return;
   }
 
-  const toolGroup = await page.pptrPage.evaluate(() => {
-    return new Promise<ToolGroup<ToolDefinition> | undefined | null>(
-      resolve => {
-        const event = new CustomEvent('devtoolstooldiscovery');
-        // @ts-expect-error Adding custom property
-        event.respondWith = (toolGroup: ToolGroup) => {
-          if (!window.__dtmcp) {
-            window.__dtmcp = {};
+  const toolGroups = await page.pptrPage.evaluate(() => {
+    return new Promise<Array<
+      Partial<
+        ToolGroup<
+          ToolDefinition & {
+            execute: (args: Record<string, unknown>) => unknown;
           }
-          window.__dtmcp.toolGroup = toolGroup;
+        >
+      >
+    > | null>(resolve => {
+      const event = new CustomEvent('devtoolstooldiscovery');
+      const groups: Array<
+        Partial<
+          ToolGroup<
+            ToolDefinition & {
+              execute: (args: Record<string, unknown>) => unknown;
+            }
+          >
+        >
+      > = [];
+      event.respondWith = toolGroup => {
+        if (!window.__dtmcp) {
+          window.__dtmcp = {};
+        }
+        if (!window.__dtmcp.toolGroups) {
+          window.__dtmcp.toolGroups = [];
+        }
+        window.__dtmcp.toolGroups.push(toolGroup);
 
-          // When receiving a toolGroup for the first time, expose a simple execution helper
-          if (!window.__dtmcp.executeTool) {
-            window.__dtmcp.executeTool = async (toolName, args) => {
-              if (!window.__dtmcp?.toolGroup) {
-                throw new Error('No tools found on the page');
+        // When receiving a toolGroup for the first time, expose a simple execution helper
+        if (!window.__dtmcp.executeTool) {
+          window.__dtmcp.executeTool = async (toolName, args) => {
+            if (
+              !window.__dtmcp?.toolGroups ||
+              window.__dtmcp.toolGroups.length === 0
+            ) {
+              throw new Error('No tools found on the page');
+            }
+            for (const group of window.__dtmcp.toolGroups) {
+              const tool = group.tools?.find(t => t.name === toolName);
+              if (tool) {
+                return await tool.execute(args);
               }
-              const tool = window.__dtmcp.toolGroup.tools.find(
-                t => t.name === toolName,
-              );
-              if (!tool) {
-                throw new Error(`Tool ${toolName} not found`);
-              }
-              return await tool.execute(args);
-            };
-          }
+            }
+            throw new Error(`Tool ${toolName} not found`);
+          };
+        }
 
-          resolve(toolGroup);
-        };
-        window.dispatchEvent(event);
-        // If the page does not synchronously call `event.respondWith`, return instead of timing out
+        groups.push(toolGroup);
+      };
+      window.dispatchEvent(event);
+      // If at least one toolGroup was added synchronously, resolve with the array.
+      // Otherwise, use setTimeout to allow for any microtask/asynchronous respondWith calls, or resolve null.
+      if (groups.length > 0) {
+        resolve(groups);
+      } else {
         setTimeout(() => {
-          resolve(null);
+          if (groups.length > 0) {
+            resolve(groups);
+          } else {
+            resolve(null);
+          }
         }, 0);
-      },
-    );
+      }
+    });
   });
 
-  for (const tool of toolGroup?.tools ?? []) {
-    replaceHtmlElementsWithUids(tool.inputSchema);
+  if (toolGroups === undefined || toolGroups === null) {
+    return toolGroups;
   }
-  return toolGroup;
+
+  const groupsArray = Array.isArray(toolGroups) ? toolGroups : [toolGroups];
+
+  for (const group of groupsArray) {
+    for (const tool of group.tools ?? []) {
+      replaceHtmlElementsWithUids(tool.inputSchema);
+    }
+  }
+  return groupsArray;
 }
 
 export class McpResponse implements Response {
@@ -563,13 +600,16 @@ export class McpResponse implements Response {
     }
 
     // Null indicates no tools.
-    let thirdPartyDeveloperTools: ToolGroup<ToolDefinition> | undefined | null;
+    let thirdPartyDeveloperTools:
+      | Array<Partial<ToolGroup<ToolDefinition>>>
+      | undefined
+      | null;
     if (
       this.#args.categoryExperimentalThirdParty &&
       this.#listThirdPartyDeveloperTools &&
       this.#page
     ) {
-      thirdPartyDeveloperTools = await getToolGroup(this.#page);
+      thirdPartyDeveloperTools = await getToolGroups(this.#page);
       if (thirdPartyDeveloperTools) {
         this.#page.thirdPartyDeveloperTools = thirdPartyDeveloperTools;
       }
@@ -707,7 +747,9 @@ export class McpResponse implements Response {
       traceInsight?: TraceInsightData;
       extensions?: Map<string, Extension>;
       lighthouseResult?: LighthouseData;
-      thirdPartyDeveloperTools?: ToolGroup<ToolDefinition> | null;
+      thirdPartyDeveloperTools?: Array<
+        Partial<ToolGroup<ToolDefinition>>
+      > | null;
       webmcpTools?: WebMCPTool[];
       errorMessage?: string;
     },
@@ -724,7 +766,7 @@ export class McpResponse implements Response {
       traceInsights?: Array<{insightName: string; insightKey: string}>;
       lighthouseResult?: object;
       extensions?: object[];
-      thirdPartyDeveloperTools?: object;
+      thirdPartyDeveloperTools?: object[];
       webmcpTools?: object[];
       message?: string;
       networkConditions?: string;
@@ -1060,21 +1102,24 @@ Call ${handleDialog.name} to handle it before continuing.`);
       response.push('## Third-party developer tools');
       if (
         data.thirdPartyDeveloperTools === null ||
-        !data.thirdPartyDeveloperTools?.tools
+        data.thirdPartyDeveloperTools.length === 0
       ) {
         response.push('No third-party developer tools available.');
       } else {
-        const toolGroup = data.thirdPartyDeveloperTools;
-        response.push(`${toolGroup.name}: ${toolGroup.description}`);
-        response.push('Available tools:');
-        const toolDefinitionsMessage = toolGroup.tools
-          .map(tool => {
-            return `name="${tool.name}", description="${tool.description}", inputSchema=${JSON.stringify(
-              tool.inputSchema,
-            )}`;
-          })
-          .join('\n');
-        response.push(toolDefinitionsMessage);
+        for (const toolGroup of data.thirdPartyDeveloperTools) {
+          response.push(
+            `${toolGroup.name ?? ''}: ${toolGroup.description ?? ''}`,
+          );
+          response.push('Available tools:');
+          const toolDefinitionsMessage = (toolGroup.tools ?? [])
+            .map(tool => {
+              return `name="${tool.name}", description="${tool.description}", inputSchema=${JSON.stringify(
+                tool.inputSchema,
+              )}`;
+            })
+            .join('\n');
+          response.push(toolDefinitionsMessage);
+        }
       }
     }
 

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -115,22 +115,8 @@ async function getToolGroups(
   }
 
   const toolGroups = await page.pptrPage.evaluate(() => {
-    return new Promise<
-      Array<
-        ToolGroup<// ToolDefinition & {
-        //   execute: (args: Record<string, unknown>) => unknown;
-        // }
-        ToolDefinition>
-      >
-    >(resolve => {
+    return new Promise<Array<ToolGroup<ToolDefinition>>>(resolve => {
       const event = new CustomEvent('devtoolstooldiscovery');
-      // const groups: Array<
-      //   ToolGroup<
-      //     ToolDefinition & {
-      //       execute: (args: Record<string, unknown>) => unknown;
-      //     }
-      //   >
-      // > = [];
       const groups: Array<ToolGroup<ToolDefinition>> = [];
       // @ts-expect-error Adding custom property
       event.respondWith = toolGroup => {
@@ -142,6 +128,7 @@ async function getToolGroups(
         }
 
         // Verify toolGroup
+        // TODO: verify tools
         if (!toolGroup.name || !toolGroup.description || !toolGroup.tools) {
           console.error('Invalid toolGroup:', toolGroup);
           return;
@@ -172,7 +159,8 @@ async function getToolGroups(
       };
       window.dispatchEvent(event);
       // If at least one toolGroup was added synchronously, resolve with the array.
-      // Otherwise, use setTimeout to allow for any microtask/asynchronous respondWith calls, or resolve null.
+      // Otherwise, use setTimeout to allow for any microtask/asynchronous respondWith calls, or resolve with an empty array.
+      // TODO: needed?
       if (groups.length > 0) {
         resolve(groups);
       } else {
@@ -187,19 +175,12 @@ async function getToolGroups(
     });
   });
 
-  // if (toolGroups === undefined || toolGroups === null) {
-  //   return toolGroups;
-  // }
-
-  // SIMPLIFY?
-  const groupsArray = Array.isArray(toolGroups) ? toolGroups : [toolGroups];
-
-  for (const group of groupsArray) {
+  for (const group of toolGroups) {
     for (const tool of group.tools ?? []) {
       replaceHtmlElementsWithUids(tool.inputSchema);
     }
   }
-  return groupsArray;
+  return toolGroups;
 }
 
 export class McpResponse implements Response {
@@ -606,8 +587,6 @@ export class McpResponse implements Response {
       extensions = await context.listExtensions();
     }
 
-    // TODO: fix comment
-    // Null indicates no tools.
     let thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>> = [];
     if (
       this.#args.categoryExperimentalThirdParty &&

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -271,7 +271,7 @@ export type ContextPage = Readonly<{
     options?: {timeout?: number; handleDialog?: 'accept' | 'dismiss' | string},
   ): Promise<WaitForEventsResult>;
   getThirdPartyDeveloperTools():
-    | ToolGroup<ThirdPartyDeveloperToolDefinition>
+    | Array<Partial<ToolGroup<ThirdPartyDeveloperToolDefinition>>>
     | undefined;
   executeThirdPartyDeveloperTool(
     toolName: string,

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -270,9 +270,9 @@ export type ContextPage = Readonly<{
     action: () => Promise<unknown>,
     options?: {timeout?: number; handleDialog?: 'accept' | 'dismiss' | string},
   ): Promise<WaitForEventsResult>;
-  getThirdPartyDeveloperTools():
-    | Array<ToolGroup<ThirdPartyDeveloperToolDefinition>>
-    | undefined;
+  getThirdPartyDeveloperTools(): Array<
+    ToolGroup<ThirdPartyDeveloperToolDefinition>
+  >;
   executeThirdPartyDeveloperTool(
     toolName: string,
     params: Record<string, unknown>,

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -27,10 +27,7 @@ import type {PaginationOptions} from '../utils/types.js';
 import type {WaitForEventsResult} from '../WaitForHelper.js';
 
 import type {ToolCategory} from './categories.js';
-import type {
-  ToolGroup,
-  ToolDefinition as ThirdPartyDeveloperToolDefinition,
-} from './thirdPartyDeveloper.js';
+import type {ToolGroups} from './thirdPartyDeveloper.js';
 
 export interface BaseToolDefinition<
   Schema extends zod.ZodRawShape = zod.ZodRawShape,
@@ -270,9 +267,8 @@ export type ContextPage = Readonly<{
     action: () => Promise<unknown>,
     options?: {timeout?: number; handleDialog?: 'accept' | 'dismiss' | string},
   ): Promise<WaitForEventsResult>;
-  getThirdPartyDeveloperTools(): Array<
-    ToolGroup<ThirdPartyDeveloperToolDefinition>
-  >;
+  getThirdPartyDeveloperTools(): ToolGroups;
+
   executeThirdPartyDeveloperTool(
     toolName: string,
     params: Record<string, unknown>,

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -271,7 +271,7 @@ export type ContextPage = Readonly<{
     options?: {timeout?: number; handleDialog?: 'accept' | 'dismiss' | string},
   ): Promise<WaitForEventsResult>;
   getThirdPartyDeveloperTools():
-    | Array<Partial<ToolGroup<ThirdPartyDeveloperToolDefinition>>>
+    | Array<ToolGroup<ThirdPartyDeveloperToolDefinition>>
     | undefined;
   executeThirdPartyDeveloperTool(
     toolName: string,

--- a/src/tools/thirdPartyDeveloper.ts
+++ b/src/tools/thirdPartyDeveloper.ts
@@ -24,12 +24,10 @@ export interface ToolGroup<T extends ToolDefinition> {
 declare global {
   interface Event {
     respondWith?: (
-      toolGroup: Partial<
-        ToolGroup<
-          ToolDefinition & {
-            execute: (args: Record<string, unknown>) => unknown;
-          }
-        >
+      toolGroup: ToolGroup<
+        ToolDefinition & {
+          execute: (args: Record<string, unknown>) => unknown;
+        }
       >,
     ) => void;
   }
@@ -42,12 +40,10 @@ declare global {
         }
       >;
       toolGroups?: Array<
-        Partial<
-          ToolGroup<
-            ToolDefinition & {
-              execute: (args: Record<string, unknown>) => unknown;
-            }
-          >
+        ToolGroup<
+          ToolDefinition & {
+            execute: (args: Record<string, unknown>) => unknown;
+          }
         >
       >;
       stashedElements?: Element[];

--- a/src/tools/thirdPartyDeveloper.ts
+++ b/src/tools/thirdPartyDeveloper.ts
@@ -21,6 +21,8 @@ export interface ToolGroup<T extends ToolDefinition> {
   tools: T[];
 }
 
+export type ToolGroups = Array<ToolGroup<ToolDefinition>>;
+
 declare global {
   interface Window {
     __dtmcp?: {

--- a/src/tools/thirdPartyDeveloper.ts
+++ b/src/tools/thirdPartyDeveloper.ts
@@ -22,10 +22,33 @@ export interface ToolGroup<T extends ToolDefinition> {
 }
 
 declare global {
+  interface Event {
+    respondWith?: (
+      toolGroup: Partial<
+        ToolGroup<
+          ToolDefinition & {
+            execute: (args: Record<string, unknown>) => unknown;
+          }
+        >
+      >,
+    ) => void;
+  }
+
   interface Window {
     __dtmcp?: {
       toolGroup?: ToolGroup<
-        ToolDefinition & {execute: (args: Record<string, unknown>) => unknown}
+        ToolDefinition & {
+          execute: (args: Record<string, unknown>) => unknown;
+        }
+      >;
+      toolGroups?: Array<
+        Partial<
+          ToolGroup<
+            ToolDefinition & {
+              execute: (args: Record<string, unknown>) => unknown;
+            }
+          >
+        >
       >;
       stashedElements?: Element[];
       executeTool?: (
@@ -90,8 +113,16 @@ export const executeThirdPartyDeveloperTool = definePageTool({
       }
     }
 
-    const toolGroup = request.page.getThirdPartyDeveloperTools();
-    const tool = toolGroup?.tools.find(t => t.name === toolName);
+    const toolGroups = request.page.getThirdPartyDeveloperTools();
+    let tool;
+    if (toolGroups) {
+      for (const group of toolGroups) {
+        tool = group.tools?.find(t => t.name === toolName);
+        if (tool) {
+          break;
+        }
+      }
+    }
     if (!tool) {
       throw new Error(`Tool ${toolName} not found`);
     }

--- a/src/tools/thirdPartyDeveloper.ts
+++ b/src/tools/thirdPartyDeveloper.ts
@@ -22,23 +22,13 @@ export interface ToolGroup<T extends ToolDefinition> {
 }
 
 declare global {
-  // interface Event {
-  //   respondWith?: (
-  //     toolGroup: ToolGroup<
-  //       ToolDefinition & {
-  //         execute: (args: Record<string, unknown>) => unknown;
-  //       }
-  //     >,
-  //   ) => void;
-  // }
-
   interface Window {
     __dtmcp?: {
-      toolGroup?: ToolGroup<
-        ToolDefinition & {
-          execute: (args: Record<string, unknown>) => unknown;
-        }
-      >;
+      // toolGroup?: ToolGroup<
+      //   ToolDefinition & {
+      //     execute: (args: Record<string, unknown>) => unknown;
+      //   }
+      // >;
       toolGroups?: Array<
         ToolGroup<
           ToolDefinition & {

--- a/src/tools/thirdPartyDeveloper.ts
+++ b/src/tools/thirdPartyDeveloper.ts
@@ -22,15 +22,15 @@ export interface ToolGroup<T extends ToolDefinition> {
 }
 
 declare global {
-  interface Event {
-    respondWith?: (
-      toolGroup: ToolGroup<
-        ToolDefinition & {
-          execute: (args: Record<string, unknown>) => unknown;
-        }
-      >,
-    ) => void;
-  }
+  // interface Event {
+  //   respondWith?: (
+  //     toolGroup: ToolGroup<
+  //       ToolDefinition & {
+  //         execute: (args: Record<string, unknown>) => unknown;
+  //       }
+  //     >,
+  //   ) => void;
+  // }
 
   interface Window {
     __dtmcp?: {

--- a/src/tools/thirdPartyDeveloper.ts
+++ b/src/tools/thirdPartyDeveloper.ts
@@ -24,11 +24,6 @@ export interface ToolGroup<T extends ToolDefinition> {
 declare global {
   interface Window {
     __dtmcp?: {
-      // toolGroup?: ToolGroup<
-      //   ToolDefinition & {
-      //     execute: (args: Record<string, unknown>) => unknown;
-      //   }
-      // >;
       toolGroups?: Array<
         ToolGroup<
           ToolDefinition & {

--- a/tests/McpResponse.test.js.snapshot
+++ b/tests/McpResponse.test.js.snapshot
@@ -1261,24 +1261,26 @@ name="myTool", description="Does something", inputSchema={"type":"object","prope
 
 exports[`third-party developer tools > lists third-party developer tools 2`] = `
 {
-  "thirdPartyDeveloperTools": {
-    "name": "My Tool Group",
-    "description": "A group of tools",
-    "tools": [
-      {
-        "name": "myTool",
-        "description": "Does something",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "foo": {
-              "type": "string"
+  "thirdPartyDeveloperTools": [
+    {
+      "name": "My Tool Group",
+      "description": "A group of tools",
+      "tools": [
+        {
+          "name": "myTool",
+          "description": "Does something",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "foo": {
+                "type": "string"
+              }
             }
           }
         }
-      }
-    ]
-  }
+      ]
+    }
+  ]
 }
 `;
 

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -1070,22 +1070,24 @@ describe('third-party developer tools', () => {
       async (response, context) => {
         const mcpPage = context.getSelectedMcpPage();
         stubToolDiscovery(mcpPage.pptrPage);
-        sinon.stub(mcpPage.pptrPage, 'evaluate').resolves({
-          name: 'My Tool Group',
-          description: 'A group of tools',
-          tools: [
-            {
-              name: 'myTool',
-              description: 'Does something',
-              inputSchema: {
-                type: 'object',
-                properties: {
-                  foo: {type: 'string'},
+        sinon.stub(mcpPage.pptrPage, 'evaluate').resolves([
+          {
+            name: 'My Tool Group',
+            description: 'A group of tools',
+            tools: [
+              {
+                name: 'myTool',
+                description: 'Does something',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    foo: {type: 'string'},
+                  },
                 },
               },
-            },
-          ],
-        });
+            ],
+          },
+        ]);
         response.setListThirdPartyDeveloperTools();
         const {content, structuredContent} = await response.handle(
           'test',

--- a/tests/tools/thirdPartyDeveloper.test.ts
+++ b/tests/tools/thirdPartyDeveloper.test.ts
@@ -17,10 +17,7 @@ import {
   executeThirdPartyDeveloperTool,
   listThirdPartyDeveloperTools,
 } from '../../src/tools/thirdPartyDeveloper.js';
-import type {
-  ToolGroup,
-  ToolDefinition,
-} from '../../src/tools/thirdPartyDeveloper.js';
+import type {ToolGroups} from '../../src/tools/thirdPartyDeveloper.js';
 import {withMcpContext} from '../utils.js';
 
 describe('thirdPartyDeveloperTools', () => {
@@ -119,7 +116,7 @@ describe('thirdPartyDeveloperTools', () => {
           assert.deepStrictEqual(
             (
               result.structuredContent as {
-                thirdPartyDeveloperTools?: Array<ToolGroup<ToolDefinition>>;
+                thirdPartyDeveloperTools?: ToolGroups;
               }
             ).thirdPartyDeveloperTools,
             undefined,
@@ -155,7 +152,7 @@ describe('thirdPartyDeveloperTools', () => {
           assert.deepStrictEqual(
             (
               result.structuredContent as {
-                thirdPartyDeveloperTools?: Array<ToolGroup<ToolDefinition>>;
+                thirdPartyDeveloperTools?: ToolGroups;
               }
             ).thirdPartyDeveloperTools,
             undefined,
@@ -185,7 +182,7 @@ describe('thirdPartyDeveloperTools', () => {
           assert.deepStrictEqual(
             (
               result.structuredContent as {
-                thirdPartyDeveloperTools?: Array<ToolGroup<ToolDefinition>>;
+                thirdPartyDeveloperTools?: ToolGroups;
               }
             ).thirdPartyDeveloperTools,
             undefined,

--- a/tests/tools/thirdPartyDeveloper.test.ts
+++ b/tests/tools/thirdPartyDeveloper.test.ts
@@ -138,7 +138,7 @@ describe('thirdPartyDeveloperTools', () => {
                 thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>>;
               }
             ).thirdPartyDeveloperTools,
-            {},
+            [],
           );
         },
         undefined,
@@ -167,13 +167,13 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          assert.strictEqual(
+          assert.deepStrictEqual(
             (
               result.structuredContent as {
                 thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>>;
               }
             ).thirdPartyDeveloperTools,
-            undefined,
+            [],
           );
         },
         undefined,
@@ -201,10 +201,10 @@ describe('thirdPartyDeveloperTools', () => {
           //   result.structuredContent.thirdPartyDeveloperTools,
           //   undefined,
           // );
-          assert.strictEqual(
+          assert.deepStrictEqual(
             (result.structuredContent as {thirdPartyDeveloperTools: undefined})
               .thirdPartyDeveloperTools,
-            undefined,
+            [],
           );
         },
         undefined,
@@ -220,6 +220,7 @@ describe('thirdPartyDeveloperTools', () => {
 
           await page.pptrPage.evaluate(() => {
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
+              // @ts-expect-error Event has `respondWith`
               e.respondWith?.({
                 name: 'group-1',
                 description: 'desc-1',
@@ -234,6 +235,7 @@ describe('thirdPartyDeveloperTools', () => {
               });
             });
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
+              // @ts-expect-error Event has `respondWith`
               e.respondWith?.({
                 name: 'group-2',
                 description: 'desc-2',
@@ -260,8 +262,8 @@ describe('thirdPartyDeveloperTools', () => {
             context,
           );
           // assert.ok(asToolsResult(result.structuredContent));
-          // @ts-expect-error Event has `respondWith`
           const actualGroups =
+          // @ts-expect-error Event has `respondWith`
             result.structuredContent.thirdPartyDeveloperTools;
           assert.ok(actualGroups);
           assert.strictEqual(actualGroups.length, 2);

--- a/tests/tools/thirdPartyDeveloper.test.ts
+++ b/tests/tools/thirdPartyDeveloper.test.ts
@@ -64,7 +64,7 @@ describe('thirdPartyDeveloperTools', () => {
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
               // if (e.respondWith && window.__dtmcp?.toolGroup) {
               // @ts-expect-error Event has `respondWith`
-              e.respondWith(window.__dtmcp?.toolGroups[0] || undefined);
+              e.respondWith(window.__dtmcp?.toolGroups[0]);
               // }
             });
           });
@@ -126,19 +126,20 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          assert.ok('thirdPartyDeveloperTools' in result.structuredContent);
+          // assert.strictEqual(result.structuredContent.thirdPartyDeveloperTools, undefined);
+          assert.ok(result.structuredContent);
           // assert.ok(asToolsResult(result.structuredContent));
           // assert.deepEqual(result.structuredContent.thirdPartyDeveloperTools, [
 
           // {},
           // ]);
-          assert.deepEqual(
+          assert.deepStrictEqual(
             (
               result.structuredContent as {
-                thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>>;
+                thirdPartyDeveloperTools?: Array<ToolGroup<ToolDefinition>>;
               }
             ).thirdPartyDeveloperTools,
-            [],
+            undefined,
           );
         },
         undefined,
@@ -167,13 +168,14 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
+          assert.ok(result.structuredContent);
           assert.deepStrictEqual(
             (
               result.structuredContent as {
-                thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>>;
+                thirdPartyDeveloperTools?: Array<ToolGroup<ToolDefinition>>;
               }
             ).thirdPartyDeveloperTools,
-            [],
+            undefined,
           );
         },
         undefined,
@@ -202,9 +204,12 @@ describe('thirdPartyDeveloperTools', () => {
           //   undefined,
           // );
           assert.deepStrictEqual(
-            (result.structuredContent as {thirdPartyDeveloperTools: undefined})
-              .thirdPartyDeveloperTools,
-            [],
+            (
+              result.structuredContent as {
+                thirdPartyDeveloperTools?: Array<ToolGroup<ToolDefinition>>;
+              }
+            ).thirdPartyDeveloperTools,
+            undefined,
           );
         },
         undefined,
@@ -263,7 +268,7 @@ describe('thirdPartyDeveloperTools', () => {
           );
           // assert.ok(asToolsResult(result.structuredContent));
           const actualGroups =
-          // @ts-expect-error Event has `respondWith`
+            // @ts-expect-error Event has `respondWith`
             result.structuredContent.thirdPartyDeveloperTools;
           assert.ok(actualGroups);
           assert.strictEqual(actualGroups.length, 2);
@@ -303,28 +308,30 @@ describe('thirdPartyDeveloperTools', () => {
         async (response, context) => {
           await setupThirdPartyDeveloperTools(response, context, () => {
             window.__dtmcp = {
-              toolGroup: {
-                name: 'test-group',
-                description: 'test description',
-                tools: [
-                  {
-                    name: 'test-tool',
-                    description: 'test tool description',
-                    inputSchema: {
-                      type: 'object',
-                      properties: {
-                        arg: {type: 'string'},
+              toolGroups: [
+                {
+                  name: 'test-group',
+                  description: 'test description',
+                  tools: [
+                    {
+                      name: 'test-tool',
+                      description: 'test tool description',
+                      inputSchema: {
+                        type: 'object',
+                        properties: {
+                          arg: {type: 'string'},
+                        },
+                        required: ['arg'],
                       },
-                      required: ['arg'],
+                      execute: () => 'result',
                     },
-                    execute: () => 'result',
-                  },
-                ],
-              },
+                  ],
+                },
+              ],
             };
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
               // @ts-expect-error Event has `respondWith`
-              e.respondWith(window.__dtmcp?.toolGroup);
+              e.respondWith(window.__dtmcp?.toolGroups[0]);
             });
           });
 
@@ -353,15 +360,17 @@ describe('thirdPartyDeveloperTools', () => {
       await withMcpContext(async (response, context) => {
         await setupThirdPartyDeveloperTools(response, context, () => {
           window.__dtmcp = {
-            toolGroup: {
-              name: 'test-group',
-              description: 'test description',
-              tools: [],
-            },
+            toolGroups: [
+              {
+                name: 'test-group',
+                description: 'test description',
+                tools: [],
+              },
+            ],
           };
           window.addEventListener('devtoolstooldiscovery', (e: Event) => {
             // @ts-expect-error Event has `respondWith`
-            e.respondWith(window.__dtmcp?.toolGroup);
+            e.respondWith(window.__dtmcp?.toolGroups[0]);
           });
         });
 
@@ -389,28 +398,30 @@ describe('thirdPartyDeveloperTools', () => {
         async (response, context) => {
           await setupThirdPartyDeveloperTools(response, context, () => {
             window.__dtmcp = {
-              toolGroup: {
-                name: 'test-group',
-                description: 'test description',
-                tools: [
-                  {
-                    name: 'test-tool',
-                    description: 'test tool description',
-                    inputSchema: {
-                      type: 'object',
-                      properties: {
-                        arg: {type: 'string'},
+              toolGroups: [
+                {
+                  name: 'test-group',
+                  description: 'test description',
+                  tools: [
+                    {
+                      name: 'test-tool',
+                      description: 'test tool description',
+                      inputSchema: {
+                        type: 'object',
+                        properties: {
+                          arg: {type: 'string'},
+                        },
+                        required: ['arg'],
                       },
-                      required: ['arg'],
+                      execute: () => 'result',
                     },
-                    execute: () => 'result',
-                  },
-                ],
-              },
+                  ],
+                },
+              ],
             };
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
               // @ts-expect-error Event has `respondWith`
-              e.respondWith(window.__dtmcp?.toolGroup);
+              e.respondWith(window.__dtmcp?.toolGroups[0]);
             });
           });
 
@@ -441,22 +452,24 @@ describe('thirdPartyDeveloperTools', () => {
         async (response, context) => {
           await setupThirdPartyDeveloperTools(response, context, () => {
             window.__dtmcp = {
-              toolGroup: {
-                name: 'test-group',
-                description: 'test description',
-                tools: [
-                  {
-                    name: 'test-tool',
-                    description: 'test tool description',
-                    inputSchema: {},
-                    execute: () => ({foo: 'bar'}),
-                  },
-                ],
-              },
+              toolGroups: [
+                {
+                  name: 'test-group',
+                  description: 'test description',
+                  tools: [
+                    {
+                      name: 'test-tool',
+                      description: 'test tool description',
+                      inputSchema: {},
+                      execute: () => ({foo: 'bar'}),
+                    },
+                  ],
+                },
+              ],
             };
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
               // @ts-expect-error Event has `respondWith`
-              e.respondWith(window.__dtmcp?.toolGroup);
+              e.respondWith(window.__dtmcp?.toolGroups[0]);
             });
           });
 
@@ -579,25 +592,27 @@ describe('thirdPartyDeveloperTools', () => {
         async (response, context) => {
           await setupThirdPartyDeveloperTools(response, context, () => {
             window.__dtmcp = {
-              toolGroup: {
-                name: 'test-group',
-                description: 'test description',
-                tools: [
-                  {
-                    name: 'test-tool',
-                    description: 'test tool description',
-                    inputSchema: {},
-                    execute: () => ({
-                      foo: 'bar',
-                      func: () => undefined,
-                    }),
-                  },
-                ],
-              },
+              toolGroups: [
+                {
+                  name: 'test-group',
+                  description: 'test description',
+                  tools: [
+                    {
+                      name: 'test-tool',
+                      description: 'test tool description',
+                      inputSchema: {},
+                      execute: () => ({
+                        foo: 'bar',
+                        func: () => undefined,
+                      }),
+                    },
+                  ],
+                },
+              ],
             };
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
               // @ts-expect-error Event has `respondWith`
-              e.respondWith(window.__dtmcp?.toolGroup);
+              e.respondWith(window.__dtmcp?.toolGroups[0]);
             });
           });
 
@@ -627,26 +642,28 @@ describe('thirdPartyDeveloperTools', () => {
         async (response, context) => {
           await setupThirdPartyDeveloperTools(response, context, () => {
             window.__dtmcp = {
-              toolGroup: {
-                name: 'test-group',
-                description: 'test description',
-                tools: [
-                  {
-                    name: 'test-tool',
-                    description: 'test tool description',
-                    inputSchema: {},
-                    execute: () => {
-                      const obj: Record<string, unknown> = {foo: 'bar'};
-                      obj.self = obj;
-                      return obj;
+              toolGroups: [
+                {
+                  name: 'test-group',
+                  description: 'test description',
+                  tools: [
+                    {
+                      name: 'test-tool',
+                      description: 'test tool description',
+                      inputSchema: {},
+                      execute: () => {
+                        const obj: Record<string, unknown> = {foo: 'bar'};
+                        obj.self = obj;
+                        return obj;
+                      },
                     },
-                  },
-                ],
-              },
+                  ],
+                },
+              ],
             };
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
               // @ts-expect-error Event has `respondWith`
-              e.respondWith(window.__dtmcp?.toolGroup);
+              e.respondWith(window.__dtmcp?.toolGroups[0]);
             });
           });
 
@@ -679,25 +696,27 @@ describe('thirdPartyDeveloperTools', () => {
               val = 'value';
             }
             window.__dtmcp = {
-              toolGroup: {
-                name: 'test-group',
-                description: 'test description',
-                tools: [
-                  {
-                    name: 'test-tool',
-                    description: 'test tool description',
-                    inputSchema: {},
-                    execute: () => ({
-                      foo: 'bar',
-                      custom: new CustomClass(),
-                    }),
-                  },
-                ],
-              },
+              toolGroups: [
+                {
+                  name: 'test-group',
+                  description: 'test description',
+                  tools: [
+                    {
+                      name: 'test-tool',
+                      description: 'test tool description',
+                      inputSchema: {},
+                      execute: () => ({
+                        foo: 'bar',
+                        custom: new CustomClass(),
+                      }),
+                    },
+                  ],
+                },
+              ],
             };
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
               // @ts-expect-error Event has `respondWith`
-              e.respondWith(window.__dtmcp?.toolGroup);
+              e.respondWith(window.__dtmcp?.toolGroups[0]);
             });
           });
 

--- a/tests/tools/thirdPartyDeveloper.test.ts
+++ b/tests/tools/thirdPartyDeveloper.test.ts
@@ -9,7 +9,7 @@ import {describe, it} from 'node:test';
 
 import sinon from 'sinon';
 
-import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
+import {parseArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
 import type {McpContext} from '../../src/McpContext.js';
 import type {McpResponse} from '../../src/McpResponse.js';
 import {TextSnapshot} from '../../src/TextSnapshot.js';
@@ -22,6 +22,14 @@ import type {
   ToolDefinition,
 } from '../../src/tools/thirdPartyDeveloper.js';
 import {withMcpContext} from '../utils.js';
+
+interface ToolsResult {
+  thirdPartyDeveloperTools?: Array<Partial<ToolGroup<ToolDefinition>>>;
+}
+
+function asToolsResult(obj: unknown): obj is ToolsResult {
+  return typeof obj === 'object' && obj !== null;
+}
 
 describe('thirdPartyDeveloperTools', () => {
   describe('list_3p_developer_tools', () => {
@@ -52,8 +60,9 @@ describe('thirdPartyDeveloperTools', () => {
               },
             };
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
-              // @ts-expect-error Event has `respondWith`
-              e.respondWith(window.__dtmcp?.toolGroup);
+              if (e.respondWith && window.__dtmcp?.toolGroup) {
+                e.respondWith(window.__dtmcp.toolGroup);
+              }
             });
           });
 
@@ -67,10 +76,13 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          // @ts-expect-error `structuredContent` has `thirdPartyDeveloperTools`
-          const actualGroup = result.structuredContent.thirdPartyDeveloperTools;
+          assert.ok(asToolsResult(result.structuredContent));
+          const actualGroup =
+            result.structuredContent.thirdPartyDeveloperTools?.[0];
+          assert.ok(actualGroup);
           assert.strictEqual(actualGroup.name, 'test-group');
           assert.strictEqual(actualGroup.description, 'test description');
+          assert.ok(actualGroup.tools);
           assert.strictEqual(actualGroup.tools.length, 1);
           assert.strictEqual(actualGroup.tools[0].name, 'test-tool');
           assert.strictEqual(
@@ -85,7 +97,11 @@ describe('thirdPartyDeveloperTools', () => {
           });
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -96,8 +112,7 @@ describe('thirdPartyDeveloperTools', () => {
           response.setPage(page);
           await page.pptrPage.evaluate(() => {
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
-              // @ts-expect-error Event has `respondWith`
-              e.respondWith({});
+              e.respondWith?.({});
             });
           });
 
@@ -111,18 +126,17 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          assert.ok('thirdPartyDeveloperTools' in result.structuredContent);
-          assert.deepEqual(
-            (
-              result.structuredContent as {
-                thirdPartyDeveloperTools: ToolGroup<ToolDefinition>;
-              }
-            ).thirdPartyDeveloperTools,
+          assert.ok(asToolsResult(result.structuredContent));
+          assert.deepEqual(result.structuredContent.thirdPartyDeveloperTools, [
             {},
-          );
+          ]);
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -147,17 +161,18 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
+          assert.ok(asToolsResult(result.structuredContent));
           assert.strictEqual(
-            (
-              result.structuredContent as {
-                thirdPartyDeveloperTools: ToolGroup<ToolDefinition>;
-              }
-            ).thirdPartyDeveloperTools,
+            result.structuredContent.thirdPartyDeveloperTools,
             undefined,
           );
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -176,14 +191,82 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
+          assert.ok(asToolsResult(result.structuredContent));
           assert.strictEqual(
-            (result.structuredContent as {thirdPartyDeveloperTools: undefined})
-              .thirdPartyDeveloperTools,
+            result.structuredContent.thirdPartyDeveloperTools,
             undefined,
           );
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
+      );
+    });
+
+    it('lists multiple toolgroups', async () => {
+      await withMcpContext(
+        async (response, context) => {
+          const page = await context.newPage();
+          response.setPage(page);
+
+          await page.pptrPage.evaluate(() => {
+            window.addEventListener('devtoolstooldiscovery', (e: Event) => {
+              e.respondWith?.({
+                name: 'group-1',
+                description: 'desc-1',
+                tools: [
+                  {
+                    name: 'tool-1',
+                    description: 'tool-1-desc',
+                    inputSchema: {},
+                    execute: () => 'r1',
+                  },
+                ],
+              });
+            });
+            window.addEventListener('devtoolstooldiscovery', (e: Event) => {
+              e.respondWith?.({
+                name: 'group-2',
+                description: 'desc-2',
+                tools: [
+                  {
+                    name: 'tool-2',
+                    description: 'tool-2-desc',
+                    inputSchema: {},
+                    execute: () => 'r2',
+                  },
+                ],
+              });
+            });
+          });
+
+          await listThirdPartyDeveloperTools.handler(
+            {params: {}, page},
+            response,
+            context,
+          );
+
+          const result = await response.handle(
+            'list_3p_developer_tools',
+            context,
+          );
+          assert.ok(asToolsResult(result.structuredContent));
+          const actualGroups =
+            result.structuredContent.thirdPartyDeveloperTools;
+          assert.ok(actualGroups);
+          assert.strictEqual(actualGroups.length, 2);
+          assert.strictEqual(actualGroups[0].name, 'group-1');
+          assert.strictEqual(actualGroups[1].name, 'group-2');
+        },
+        undefined,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
   });
@@ -252,7 +335,11 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -339,7 +426,11 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -384,7 +475,11 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -393,23 +488,25 @@ describe('thirdPartyDeveloperTools', () => {
         const page = await context.newPage();
         response.setPage(page);
 
-        page.thirdPartyDeveloperTools = {
-          name: 'test-group',
-          description: 'test description',
-          tools: [
-            {
-              name: 'test-tool',
-              description: 'test tool description',
-              inputSchema: {
-                type: 'object',
-                properties: {
-                  element: {type: 'object'},
+        page.thirdPartyDeveloperTools = [
+          {
+            name: 'test-group',
+            description: 'test description',
+            tools: [
+              {
+                name: 'test-tool',
+                description: 'test tool description',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    element: {type: 'object'},
+                  },
+                  required: ['element'],
                 },
-                required: ['element'],
               },
-            },
-          ],
-        };
+            ],
+          },
+        ];
 
         await page.pptrPage.evaluate(() => {
           window.__dtmcp = {
@@ -523,7 +620,11 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -572,7 +673,11 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -627,7 +732,11 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -637,17 +746,19 @@ describe('thirdPartyDeveloperTools', () => {
           const page = await context.newPage();
           response.setPage(page);
 
-          page.thirdPartyDeveloperTools = {
-            name: 'test-group',
-            description: 'test description',
-            tools: [
-              {
-                name: 'test-tool',
-                description: 'test tool description',
-                inputSchema: {},
-              },
-            ],
-          };
+          page.thirdPartyDeveloperTools = [
+            {
+              name: 'test-group',
+              description: 'test description',
+              tools: [
+                {
+                  name: 'test-tool',
+                  description: 'test tool description',
+                  inputSchema: {},
+                },
+              ],
+            },
+          ];
 
           await page.pptrPage.evaluate(() => {
             window.__dtmcp = {
@@ -684,7 +795,11 @@ describe('thirdPartyDeveloperTools', () => {
           stub.restore();
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -694,17 +809,19 @@ describe('thirdPartyDeveloperTools', () => {
           const page = await context.newPage();
           response.setPage(page);
 
-          page.thirdPartyDeveloperTools = {
-            name: 'test-group',
-            description: 'test description',
-            tools: [
-              {
-                name: 'test-tool',
-                description: 'test tool description',
-                inputSchema: {},
-              },
-            ],
-          };
+          page.thirdPartyDeveloperTools = [
+            {
+              name: 'test-group',
+              description: 'test description',
+              tools: [
+                {
+                  name: 'test-tool',
+                  description: 'test tool description',
+                  inputSchema: {},
+                },
+              ],
+            },
+          ];
 
           await page.pptrPage.evaluate(() => {
             window.__dtmcp = {
@@ -750,7 +867,11 @@ describe('thirdPartyDeveloperTools', () => {
           stubSnapshot.restore();
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
 
@@ -760,17 +881,19 @@ describe('thirdPartyDeveloperTools', () => {
           const page = await context.newPage();
           response.setPage(page);
 
-          page.thirdPartyDeveloperTools = {
-            name: 'test-group',
-            description: 'test description',
-            tools: [
-              {
-                name: 'test-tool',
-                description: 'test tool description',
-                inputSchema: {},
-              },
-            ],
-          };
+          page.thirdPartyDeveloperTools = [
+            {
+              name: 'test-group',
+              description: 'test description',
+              tools: [
+                {
+                  name: 'test-tool',
+                  description: 'test tool description',
+                  inputSchema: {},
+                },
+              ],
+            },
+          ];
 
           await page.pptrPage.evaluate(() => {
             window.__dtmcp = {
@@ -808,7 +931,11 @@ describe('thirdPartyDeveloperTools', () => {
           stubSnapshot.restore();
         },
         undefined,
-        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        parseArguments('1.0.0', [
+          'node',
+          'test.js',
+          '--categoryExperimentalThirdParty',
+        ]),
       );
     });
   });

--- a/tests/tools/thirdPartyDeveloper.test.ts
+++ b/tests/tools/thirdPartyDeveloper.test.ts
@@ -23,14 +23,6 @@ import type {
 } from '../../src/tools/thirdPartyDeveloper.js';
 import {withMcpContext} from '../utils.js';
 
-// interface ToolsResult {
-//   thirdPartyDeveloperTools?: Array<Partial<ToolGroup<ToolDefinition>>>;
-// }
-
-// function asToolsResult(obj: unknown): obj is ToolsResult {
-//   return typeof obj === 'object' && obj !== null;
-// }
-
 describe('thirdPartyDeveloperTools', () => {
   describe('list_3p_developer_tools', () => {
     it('lists tools', async () => {
@@ -62,10 +54,8 @@ describe('thirdPartyDeveloperTools', () => {
               ],
             };
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
-              // if (e.respondWith && window.__dtmcp?.toolGroup) {
               // @ts-expect-error Event has `respondWith`
               e.respondWith(window.__dtmcp?.toolGroups[0]);
-              // }
             });
           });
 
@@ -79,7 +69,6 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          // assert.ok(asToolsResult(result.structuredContent));
           // @ts-expect-error `structuredContent` has `thirdPartyDeveloperTools`
           const groups = result.structuredContent.thirdPartyDeveloperTools;
           assert.strictEqual(groups.length, 1);
@@ -126,13 +115,7 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          // assert.strictEqual(result.structuredContent.thirdPartyDeveloperTools, undefined);
           assert.ok(result.structuredContent);
-          // assert.ok(asToolsResult(result.structuredContent));
-          // assert.deepEqual(result.structuredContent.thirdPartyDeveloperTools, [
-
-          // {},
-          // ]);
           assert.deepStrictEqual(
             (
               result.structuredContent as {
@@ -198,11 +181,7 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          // assert.ok(asToolsResult(result.structuredContent));
-          // assert.strictEqual(
-          //   result.structuredContent.thirdPartyDeveloperTools,
-          //   undefined,
-          // );
+          assert.ok(result.structuredContent);
           assert.deepStrictEqual(
             (
               result.structuredContent as {
@@ -266,9 +245,8 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          // assert.ok(asToolsResult(result.structuredContent));
           const actualGroups =
-            // @ts-expect-error Event has `respondWith`
+            // @ts-expect-error structuredContent has `thirdPartyDeveloperTools`
             result.structuredContent.thirdPartyDeveloperTools;
           assert.ok(actualGroups);
           assert.strictEqual(actualGroups.length, 2);
@@ -277,11 +255,6 @@ describe('thirdPartyDeveloperTools', () => {
         },
         undefined,
         {categoryExperimentalThirdParty: true} as ParsedArguments,
-        // parseArguments('1.0.0', [
-        //   'node',
-        //   'test.js',
-        //   '--categoryExperimentalThirdParty',
-        // ]),
       );
     });
   });

--- a/tests/tools/thirdPartyDeveloper.test.ts
+++ b/tests/tools/thirdPartyDeveloper.test.ts
@@ -9,7 +9,7 @@ import {describe, it} from 'node:test';
 
 import sinon from 'sinon';
 
-import {parseArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
+import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
 import type {McpContext} from '../../src/McpContext.js';
 import type {McpResponse} from '../../src/McpResponse.js';
 import {TextSnapshot} from '../../src/TextSnapshot.js';
@@ -23,13 +23,13 @@ import type {
 } from '../../src/tools/thirdPartyDeveloper.js';
 import {withMcpContext} from '../utils.js';
 
-interface ToolsResult {
-  thirdPartyDeveloperTools?: Array<Partial<ToolGroup<ToolDefinition>>>;
-}
+// interface ToolsResult {
+//   thirdPartyDeveloperTools?: Array<Partial<ToolGroup<ToolDefinition>>>;
+// }
 
-function asToolsResult(obj: unknown): obj is ToolsResult {
-  return typeof obj === 'object' && obj !== null;
-}
+// function asToolsResult(obj: unknown): obj is ToolsResult {
+//   return typeof obj === 'object' && obj !== null;
+// }
 
 describe('thirdPartyDeveloperTools', () => {
   describe('list_3p_developer_tools', () => {
@@ -41,28 +41,31 @@ describe('thirdPartyDeveloperTools', () => {
 
           await page.pptrPage.evaluate(() => {
             window.__dtmcp = {
-              toolGroup: {
-                name: 'test-group',
-                description: 'test description',
-                tools: [
-                  {
-                    name: 'test-tool',
-                    description: 'test tool description',
-                    inputSchema: {
-                      type: 'object',
-                      properties: {
-                        arg: {type: 'string'},
+              toolGroups: [
+                {
+                  name: 'test-group',
+                  description: 'test description',
+                  tools: [
+                    {
+                      name: 'test-tool',
+                      description: 'test tool description',
+                      inputSchema: {
+                        type: 'object',
+                        properties: {
+                          arg: {type: 'string'},
+                        },
                       },
+                      execute: () => 'result',
                     },
-                    execute: () => 'result',
-                  },
-                ],
-              },
+                  ],
+                },
+              ],
             };
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
-              if (e.respondWith && window.__dtmcp?.toolGroup) {
-                e.respondWith(window.__dtmcp.toolGroup);
-              }
+              // if (e.respondWith && window.__dtmcp?.toolGroup) {
+              // @ts-expect-error Event has `respondWith`
+              e.respondWith(window.__dtmcp?.toolGroups[0] || undefined);
+              // }
             });
           });
 
@@ -76,13 +79,13 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          assert.ok(asToolsResult(result.structuredContent));
-          const actualGroup =
-            result.structuredContent.thirdPartyDeveloperTools?.[0];
-          assert.ok(actualGroup);
+          // assert.ok(asToolsResult(result.structuredContent));
+          // @ts-expect-error `structuredContent` has `thirdPartyDeveloperTools`
+          const groups = result.structuredContent.thirdPartyDeveloperTools;
+          assert.strictEqual(groups.length, 1);
+          const actualGroup = groups[0];
           assert.strictEqual(actualGroup.name, 'test-group');
           assert.strictEqual(actualGroup.description, 'test description');
-          assert.ok(actualGroup.tools);
           assert.strictEqual(actualGroup.tools.length, 1);
           assert.strictEqual(actualGroup.tools[0].name, 'test-tool');
           assert.strictEqual(
@@ -97,11 +100,7 @@ describe('thirdPartyDeveloperTools', () => {
           });
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -112,7 +111,8 @@ describe('thirdPartyDeveloperTools', () => {
           response.setPage(page);
           await page.pptrPage.evaluate(() => {
             window.addEventListener('devtoolstooldiscovery', (e: Event) => {
-              e.respondWith?.({});
+              // @ts-expect-error Event has `respondWith`
+              e.respondWith({});
             });
           });
 
@@ -126,17 +126,23 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          assert.ok(asToolsResult(result.structuredContent));
-          assert.deepEqual(result.structuredContent.thirdPartyDeveloperTools, [
+          assert.ok('thirdPartyDeveloperTools' in result.structuredContent);
+          // assert.ok(asToolsResult(result.structuredContent));
+          // assert.deepEqual(result.structuredContent.thirdPartyDeveloperTools, [
+
+          // {},
+          // ]);
+          assert.deepEqual(
+            (
+              result.structuredContent as {
+                thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>>;
+              }
+            ).thirdPartyDeveloperTools,
             {},
-          ]);
+          );
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -161,18 +167,17 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          assert.ok(asToolsResult(result.structuredContent));
           assert.strictEqual(
-            result.structuredContent.thirdPartyDeveloperTools,
+            (
+              result.structuredContent as {
+                thirdPartyDeveloperTools: Array<ToolGroup<ToolDefinition>>;
+              }
+            ).thirdPartyDeveloperTools,
             undefined,
           );
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -191,18 +196,19 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          assert.ok(asToolsResult(result.structuredContent));
+          // assert.ok(asToolsResult(result.structuredContent));
+          // assert.strictEqual(
+          //   result.structuredContent.thirdPartyDeveloperTools,
+          //   undefined,
+          // );
           assert.strictEqual(
-            result.structuredContent.thirdPartyDeveloperTools,
+            (result.structuredContent as {thirdPartyDeveloperTools: undefined})
+              .thirdPartyDeveloperTools,
             undefined,
           );
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -253,7 +259,8 @@ describe('thirdPartyDeveloperTools', () => {
             'list_3p_developer_tools',
             context,
           );
-          assert.ok(asToolsResult(result.structuredContent));
+          // assert.ok(asToolsResult(result.structuredContent));
+          // @ts-expect-error Event has `respondWith`
           const actualGroups =
             result.structuredContent.thirdPartyDeveloperTools;
           assert.ok(actualGroups);
@@ -262,11 +269,12 @@ describe('thirdPartyDeveloperTools', () => {
           assert.strictEqual(actualGroups[1].name, 'group-2');
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
+        // parseArguments('1.0.0', [
+        //   'node',
+        //   'test.js',
+        //   '--categoryExperimentalThirdParty',
+        // ]),
       );
     });
   });
@@ -335,11 +343,7 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -426,11 +430,7 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -475,11 +475,7 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -620,11 +616,7 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -673,11 +665,7 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -732,11 +720,7 @@ describe('thirdPartyDeveloperTools', () => {
           );
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -795,11 +779,7 @@ describe('thirdPartyDeveloperTools', () => {
           stub.restore();
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -867,11 +847,7 @@ describe('thirdPartyDeveloperTools', () => {
           stubSnapshot.restore();
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
 
@@ -931,11 +907,7 @@ describe('thirdPartyDeveloperTools', () => {
           stubSnapshot.restore();
         },
         undefined,
-        parseArguments('1.0.0', [
-          'node',
-          'test.js',
-          '--categoryExperimentalThirdParty',
-        ]),
+        {categoryExperimentalThirdParty: true} as ParsedArguments,
       );
     });
   });


### PR DESCRIPTION
This allows a page to have multiple providers of third-party developer tools, which each respond to the `devtoolstooldiscovery` event.

- Multiple `ToolGroup`s
- MCP tool responses only mention third-party developer tools, if there are any. Otherwise this part of the output is skipped.

