### PR TITLE
chore: install HostBindingAdapter

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -10,8 +10,8 @@ import os from 'node:os';
 import path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 
-import type {TargetUniverse} from './DevtoolsUtils.js';
-import {UniverseManager} from './DevtoolsUtils.js';
+import type {TargetUniverse} from './devtools/DevtoolsUtils.js';
+import {UniverseManager} from './devtools/DevtoolsUtils.js';
 import {HeapSnapshotManager} from './HeapSnapshotManager.js';
 import type {AggregatedInfoWithId} from './HeapSnapshotManager.js';
 import {McpPage} from './McpPage.js';

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -11,7 +11,10 @@ import path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 
 import type {TargetUniverse} from './devtools/DevtoolsUtils.js';
-import {UniverseManager} from './devtools/DevtoolsUtils.js';
+import {
+  overrideDevToolsGlobals,
+  UniverseManager,
+} from './devtools/DevtoolsUtils.js';
 import {HeapSnapshotManager} from './HeapSnapshotManager.js';
 import type {AggregatedInfoWithId} from './HeapSnapshotManager.js';
 import {McpPage} from './McpPage.js';
@@ -108,6 +111,8 @@ export class McpContext implements Context {
     options: McpContextOptions,
     locatorClass: typeof Locator,
   ) {
+    overrideDevToolsGlobals();
+
     this.browser = browser;
     this.logger = logger;
     this.#locatorClass = locatorClass;

--- a/src/PageCollector.ts
+++ b/src/PageCollector.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {FakeIssuesManager} from './DevtoolsUtils.js';
+import {FakeIssuesManager} from './devtools/DevtoolsUtils.js';
 import {logger} from './logger.js';
 import type {
   Target,

--- a/src/devtools/DevToolsConnectionAdapter.ts
+++ b/src/devtools/DevToolsConnectionAdapter.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as puppeteer from './third_party/index.js';
-import type {DevTools} from './third_party/index.js';
-import {CDPSessionEvent} from './third_party/index.js';
+import type * as puppeteer from '../third_party/index.js';
+import type {DevTools} from '../third_party/index.js';
+import {CDPSessionEvent} from '../third_party/index.js';
 
 /**
  * This class makes a puppeteer connection look like DevTools CDPConnection.

--- a/src/devtools/DevtoolsUtils.ts
+++ b/src/devtools/DevtoolsUtils.ts
@@ -16,7 +16,7 @@ import type {
 } from '../third_party/index.js';
 
 import {PuppeteerDevToolsConnection} from './DevToolsConnectionAdapter.js';
-import {McpHostBidningAdapter} from './McpHostBindingAdapter.js';
+import {McpHostBindingAdapter} from './McpHostBindingAdapter.js';
 
 /**
  * A mock implementation of an issues manager that only implements the methods
@@ -31,7 +31,7 @@ export class FakeIssuesManager extends DevTools.Common.ObjectWrapper
 
 export function overrideDevToolsGlobals(): void {
   DevTools.Host.InspectorFrontendHost.installInspectorFrontendHost(
-    new McpHostBidningAdapter(),
+    new McpHostBindingAdapter(),
   );
 
   // DevTools CDP errors can get noisy.

--- a/src/devtools/DevtoolsUtils.ts
+++ b/src/devtools/DevtoolsUtils.ts
@@ -18,10 +18,6 @@ import type {
 import {PuppeteerDevToolsConnection} from './DevToolsConnectionAdapter.js';
 import {McpHostBidningAdapter} from './McpHostBindingAdapter.js';
 
-DevTools.Host.InspectorFrontendHost.installInspectorFrontendHost(
-  new McpHostBidningAdapter(),
-);
-
 /**
  * A mock implementation of an issues manager that only implements the methods
  * that are actually used by the IssuesAggregator
@@ -33,89 +29,100 @@ export class FakeIssuesManager extends DevTools.Common.ObjectWrapper
   }
 }
 
-// DevTools CDP errors can get noisy.
-DevTools.ProtocolClient.InspectorBackend.test.suppressRequestErrors = true;
-
-// Stub out Network emulation commands on the DevTools Agent prototype globally.
-// This prevents the DevTools Frontend from ever resetting/clearing Puppeteer's
-// active network blocking/throttling rules during target setup or session lifetime.
-const networkAgentPrototype =
-  DevTools.ProtocolClient.InspectorBackend.inspectorBackend.agentPrototypes.get(
-    'Network',
+export function overrideDevToolsGlobals(): void {
+  DevTools.Host.InspectorFrontendHost.installInspectorFrontendHost(
+    new McpHostBidningAdapter(),
   );
-if (networkAgentPrototype) {
-  Object.defineProperty(
-    networkAgentPrototype,
-    'invoke_emulateNetworkConditionsByRule',
-    {
+
+  // DevTools CDP errors can get noisy.
+  DevTools.ProtocolClient.InspectorBackend.test.suppressRequestErrors = true;
+
+  // Stub out Network emulation commands on the DevTools Agent prototype globally.
+  // This prevents the DevTools Frontend from ever resetting/clearing Puppeteer's
+  // active network blocking/throttling rules during target setup or session lifetime.
+  const networkAgentPrototype =
+    DevTools.ProtocolClient.InspectorBackend.inspectorBackend.agentPrototypes.get(
+      'Network',
+    );
+  if (networkAgentPrototype) {
+    Object.defineProperty(
+      networkAgentPrototype,
+      'invoke_emulateNetworkConditionsByRule',
+      {
+        value: () => {
+          return Promise.resolve({
+            ruleIds: [],
+            getError: () => undefined,
+          });
+        },
+        writable: true,
+        configurable: true,
+        enumerable: true,
+      },
+    );
+    Object.defineProperty(
+      networkAgentPrototype,
+      'invoke_overrideNetworkState',
+      {
+        value: () => {
+          return Promise.resolve({
+            getError: () => undefined,
+          });
+        },
+        writable: true,
+        configurable: true,
+        enumerable: true,
+      },
+    );
+    Object.defineProperty(networkAgentPrototype, 'invoke_enable', {
       value: () => {
         return Promise.resolve({
-          ruleIds: [],
           getError: () => undefined,
         });
       },
       writable: true,
       configurable: true,
       enumerable: true,
+    });
+    Object.defineProperty(networkAgentPrototype, 'invoke_disable', {
+      value: () => {
+        return Promise.resolve({
+          getError: () => undefined,
+        });
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+    Object.defineProperty(networkAgentPrototype, 'invoke_setBlockedURLs', {
+      value: () => {
+        return Promise.resolve({
+          getError: () => undefined,
+        });
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  }
+
+  DevTools.I18n.DevToolsLocale.DevToolsLocale.instance({
+    create: true,
+    data: {
+      navigatorLanguage: 'en-US',
+      settingLanguage: 'en-US',
+      lookupClosestDevToolsLocale: l => l,
     },
-  );
-  Object.defineProperty(networkAgentPrototype, 'invoke_overrideNetworkState', {
-    value: () => {
-      return Promise.resolve({
-        getError: () => undefined,
-      });
-    },
-    writable: true,
-    configurable: true,
-    enumerable: true,
   });
-  Object.defineProperty(networkAgentPrototype, 'invoke_enable', {
-    value: () => {
-      return Promise.resolve({
-        getError: () => undefined,
-      });
-    },
-    writable: true,
-    configurable: true,
-    enumerable: true,
-  });
-  Object.defineProperty(networkAgentPrototype, 'invoke_disable', {
-    value: () => {
-      return Promise.resolve({
-        getError: () => undefined,
-      });
-    },
-    writable: true,
-    configurable: true,
-    enumerable: true,
-  });
-  Object.defineProperty(networkAgentPrototype, 'invoke_setBlockedURLs', {
-    value: () => {
-      return Promise.resolve({
-        getError: () => undefined,
-      });
-    },
-    writable: true,
-    configurable: true,
-    enumerable: true,
+
+  DevTools.I18n.i18n.registerLocaleDataForTest('en-US', {});
+
+  DevTools.Formatter.FormatterWorkerPool.FormatterWorkerPool.instance({
+    forceNew: true,
+    entrypointURL: import.meta
+      .resolve('../third_party/devtools-formatter-worker.js'),
   });
 }
-
-DevTools.I18n.DevToolsLocale.DevToolsLocale.instance({
-  create: true,
-  data: {
-    navigatorLanguage: 'en-US',
-    settingLanguage: 'en-US',
-    lookupClosestDevToolsLocale: l => l,
-  },
-});
-DevTools.I18n.i18n.registerLocaleDataForTest('en-US', {});
-
-DevTools.Formatter.FormatterWorkerPool.FormatterWorkerPool.instance({
-  forceNew: true,
-  entrypointURL: import.meta
-    .resolve('./third_party/devtools-formatter-worker.js'),
-});
 
 export interface TargetUniverse {
   /** The DevTools target corresponding to the puppeteer Page */

--- a/src/devtools/DevtoolsUtils.ts
+++ b/src/devtools/DevtoolsUtils.ts
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {PuppeteerDevToolsConnection} from './DevToolsConnectionAdapter.js';
-import {Mutex} from './Mutex.js';
-import {DevTools} from './third_party/index.js';
+import {Mutex} from '../Mutex.js';
+import {DevTools} from '../third_party/index.js';
 import type {
   Browser,
   CDPSession,
@@ -14,7 +13,14 @@ import type {
   Page,
   Protocol,
   Target as PuppeteerTarget,
-} from './third_party/index.js';
+} from '../third_party/index.js';
+
+import {PuppeteerDevToolsConnection} from './DevToolsConnectionAdapter.js';
+import {McpHostBidningAdapter} from './McpHostBindingAdapter.js';
+
+DevTools.Host.InspectorFrontendHost.installInspectorFrontendHost(
+  new McpHostBidningAdapter(),
+);
 
 /**
  * A mock implementation of an issues manager that only implements the methods

--- a/src/devtools/McpHostBindingAdapter.ts
+++ b/src/devtools/McpHostBindingAdapter.ts
@@ -1,0 +1,283 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {DevTools} from '../third_party/index.js';
+
+class HostBindingUnsupported extends Error {
+  constructor(method: string) {
+    super(`Host binding ${method} is not supported`);
+  }
+}
+
+export class McpHostBidningAdapter
+  implements DevTools.Host.InspectorFrontendHostAPI.InspectorFrontendHostAPI
+{
+  declare events: DevTools.Common.EventTarget.EventTarget<DevTools.Host.InspectorFrontendHostAPI.EventTypes>;
+  requestShowPanel(): never {
+    throw new HostBindingUnsupported('requestShowPanel');
+  }
+  requestInspectElement(): never {
+    throw new HostBindingUnsupported('requestInspectElement');
+  }
+  inspectElementCompleted(): never {
+    throw new HostBindingUnsupported('inspectElementCompleted');
+  }
+  inspectedURLChanged(): never {
+    throw new HostBindingUnsupported('inspectedURLChanged');
+  }
+  openInEditor(): never {
+    throw new HostBindingUnsupported('openInEditor');
+  }
+  openRawFile(): never {
+    throw new HostBindingUnsupported('openRawFile');
+  }
+  identifyForPane(): boolean {
+    throw new HostBindingUnsupported('identifyForPane');
+  }
+  setInspectedPageBounds(): never {
+    throw new HostBindingUnsupported('setInspectedPageBounds');
+  }
+  closeWindow(): never {
+    throw new HostBindingUnsupported('closeWindow');
+  }
+  bringToFront(): never {
+    throw new HostBindingUnsupported('bringToFront');
+  }
+  concentrationChanged(): never {
+    throw new HostBindingUnsupported('concentrationChanged');
+  }
+  recordedPageWidth(): number {
+    throw new HostBindingUnsupported('recordedPageWidth');
+  }
+  recordedPageHeight(): number {
+    throw new HostBindingUnsupported('recordedPageHeight');
+  }
+  loadExtensions(): never {
+    throw new HostBindingUnsupported('loadExtensions');
+  }
+  canInspectURL(): boolean {
+    throw new HostBindingUnsupported('canInspectURL');
+  }
+  isHostedMode(): boolean {
+    throw new HostBindingUnsupported('isHostedMode');
+  }
+  connectAutomaticFileSystem(): never {
+    throw new HostBindingUnsupported('connectAutomaticFileSystem');
+  }
+  disconnectAutomaticFileSystem(): never {
+    throw new HostBindingUnsupported('disconnectAutomaticFileSystem');
+  }
+  addFileSystem(): never {
+    throw new HostBindingUnsupported('addFileSystem');
+  }
+  loadCompleted(): never {
+    throw new HostBindingUnsupported('loadCompleted');
+  }
+  indexPath(): never {
+    throw new HostBindingUnsupported('indexPath');
+  }
+  showCertificateViewer(): never {
+    throw new HostBindingUnsupported('showCertificateViewer');
+  }
+  setWhitelistedShortcuts(): never {
+    throw new HostBindingUnsupported('setWhitelistedShortcuts');
+  }
+  setEyeDropperActive(): never {
+    throw new HostBindingUnsupported('setEyeDropperActive');
+  }
+  openInNewTab(): never {
+    throw new HostBindingUnsupported('openInNewTab');
+  }
+  openSearchResultsInNewTab(): never {
+    throw new HostBindingUnsupported('openSearchResultsInNewTab');
+  }
+  showItemInFolder(): never {
+    throw new HostBindingUnsupported('showItemInFolder');
+  }
+  removeFileSystem(): never {
+    throw new HostBindingUnsupported('removeFileSystem');
+  }
+  requestFileSystems(): never {
+    throw new HostBindingUnsupported('requestFileSystems');
+  }
+  save(): never {
+    throw new HostBindingUnsupported('save');
+  }
+  append(): never {
+    throw new HostBindingUnsupported('append');
+  }
+  close(): never {
+    throw new HostBindingUnsupported('close');
+  }
+  searchInPath(): never {
+    throw new HostBindingUnsupported('searchInPath');
+  }
+  stopIndexing(): never {
+    throw new HostBindingUnsupported('stopIndexing');
+  }
+  copyText(): never {
+    throw new HostBindingUnsupported('copyText');
+  }
+  isolatedFileSystem(): never {
+    throw new HostBindingUnsupported('isolatedFileSystem');
+  }
+  loadNetworkResource(): never {
+    throw new HostBindingUnsupported('loadNetworkResource');
+  }
+  registerPreference(): never {
+    throw new HostBindingUnsupported('registerPreference');
+  }
+  getPreferences(): never {
+    throw new HostBindingUnsupported('getPreferences');
+  }
+  getPreference(): never {
+    throw new HostBindingUnsupported('getPreference');
+  }
+  setPreference(): never {
+    throw new HostBindingUnsupported('setPreference');
+  }
+  removePreference(): never {
+    throw new HostBindingUnsupported('removePreference');
+  }
+  clearPreferences(): never {
+    throw new HostBindingUnsupported('clearPreferences');
+  }
+  getSyncInformation(): never {
+    throw new HostBindingUnsupported('getSyncInformation');
+  }
+  getHostConfig(): never {
+    throw new HostBindingUnsupported('getHostConfig');
+  }
+  upgradeDraggedFileSystemPermissions(): never {
+    throw new HostBindingUnsupported('upgradeDraggedFileSystemPermissions');
+  }
+  platform(): never {
+    throw new HostBindingUnsupported('platform');
+  }
+  recordCountHistogram(): never {
+    throw new HostBindingUnsupported('recordCountHistogram');
+  }
+  recordEnumeratedHistogram(): never {
+    throw new HostBindingUnsupported('recordEnumeratedHistogram');
+  }
+  recordPerformanceHistogram(): never {
+    throw new HostBindingUnsupported('recordPerformanceHistogram');
+  }
+  recordPerformanceHistogramMedium(): never {
+    throw new HostBindingUnsupported('recordPerformanceHistogramMedium');
+  }
+  recordUserMetricsAction(): never {
+    throw new HostBindingUnsupported('recordUserMetricsAction');
+  }
+  recordNewBadgeUsage(): never {
+    throw new HostBindingUnsupported('recordNewBadgeUsage');
+  }
+  sendMessageToBackend(): never {
+    throw new HostBindingUnsupported('sendMessageToBackend');
+  }
+  setDevicesDiscoveryConfig(): never {
+    throw new HostBindingUnsupported('setDevicesDiscoveryConfig');
+  }
+  setDevicesUpdatesEnabled(): never {
+    throw new HostBindingUnsupported('setDevicesUpdatesEnabled');
+  }
+  openRemotePage(): never {
+    throw new HostBindingUnsupported('openRemotePage');
+  }
+  openNodeFrontend(): never {
+    throw new HostBindingUnsupported('openNodeFrontend');
+  }
+  setInjectedScriptForOrigin(): never {
+    throw new HostBindingUnsupported('setInjectedScriptForOrigin');
+  }
+  setIsDocked(): never {
+    throw new HostBindingUnsupported('setIsDocked');
+  }
+  showSurvey(): never {
+    throw new HostBindingUnsupported('showSurvey');
+  }
+  canShowSurvey(): never {
+    throw new HostBindingUnsupported('canShowSurvey');
+  }
+  zoomFactor(): never {
+    throw new HostBindingUnsupported('zoomFactor');
+  }
+  zoomIn(): never {
+    throw new HostBindingUnsupported('zoomIn');
+  }
+  zoomOut(): never {
+    throw new HostBindingUnsupported('zoomOut');
+  }
+  resetZoom(): never {
+    throw new HostBindingUnsupported('resetZoom');
+  }
+  showContextMenuAtPoint(): never {
+    throw new HostBindingUnsupported('showContextMenuAtPoint');
+  }
+  reattach(): never {
+    throw new HostBindingUnsupported('reattach');
+  }
+  readyForTest(): never {
+    throw new HostBindingUnsupported('readyForTest');
+  }
+  connectionReady(): never {
+    throw new HostBindingUnsupported('connectionReady');
+  }
+  setOpenNewWindowForPopups(): never {
+    throw new HostBindingUnsupported('setOpenNewWindowForPopups');
+  }
+  setAddExtensionCallback(): never {
+    throw new HostBindingUnsupported('setAddExtensionCallback');
+  }
+  initialTargetId(): never {
+    throw new HostBindingUnsupported('initialTargetId');
+  }
+  doAidaConversation = (): never => {
+    throw new HostBindingUnsupported('doAidaConversation');
+  };
+  registerAidaClientEvent = (): never => {
+    throw new HostBindingUnsupported('registerAidaClientEvent');
+  };
+  aidaCodeComplete = (): never => {
+    throw new HostBindingUnsupported('aidaCodeComplete');
+  };
+  dispatchHttpRequest = (): never => {
+    throw new HostBindingUnsupported('dispatchHttpRequest');
+  };
+  recordImpression(): never {
+    throw new HostBindingUnsupported('recordImpression');
+  }
+  recordResize(): never {
+    throw new HostBindingUnsupported('recordResize');
+  }
+  recordClick(): never {
+    throw new HostBindingUnsupported('recordClick');
+  }
+  recordHover(): never {
+    throw new HostBindingUnsupported('recordHover');
+  }
+  recordDrag(): never {
+    throw new HostBindingUnsupported('recordDrag');
+  }
+  recordChange(): never {
+    throw new HostBindingUnsupported('recordChange');
+  }
+  recordKeyDown(): never {
+    throw new HostBindingUnsupported('recordKeyDown');
+  }
+  recordSettingAccess(): never {
+    throw new HostBindingUnsupported('recordSettingAccess');
+  }
+  recordFunctionCall(): never {
+    throw new HostBindingUnsupported('recordFunctionCall');
+  }
+  setChromeFlag(): never {
+    throw new HostBindingUnsupported('setChromeFlag');
+  }
+  requestRestart(): never {
+    throw new HostBindingUnsupported('requestRestart');
+  }
+}

--- a/src/devtools/McpHostBindingAdapter.ts
+++ b/src/devtools/McpHostBindingAdapter.ts
@@ -10,10 +10,10 @@ import type {DevTools} from '../third_party/index.js';
 
 /**
  * BaseClass that is noop or throws for methods.
- * the McpHostBidningAdapter should only implement methods
+ * the McpHostBindingAdapter should only implement methods
  * that it needs to support.
  */
-class BaseMcpHostBidningAdapter
+class BaseMcpHostBindingAdapter
   implements DevTools.Host.InspectorFrontendHostAPI.InspectorFrontendHostAPI
 {
   declare events: DevTools.Common.EventTarget.EventTarget<DevTools.Host.InspectorFrontendHostAPI.EventTypes>;
@@ -221,7 +221,7 @@ class BaseMcpHostBidningAdapter
   loadNetworkResource(): void {}
 }
 
-export class McpHostBidningAdapter extends BaseMcpHostBidningAdapter {
+export class McpHostBindingAdapter extends BaseMcpHostBindingAdapter {
   override isolatedFileSystem(): null {
     return null;
   }
@@ -250,6 +250,6 @@ export class McpHostBidningAdapter extends BaseMcpHostBidningAdapter {
   }
 
   override loadNetworkResource(): void {
-    // TODO(nvitkov):
+    // TODO(nvitkov): Add support for this
   }
 }

--- a/src/devtools/McpHostBindingAdapter.ts
+++ b/src/devtools/McpHostBindingAdapter.ts
@@ -9,7 +9,7 @@
 import type {DevTools} from '../third_party/index.js';
 
 /**
- * BaseClass that throws for all host methods.
+ * BaseClass that is noop or throws for methods.
  * the McpHostBidningAdapter should only implement methods
  * that it needs to support.
  */

--- a/src/devtools/McpHostBindingAdapter.ts
+++ b/src/devtools/McpHostBindingAdapter.ts
@@ -4,280 +4,252 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 import type {DevTools} from '../third_party/index.js';
 
-class HostBindingUnsupported extends Error {
-  constructor(method: string) {
-    super(`Host binding ${method} is not supported`);
-  }
-}
-
-export class McpHostBidningAdapter
+/**
+ * BaseClass that throws for all host methods.
+ * the McpHostBidningAdapter should only implement methods
+ * that it needs to support.
+ */
+class BaseMcpHostBidningAdapter
   implements DevTools.Host.InspectorFrontendHostAPI.InspectorFrontendHostAPI
 {
   declare events: DevTools.Common.EventTarget.EventTarget<DevTools.Host.InspectorFrontendHostAPI.EventTypes>;
-  requestShowPanel(): never {
-    throw new HostBindingUnsupported('requestShowPanel');
+  connectAutomaticFileSystem(): void {}
+
+  disconnectAutomaticFileSystem(): void {}
+
+  addFileSystem(): void {}
+
+  loadCompleted(): void {}
+
+  indexPath(): void {}
+
+  setInspectedPageBounds(): void {}
+
+  showCertificateViewer(): void {}
+
+  setWhitelistedShortcuts(): void {}
+
+  setEyeDropperActive(): void {}
+
+  inspectElementCompleted(): void {}
+
+  openInNewTab(): void {}
+
+  openSearchResultsInNewTab(): void {}
+
+  showItemInFolder(): void {}
+
+  removeFileSystem(): void {}
+
+  requestFileSystems(): void {}
+
+  save(): void {}
+
+  append(): void {}
+
+  close(): void {}
+
+  searchInPath(): void {}
+
+  stopIndexing(): void {}
+
+  bringToFront(): void {}
+
+  closeWindow(): void {}
+
+  copyText(): void {}
+
+  inspectedURLChanged(): void {}
+
+  isolatedFileSystem(): null {
+    throw new Error('Not implemented');
   }
-  requestInspectElement(): never {
-    throw new HostBindingUnsupported('requestInspectElement');
+
+  registerPreference(): void {}
+
+  getPreferences(): void {}
+
+  getPreference(): void {}
+
+  setPreference(): void {}
+
+  removePreference(): void {}
+
+  clearPreferences(): void {}
+
+  getSyncInformation(): void {}
+
+  getHostConfig(): void {}
+
+  upgradeDraggedFileSystemPermissions(): void {}
+
+  platform(): string {
+    throw new Error('Not implemented');
   }
-  inspectElementCompleted(): never {
-    throw new HostBindingUnsupported('inspectElementCompleted');
+
+  recordCountHistogram(): void {}
+
+  recordEnumeratedHistogram(): void {}
+
+  recordPerformanceHistogram(): void {}
+
+  recordPerformanceHistogramMedium(): void {}
+
+  recordUserMetricsAction(): void {}
+
+  recordNewBadgeUsage(): void {}
+
+  sendMessageToBackend(): void {}
+
+  setDevicesDiscoveryConfig(): void {}
+
+  setDevicesUpdatesEnabled(): void {}
+
+  openRemotePage(): void {}
+
+  openNodeFrontend(): void {}
+
+  setInjectedScriptForOrigin(): void {}
+
+  setIsDocked(): void {}
+
+  showSurvey(): void {}
+
+  canShowSurvey(): void {}
+
+  zoomFactor(): number {
+    throw new Error('Not implemented');
   }
-  inspectedURLChanged(): never {
-    throw new HostBindingUnsupported('inspectedURLChanged');
-  }
-  openInEditor(): never {
-    throw new HostBindingUnsupported('openInEditor');
-  }
-  openRawFile(): never {
-    throw new HostBindingUnsupported('openRawFile');
-  }
-  identifyForPane(): boolean {
-    throw new HostBindingUnsupported('identifyForPane');
-  }
-  setInspectedPageBounds(): never {
-    throw new HostBindingUnsupported('setInspectedPageBounds');
-  }
-  closeWindow(): never {
-    throw new HostBindingUnsupported('closeWindow');
-  }
-  bringToFront(): never {
-    throw new HostBindingUnsupported('bringToFront');
-  }
-  concentrationChanged(): never {
-    throw new HostBindingUnsupported('concentrationChanged');
-  }
-  recordedPageWidth(): number {
-    throw new HostBindingUnsupported('recordedPageWidth');
-  }
-  recordedPageHeight(): number {
-    throw new HostBindingUnsupported('recordedPageHeight');
-  }
-  loadExtensions(): never {
-    throw new HostBindingUnsupported('loadExtensions');
-  }
-  canInspectURL(): boolean {
-    throw new HostBindingUnsupported('canInspectURL');
-  }
+
+  zoomIn(): void {}
+
+  zoomOut(): void {}
+
+  resetZoom(): void {}
+
+  showContextMenuAtPoint(): void {}
+
+  reattach(): void {}
+
+  readyForTest(): void {}
+
+  connectionReady(): void {}
+
+  setOpenNewWindowForPopups(): void {}
+
   isHostedMode(): boolean {
-    throw new HostBindingUnsupported('isHostedMode');
-  }
-  connectAutomaticFileSystem(): never {
-    throw new HostBindingUnsupported('connectAutomaticFileSystem');
-  }
-  disconnectAutomaticFileSystem(): never {
-    throw new HostBindingUnsupported('disconnectAutomaticFileSystem');
-  }
-  addFileSystem(): never {
-    throw new HostBindingUnsupported('addFileSystem');
-  }
-  loadCompleted(): never {
-    throw new HostBindingUnsupported('loadCompleted');
-  }
-  indexPath(): never {
-    throw new HostBindingUnsupported('indexPath');
-  }
-  showCertificateViewer(): never {
-    throw new HostBindingUnsupported('showCertificateViewer');
-  }
-  setWhitelistedShortcuts(): never {
-    throw new HostBindingUnsupported('setWhitelistedShortcuts');
-  }
-  setEyeDropperActive(): never {
-    throw new HostBindingUnsupported('setEyeDropperActive');
-  }
-  openInNewTab(): never {
-    throw new HostBindingUnsupported('openInNewTab');
-  }
-  openSearchResultsInNewTab(): never {
-    throw new HostBindingUnsupported('openSearchResultsInNewTab');
-  }
-  showItemInFolder(): never {
-    throw new HostBindingUnsupported('showItemInFolder');
-  }
-  removeFileSystem(): never {
-    throw new HostBindingUnsupported('removeFileSystem');
-  }
-  requestFileSystems(): never {
-    throw new HostBindingUnsupported('requestFileSystems');
-  }
-  save(): never {
-    throw new HostBindingUnsupported('save');
-  }
-  append(): never {
-    throw new HostBindingUnsupported('append');
-  }
-  close(): never {
-    throw new HostBindingUnsupported('close');
-  }
-  searchInPath(): never {
-    throw new HostBindingUnsupported('searchInPath');
-  }
-  stopIndexing(): never {
-    throw new HostBindingUnsupported('stopIndexing');
-  }
-  copyText(): never {
-    throw new HostBindingUnsupported('copyText');
-  }
-  isolatedFileSystem(): never {
-    throw new HostBindingUnsupported('isolatedFileSystem');
-  }
-  loadNetworkResource(): never {
-    throw new HostBindingUnsupported('loadNetworkResource');
-  }
-  registerPreference(): never {
-    throw new HostBindingUnsupported('registerPreference');
-  }
-  getPreferences(): never {
-    throw new HostBindingUnsupported('getPreferences');
-  }
-  getPreference(): never {
-    throw new HostBindingUnsupported('getPreference');
-  }
-  setPreference(): never {
-    throw new HostBindingUnsupported('setPreference');
-  }
-  removePreference(): never {
-    throw new HostBindingUnsupported('removePreference');
-  }
-  clearPreferences(): never {
-    throw new HostBindingUnsupported('clearPreferences');
-  }
-  getSyncInformation(): never {
-    throw new HostBindingUnsupported('getSyncInformation');
-  }
-  getHostConfig(): never {
-    throw new HostBindingUnsupported('getHostConfig');
-  }
-  upgradeDraggedFileSystemPermissions(): never {
-    throw new HostBindingUnsupported('upgradeDraggedFileSystemPermissions');
-  }
-  platform(): never {
-    throw new HostBindingUnsupported('platform');
-  }
-  recordCountHistogram(): never {
-    throw new HostBindingUnsupported('recordCountHistogram');
-  }
-  recordEnumeratedHistogram(): never {
-    throw new HostBindingUnsupported('recordEnumeratedHistogram');
-  }
-  recordPerformanceHistogram(): never {
-    throw new HostBindingUnsupported('recordPerformanceHistogram');
-  }
-  recordPerformanceHistogramMedium(): never {
-    throw new HostBindingUnsupported('recordPerformanceHistogramMedium');
-  }
-  recordUserMetricsAction(): never {
-    throw new HostBindingUnsupported('recordUserMetricsAction');
-  }
-  recordNewBadgeUsage(): never {
-    throw new HostBindingUnsupported('recordNewBadgeUsage');
-  }
-  sendMessageToBackend(): never {
-    throw new HostBindingUnsupported('sendMessageToBackend');
-  }
-  setDevicesDiscoveryConfig(): never {
-    throw new HostBindingUnsupported('setDevicesDiscoveryConfig');
-  }
-  setDevicesUpdatesEnabled(): never {
-    throw new HostBindingUnsupported('setDevicesUpdatesEnabled');
-  }
-  openRemotePage(): never {
-    throw new HostBindingUnsupported('openRemotePage');
-  }
-  openNodeFrontend(): never {
-    throw new HostBindingUnsupported('openNodeFrontend');
-  }
-  setInjectedScriptForOrigin(): never {
-    throw new HostBindingUnsupported('setInjectedScriptForOrigin');
-  }
-  setIsDocked(): never {
-    throw new HostBindingUnsupported('setIsDocked');
-  }
-  showSurvey(): never {
-    throw new HostBindingUnsupported('showSurvey');
-  }
-  canShowSurvey(): never {
-    throw new HostBindingUnsupported('canShowSurvey');
-  }
-  zoomFactor(): never {
-    throw new HostBindingUnsupported('zoomFactor');
-  }
-  zoomIn(): never {
-    throw new HostBindingUnsupported('zoomIn');
-  }
-  zoomOut(): never {
-    throw new HostBindingUnsupported('zoomOut');
-  }
-  resetZoom(): never {
-    throw new HostBindingUnsupported('resetZoom');
-  }
-  showContextMenuAtPoint(): never {
-    throw new HostBindingUnsupported('showContextMenuAtPoint');
-  }
-  reattach(): never {
-    throw new HostBindingUnsupported('reattach');
-  }
-  readyForTest(): never {
-    throw new HostBindingUnsupported('readyForTest');
-  }
-  connectionReady(): never {
-    throw new HostBindingUnsupported('connectionReady');
-  }
-  setOpenNewWindowForPopups(): never {
-    throw new HostBindingUnsupported('setOpenNewWindowForPopups');
-  }
-  setAddExtensionCallback(): never {
-    throw new HostBindingUnsupported('setAddExtensionCallback');
-  }
-  initialTargetId(): never {
-    throw new HostBindingUnsupported('initialTargetId');
-  }
-  doAidaConversation = (): never => {
-    throw new HostBindingUnsupported('doAidaConversation');
-  };
-  registerAidaClientEvent = (): never => {
-    throw new HostBindingUnsupported('registerAidaClientEvent');
-  };
-  aidaCodeComplete = (): never => {
-    throw new HostBindingUnsupported('aidaCodeComplete');
-  };
-  dispatchHttpRequest = (): never => {
-    throw new HostBindingUnsupported('dispatchHttpRequest');
-  };
-  recordImpression(): never {
-    throw new HostBindingUnsupported('recordImpression');
-  }
-  recordResize(): never {
-    throw new HostBindingUnsupported('recordResize');
-  }
-  recordClick(): never {
-    throw new HostBindingUnsupported('recordClick');
-  }
-  recordHover(): never {
-    throw new HostBindingUnsupported('recordHover');
-  }
-  recordDrag(): never {
-    throw new HostBindingUnsupported('recordDrag');
-  }
-  recordChange(): never {
-    throw new HostBindingUnsupported('recordChange');
-  }
-  recordKeyDown(): never {
-    throw new HostBindingUnsupported('recordKeyDown');
-  }
-  recordSettingAccess(): never {
-    throw new HostBindingUnsupported('recordSettingAccess');
-  }
-  recordFunctionCall(): never {
-    throw new HostBindingUnsupported('recordFunctionCall');
-  }
-  setChromeFlag(): never {
-    throw new HostBindingUnsupported('setChromeFlag');
-  }
-  requestRestart(): never {
-    throw new HostBindingUnsupported('requestRestart');
+    throw new Error('Not implemented');
+  }
+
+  setAddExtensionCallback(): void {}
+
+  initialTargetId(): Promise<string | null> {
+    throw new Error('Not implemented');
+  }
+
+  doAidaConversation(
+    _request: string,
+    _streamId: number,
+    cb: (
+      result: DevTools.Host.InspectorFrontendHostAPI.DoAidaConversationResult,
+    ) => void,
+  ): void {
+    cb({
+      error: 'Not implemented',
+    });
+  }
+
+  registerAidaClientEvent(
+    _request: string,
+    cb: (
+      result: DevTools.Host.InspectorFrontendHostAPI.AidaClientResult,
+    ) => void,
+  ): void {
+    cb({
+      error: 'Not implemented',
+    });
+  }
+
+  aidaCodeComplete(
+    _request: string,
+    cb: (
+      result: DevTools.Host.InspectorFrontendHostAPI.AidaCodeCompleteResult,
+    ) => void,
+  ): void {
+    cb({
+      error: 'Not implemented',
+    });
+  }
+
+  dispatchHttpRequest(
+    _request: DevTools.Host.InspectorFrontendHostAPI.DispatchHttpRequestRequest,
+    cb: (
+      result: DevTools.Host.InspectorFrontendHostAPI.DispatchHttpRequestResult,
+    ) => void,
+  ): void {
+    cb({
+      error: 'Not implemented',
+    });
+  }
+
+  recordImpression(): void {}
+
+  recordResize(): void {}
+
+  recordClick(): void {}
+
+  recordHover(): void {}
+
+  recordDrag(): void {}
+
+  recordChange(): void {}
+
+  recordKeyDown(): void {}
+
+  recordSettingAccess(): void {}
+
+  recordFunctionCall(): void {}
+
+  setChromeFlag(): void {}
+
+  requestRestart(): void {}
+
+  loadNetworkResource(): void {}
+}
+
+export class McpHostBidningAdapter extends BaseMcpHostBidningAdapter {
+  override isolatedFileSystem(): null {
+    return null;
+  }
+
+  override platform(): string {
+    switch (process.platform) {
+      case 'darwin':
+        return 'mac';
+      case 'win32':
+        return 'windows';
+      default:
+        return 'linux';
+    }
+  }
+
+  override zoomFactor(): number {
+    return 1;
+  }
+
+  override isHostedMode(): boolean {
+    return true;
+  }
+
+  override initialTargetId(): Promise<string | null> {
+    return Promise.resolve(null);
+  }
+
+  override loadNetworkResource(): void {
+    // TODO(nvitkov):
   }
 }

--- a/src/formatters/ConsoleFormatter.ts
+++ b/src/formatters/ConsoleFormatter.ts
@@ -8,7 +8,7 @@ import {
   createStackTraceForConsoleMessage,
   type TargetUniverse,
   SymbolizedError,
-} from '../DevtoolsUtils.js';
+} from '../devtools/DevtoolsUtils.js';
 import {UncaughtError} from '../PageCollector.js';
 import * as DevTools from '../third_party/index.js';
 import type {ConsoleMessage} from '../third_party/index.js';

--- a/tests/devtools/DevtoolsUtils.test.ts
+++ b/tests/devtools/DevtoolsUtils.test.ts
@@ -9,18 +9,17 @@ import {afterEach, describe, it} from 'node:test';
 
 import sinon from 'sinon';
 
-import {UniverseManager} from '../src/DevtoolsUtils.js';
-import {DevTools} from '../src/third_party/index.js';
-import type {Browser, Target} from '../src/third_party/index.js';
-
-import {serverHooks} from './server.js';
+import {UniverseManager} from '../../src/devtools/DevtoolsUtils.js';
+import {DevTools} from '../../src/third_party/index.js';
+import type {Browser, Target} from '../../src/third_party/index.js';
+import {serverHooks} from '../server.js';
 import {
   getMockBrowser,
   getMockPage,
   html,
   mockListener,
   withBrowser,
-} from './utils.js';
+} from '../utils.js';
 
 describe('UniverseManager', () => {
   const server = serverHooks();

--- a/tests/formatters/ConsoleFormatter.test.ts
+++ b/tests/formatters/ConsoleFormatter.test.ts
@@ -6,7 +6,7 @@
 
 import {describe, it} from 'node:test';
 
-import {SymbolizedError} from '../../src/DevtoolsUtils.js';
+import {SymbolizedError} from '../../src/devtools/DevtoolsUtils.js';
 import {ConsoleFormatter} from '../../src/formatters/ConsoleFormatter.js';
 import {UncaughtError} from '../../src/PageCollector.js';
 import type {ConsoleMessage, Protocol} from '../../src/third_party/index.js';

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,7 +7,13 @@
 import '../src/polyfill.js';
 
 import path from 'node:path';
-import {it} from 'node:test';
+import {before, it} from 'node:test';
+
+import {overrideDevToolsGlobals} from '../src/devtools/DevtoolsUtils.js';
+
+before(() => {
+  overrideDevToolsGlobals();
+});
 
 // This is run by Node when we execute the tests via the --import flag.
 it.snapshot.setResolveSnapshotPath(testPath => {

--- a/tests/trace-processing/parse.test.ts
+++ b/tests/trace-processing/parse.test.ts
@@ -12,8 +12,6 @@ import {
   parseRawTraceBuffer,
 } from '../../src/trace-processing/parse.js';
 
-import '../../src/devtools/DevtoolsUtils.js';
-
 import {loadTraceAsBuffer} from './fixtures/load.js';
 
 describe('Trace parsing', async () => {

--- a/tests/trace-processing/parse.test.ts
+++ b/tests/trace-processing/parse.test.ts
@@ -12,7 +12,7 @@ import {
   parseRawTraceBuffer,
 } from '../../src/trace-processing/parse.js';
 
-import '../../src/DevtoolsUtils.js';
+import '../../src/devtools/DevtoolsUtils.js';
 
 import {loadTraceAsBuffer} from './fixtures/load.js';
 


### PR DESCRIPTION
This PR introduces the HostBindingAdapter to utilize the functions usually available to DevTools.
Additionally I moved all the DevTools related files under a `devtools` directory to better separate the extractor logic.
The patch scripts for DevTools were moved under a function to remove the side-effect nature of the file.
Now gets called in a the creation of the McpContext (and a before hook in test.)