### PR TITLE
chore: expose loadResouce HostBinding

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -113,7 +113,11 @@ export class McpContext implements Context {
     options: McpContextOptions,
     locatorClass: typeof Locator,
   ) {
-    overrideDevToolsGlobals();
+    overrideDevToolsGlobals({
+      loadResource: (url: string) => {
+        return this.loadResource(url);
+      },
+    });
 
     this.browser = browser;
     this.logger = logger;
@@ -939,5 +943,29 @@ export class McpContext implements Context {
       maxNodes,
       maxSiblings,
     );
+  }
+
+  async loadResource(path: string): Promise<string> {
+    const url = new URL(path);
+
+    switch (url.protocol) {
+      case 'https:':
+      case 'http:': {
+        // TODO: Vefigy allow/block list
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Failed to load resource: ${url}`);
+        }
+        return response.text();
+      }
+
+      case 'file:': {
+        await this.validatePath(fileURLToPath(url));
+        return await fsPromises.readFile(fileURLToPath(url), 'utf-8');
+      }
+
+      default:
+        throw new Error(`Unsupported protocol: ${url.protocol}`);
+    }
   }
 }

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -951,7 +951,7 @@ export class McpContext implements Context {
     switch (url.protocol) {
       case 'https:':
       case 'http:': {
-        // TODO: Vefigy allow/block list
+        // TODO: Verify allow/block list
         const response = await fetch(url);
         if (!response.ok) {
           throw new Error(`Failed to load resource: ${url}`);

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -965,7 +965,7 @@ export class McpContext implements Context {
       }
 
       default:
-        throw new Error(`Unsupported protocol: ${url.protocol}`);
+        throw new Error(`Unsupported protocol for: ${url}`);
     }
   }
 }

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -961,7 +961,7 @@ export class McpContext implements Context {
 
       case 'file:': {
         await this.validatePath(fileURLToPath(url));
-        return await fsPromises.readFile(fileURLToPath(url), 'utf-8');
+        return await fsPromises.readFile(url, 'utf-8');
       }
 
       default:

--- a/src/devtools/DevtoolsUtils.ts
+++ b/src/devtools/DevtoolsUtils.ts
@@ -29,9 +29,13 @@ export class FakeIssuesManager extends DevTools.Common.ObjectWrapper
   }
 }
 
-export function overrideDevToolsGlobals(): void {
+export function overrideDevToolsGlobals({
+  loadResource,
+}: {
+  loadResource: (url: string) => Promise<string>;
+}): void {
   DevTools.Host.InspectorFrontendHost.installInspectorFrontendHost(
-    new McpHostBindingAdapter(),
+    new McpHostBindingAdapter(loadResource),
   );
 
   // DevTools CDP errors can get noisy.

--- a/src/devtools/McpHostBindingAdapter.ts
+++ b/src/devtools/McpHostBindingAdapter.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import type {DevTools} from '../third_party/index.js';
+import {DevTools} from '../third_party/index.js';
 
 /**
  * BaseClass that is noop or throws for methods.
@@ -218,10 +218,24 @@ class BaseMcpHostBindingAdapter
 
   requestRestart(): void {}
 
-  loadNetworkResource(): void {}
+  loadNetworkResource(
+    _urlString: string,
+    _headers: string,
+    _streamId: number,
+    _callback: (
+      arg0: DevTools.Host.InspectorFrontendHostAPI.LoadNetworkResourceResult,
+    ) => void,
+  ): void {}
 }
 
 export class McpHostBindingAdapter extends BaseMcpHostBindingAdapter {
+  #loadResource: (path: string) => Promise<string>;
+
+  constructor(loadResource: (path: string) => Promise<string>) {
+    super();
+    this.#loadResource = loadResource;
+  }
+
   override isolatedFileSystem(): null {
     return null;
   }
@@ -249,7 +263,29 @@ export class McpHostBindingAdapter extends BaseMcpHostBindingAdapter {
     return Promise.resolve(null);
   }
 
-  override loadNetworkResource(): void {
-    // TODO(nvitkov): Add support for this
+  override loadNetworkResource(
+    urlString: string,
+    _headers: string,
+    streamId: number,
+    callback: (
+      arg0: DevTools.Host.InspectorFrontendHostAPI.LoadNetworkResourceResult,
+    ) => void,
+  ): void {
+    if (!URL.canParse(urlString)) {
+      callback({
+        statusCode: 404,
+        urlValid: false,
+      });
+      return;
+    }
+
+    this.#loadResource(urlString)
+      .then(content => {
+        DevTools.Host.ResourceLoader.streamWrite(streamId, content);
+        callback({statusCode: 200});
+      })
+      .catch(() => {
+        callback({statusCode: 404});
+      });
   }
 }

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -298,4 +298,22 @@ describe('McpContext', () => {
       );
     });
   });
+
+  describe('loadResource', () => {
+    it('file protocol calls validatePath', async () => {
+      await withMcpContext(async (_response, context) => {
+        const validatePathSpy = sinon.spy(context, 'validatePath');
+        const testFilePath = path.join(os.tmpdir(), 'load-resource-test.txt');
+        await fs.writeFile(testFilePath, 'test content');
+        try {
+          const url = pathToFileURL(testFilePath).href;
+          const content = await context.loadResource(url);
+          assert.strictEqual(content, 'test content');
+          sinon.assert.calledWith(validatePathSpy, testFilePath);
+        } finally {
+          await fs.rm(testFilePath, {force: true});
+        }
+      });
+    });
+  });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -12,7 +12,9 @@ import {before, it} from 'node:test';
 import {overrideDevToolsGlobals} from '../src/devtools/DevtoolsUtils.js';
 
 before(() => {
-  overrideDevToolsGlobals();
+  overrideDevToolsGlobals({
+    loadResource: async () => '',
+  });
 });
 
 // This is run by Node when we execute the tests via the --import flag.


### PR DESCRIPTION
This makes sure that if any resource that is loaded via the HostBinding will be correctly checked agains the roots object.