### PR TITLE
fix: include page titles in list_pages

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -879,14 +879,15 @@ Call ${handleDialog.name} to handle it before continuing.`);
         const parts = [`## Pages`];
         const structuredPages = [];
         for (const page of regularPages) {
+          const title = getPageTitle(page);
           const isolatedContextName = context.getIsolatedContextName(page);
           const contextLabel = isolatedContextName
             ? ` isolatedContext=${isolatedContextName}`
             : '';
           parts.push(
-            `${context.getPageId(page)}: ${page.url()}${context.isPageSelected(page) ? ' [selected]' : ''}${contextLabel}`,
+            `${context.getPageId(page)}: ${title} (${page.url()})${context.isPageSelected(page) ? ' [selected]' : ''}${contextLabel}`,
           );
-          structuredPages.push(createStructuredPage(page, context));
+          structuredPages.push(createStructuredPage(page, context, title));
         }
         response.push(...parts);
         structuredContent.pages = structuredPages;
@@ -897,14 +898,17 @@ Call ${handleDialog.name} to handle it before continuing.`);
           response.push(`## Extension Pages`);
           const structuredExtensionPages = [];
           for (const page of extensionPages) {
+            const title = getPageTitle(page);
             const isolatedContextName = context.getIsolatedContextName(page);
             const contextLabel = isolatedContextName
               ? ` isolatedContext=${isolatedContextName}`
               : '';
             response.push(
-              `${context.getPageId(page)}: ${page.url()}${context.isPageSelected(page) ? ' [selected]' : ''}${contextLabel}`,
+              `${context.getPageId(page)}: ${title} (${page.url()})${context.isPageSelected(page) ? ' [selected]' : ''}${contextLabel}`,
             );
-            structuredExtensionPages.push(createStructuredPage(page, context));
+            structuredExtensionPages.push(
+              createStructuredPage(page, context, title),
+            );
           }
           structuredContent.extensionPages = structuredExtensionPages;
         }
@@ -1233,20 +1237,40 @@ Call ${handleDialog.name} to handle it before continuing.`);
     this.#textResponseLines = [];
   }
 }
-function createStructuredPage(page: Page, context: McpContext) {
+function createStructuredPage(page: Page, context: McpContext, title: string) {
   const isolatedContextName = context.getIsolatedContextName(page);
   const entry: {
     id: number | undefined;
     url: string;
+    title: string;
     selected: boolean;
     isolatedContext?: string;
   } = {
     id: context.getPageId(page),
     url: page.url(),
+    title,
     selected: context.isPageSelected(page),
   };
   if (isolatedContextName) {
     entry.isolatedContext = isolatedContextName;
   }
   return entry;
+}
+
+function getPageTitle(page: Page): string {
+  const target = page.target();
+  if (
+    '_getTargetInfo' in target &&
+    typeof target._getTargetInfo === 'function'
+  ) {
+    const targetInfo = target._getTargetInfo();
+    if (isTargetInfo(targetInfo)) {
+      return targetInfo.title ?? '';
+    }
+  }
+  return '';
+}
+
+function isTargetInfo(value: unknown): value is {title?: string} {
+  return typeof value === 'object' && value !== null && 'title' in value;
 }

--- a/tests/McpResponse.test.js.snapshot
+++ b/tests/McpResponse.test.js.snapshot
@@ -315,7 +315,7 @@ exports[`McpResponse > doesn't list the issue message if mapping returns null 1`
 
 exports[`McpResponse > list pages 1`] = `
 ## Pages
-1: about:blank [selected]
+1: about:blank (about:blank) [selected]
 `;
 
 exports[`McpResponse > list pages 2`] = `
@@ -324,6 +324,7 @@ exports[`McpResponse > list pages 2`] = `
     {
       "id": 1,
       "url": "about:blank",
+      "title": "about:blank",
       "selected": true
     }
   ]
@@ -1286,7 +1287,7 @@ exports[`third-party developer tools > lists third-party developer tools 2`] = `
 
 exports[`webmcp > includes webmcp tools in list_pages response 1`] = `
 ## Pages
-1: about:blank [selected]
+1: about:blank (about:blank) [selected]
 ## WebMCP tools
 name="test_tool", description="A test tool", inputSchema={"type":"object","properties":{},"required":[]}, annotations=undefined
 `;
@@ -1297,6 +1298,7 @@ exports[`webmcp > includes webmcp tools in list_pages response 2`] = `
     {
       "id": 1,
       "url": "about:blank",
+      "title": "about:blank",
       "selected": true
     }
   ],
@@ -1317,7 +1319,7 @@ exports[`webmcp > includes webmcp tools in list_pages response 2`] = `
 exports[`webmcp > includes webmcp tools in navigate_page response 1`] = `
 Successfully navigated to about:blank.
 ## Pages
-1: about:blank [selected]
+1: about:blank (about:blank) [selected]
 ## WebMCP tools
 name="test_tool", description="A test tool", inputSchema={"type":"object","properties":{},"required":[]}, annotations=undefined
 `;
@@ -1329,6 +1331,7 @@ exports[`webmcp > includes webmcp tools in navigate_page response 2`] = `
     {
       "id": 1,
       "url": "about:blank",
+      "title": "about:blank",
       "selected": true
     }
   ],
@@ -1348,7 +1351,7 @@ exports[`webmcp > includes webmcp tools in navigate_page response 2`] = `
 
 exports[`webmcp > includes webmcp tools in select_page response 1`] = `
 ## Pages
-1: about:blank [selected]
+1: about:blank (about:blank) [selected]
 ## WebMCP tools
 name="test_tool", description="A test tool", inputSchema={"type":"object","properties":{},"required":[]}, annotations=undefined
 `;
@@ -1359,6 +1362,7 @@ exports[`webmcp > includes webmcp tools in select_page response 2`] = `
     {
       "id": 1,
       "url": "about:blank",
+      "title": "about:blank",
       "selected": true
     }
   ],
@@ -1379,7 +1383,7 @@ exports[`webmcp > includes webmcp tools in select_page response 2`] = `
 exports[`webmcp > list no webmcp tools if experimentalWebmcp is false 1`] = `
 Successfully navigated to about:blank.
 ## Pages
-1: about:blank [selected]
+1: about:blank (about:blank) [selected]
 `;
 
 exports[`webmcp > list no webmcp tools if experimentalWebmcp is false 2`] = `
@@ -1389,6 +1393,7 @@ exports[`webmcp > list no webmcp tools if experimentalWebmcp is false 2`] = `
     {
       "id": 1,
       "url": "about:blank",
+      "title": "about:blank",
       "selected": true
     }
   ]

--- a/tests/index.test.js.snapshot
+++ b/tests/index.test.js.snapshot
@@ -7,13 +7,13 @@ exports[`e2e > Dialogs > when dialog is open and tool is blocked, returns an err
 `;
 
 exports[`e2e > Dialogs > when dialog is open and tool is not blocked, executes tool 1`] = `
-{"content":[{"type":"text","text":"## Pages\\n1: about:blank\\n2: data:text/html,<button id=\\"test\\" onclick=\\"alert('test dialog')\\">Click me</button>\\n3: data:text/html,<h1>New</h1> [selected]"}]}
+{"content":[{"type":"text","text":"## Pages\\n1: about:blank (about:blank)\\n2: data:text/html,<button id=\\"test\\" onclick=\\"alert('test dialog')\\">Click me</button> (data:text/html,<button id=\\"test\\" onclick=\\"alert('test dialog')\\">Click me</button>)\\n3: data:text/html,<h1>New</h1> (data:text/html,<h1>New</h1>) [selected]"}]}
 `;
 
 exports[`e2e > calls a tool 1`] = `
-[{"type":"text","text":"## Pages\\n1: about:blank [selected]"}]
+[{"type":"text","text":"## Pages\\n1: about:blank (about:blank) [selected]"}]
 `;
 
 exports[`e2e > calls a tool multiple times 1`] = `
-[{"type":"text","text":"## Pages\\n1: about:blank [selected]"}]
+[{"type":"text","text":"## Pages\\n1: about:blank (about:blank) [selected]"}]
 `;

--- a/tests/tools/pages.test.js.snapshot
+++ b/tests/tools/pages.test.js.snapshot
@@ -1,51 +1,51 @@
 exports[`pages > close_page > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"## Pages\\n1: about:blank [selected]"}],"structuredContent":{"pages":[{"id":1,"url":"about:blank","selected":true}]}}
+{"content":[{"type":"text","text":"## Pages\\n1: about:blank (about:blank) [selected]"}],"structuredContent":{"pages":[{"id":1,"url":"about:blank","title":"about:blank","selected":true}]}}
 `;
 
 exports[`pages > list_pages > list pages for extension pages with --category-extensions 1`] = `
 ## Pages
-1: about:blank [selected]
+1: about:blank (about:blank) [selected]
 ## Extension Pages
-2: chrome-extension://<extension-id>/popup.html
+2: chrome-extension://<extension-id>/popup.html (chrome-extension://<extension-id>/popup.html)
 `;
 
 exports[`pages > list_pages > list pages for extension service workers with --category-extensions 1`] = `
 ## Pages
-1: about:blank [selected]
+1: about:blank (about:blank) [selected]
 ## Extension Service Workers
 sw-1: chrome-extension://<extension-id>/sw.js
 `;
 
 exports[`pages > list_pages > list pages for extension service workers without --category-extensions 1`] = `
 ## Pages
-1: about:blank [selected]
+1: about:blank (about:blank) [selected]
 `;
 
 exports[`pages > list_pages > list pages for side panels with --category-extensions 1`] = `
 ## Pages
-1: about:blank
+1: about:blank (about:blank)
 ## Extension Pages
-2: chrome-extension://<extension-id>/sidepanel.html [selected]
+2: chrome-extension://<extension-id>/sidepanel.html (chrome-extension://<extension-id>/sidepanel.html) [selected]
 ## Extension Service Workers
 sw-1: chrome-extension://<extension-id>/sw.js
 `;
 
 exports[`pages > list_pages > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","selected":true}]}}
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank (about:blank) [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"about:blank","selected":true}]}}
 `;
 
 exports[`pages > navigate_page > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"Successfully navigated to data:text/html,<div>Navigated</div>.\\n# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: data:text/html,<div>Navigated</div> [selected]"}],"structuredContent":{"message":"Successfully navigated to data:text/html,<div>Navigated</div>.","dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"data:text/html,<div>Navigated</div>","selected":true}]}}
+{"content":[{"type":"text","text":"Successfully navigated to data:text/html,<div>Navigated</div>.\\n# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: data:text/html,<div>Navigated</div> (data:text/html,<div>Navigated</div>) [selected]"}],"structuredContent":{"message":"Successfully navigated to data:text/html,<div>Navigated</div>.","dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"data:text/html,<div>Navigated</div>","title":"data:text/html,<div>Navigated</div>","selected":true}]}}
 `;
 
 exports[`pages > new_page with isolatedContext > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank\\n2: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","selected":false},{"id":2,"url":"about:blank","selected":true}]}}
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank (about:blank)\\n2: about:blank (about:blank) [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"about:blank","selected":false},{"id":2,"url":"about:blank","title":"about:blank","selected":true}]}}
 `;
 
 exports[`pages > resize > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","selected":true}]}}
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank (about:blank) [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"about:blank","selected":true}]}}
 `;
 
 exports[`pages > select_page > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","selected":true}]}}
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank (about:blank) [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"about:blank","selected":true}]}}
 `;


### PR DESCRIPTION
## Summary
- include each page title in list_pages text output as id: title (url)
- add title to structured page entries
- use target metadata so list_pages still works while dialogs are open

Fixes #2156

## Testing
- npm run test:update-snapshots -- tests/McpResponse.test.ts tests/tools/pages.test.ts
- npm run test -- tests/McpResponse.test.ts tests/tools/pages.test.ts
- npm run format