### PR TITLE
fix: return error message when screencast_stop is called with no active recording

### DIFF
--- a/src/tools/screencast.ts
+++ b/src/tools/screencast.ts
@@ -107,6 +107,9 @@ export const stopScreencast = definePageTool({
   handler: async (_request, response, context) => {
     const data = context.getScreenRecorder();
     if (!data) {
+      response.appendResponseLine(
+        'Error: no active screencast recording to stop.',
+      );
       return;
     }
     try {

--- a/tests/tools/screencast.test.ts
+++ b/tests/tools/screencast.test.ts
@@ -151,7 +151,7 @@ describe('screencast', () => {
   });
 
   describe('screencast_stop', () => {
-    it('does nothing if no recording is active', async () => {
+    it('returns an error message if no recording is active', async () => {
       await withMcpContext(async (response, context) => {
         assert.strictEqual(context.getScreenRecorder(), null);
         await stopScreencast.handler(
@@ -159,7 +159,11 @@ describe('screencast', () => {
           response,
           context,
         );
-        assert.strictEqual(response.responseLines.length, 0);
+        assert.ok(
+          response.responseLines
+            .join('\n')
+            .includes('no active screencast recording to stop'),
+        );
       });
     });
 


### PR DESCRIPTION
## Summary

`screencast_stop` returns an empty response when no recording is active, making it impossible for the calling agent to distinguish "stopped successfully" from "nothing was recording."

`screencast_start` already handles its inverse case with an explicit error (`"a screencast recording is already in progress"`), so this makes `stop` consistent.

## Change

Added an error message when `screencast_stop` is called without an active recording:

```ts
if (!data) {
  response.appendResponseLine(
    'Error: no active screencast recording to stop.',
  );
  return;
}
```

## Before

Empty tool response — agent cannot tell what happened.

## After

`Error: no active screencast recording to stop.`