### PR TITLE
fix: limit windows test concurrency

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Run tests
         shell: bash
         # Retry tests if they fail in the merge queue.
-        run: npm run test:no-build -- ${{ github.event_name == 'merge_group' && '--retry' || '' }}
+        run: >
+          npm run test:no-build --
+          ${{ matrix.os == 'windows-latest' && '--test-concurrency=1' || '' }}
+          ${{ github.event_name == 'merge_group' && '--retry' || '' }}
 
   # Gating job for branch protection.
   test-success:


### PR DESCRIPTION
Fixes #2137.

This updates the test workflow so Windows jobs run the Node test runner with `--test-concurrency=1`.

The issue points to intermittent Windows failures where the browser target closes during screenshot tests. Those tests start real browser sessions, and limiting test concurrency on Windows avoids overlapping screenshot/browser work there while keeping the existing parallel behavior on Linux and macOS.

Verification:

- `git diff --check`
- Inspected the workflow command expansion: only `windows-latest` receives `--test-concurrency=1`; merge queue retries still pass `--retry` as before.
