### PR TITLE
chore(webmcp): s/enable-features=WebMCPTesting/enable-features=WebMCP/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ The Chrome DevTools MCP server supports the following configuration option:
   - **Type:** string
 
 - **`--categoryExperimentalWebmcp`/ `--category-experimental-webmcp`**
-  Set to true to enable debugging WebMCP tools. Requires Chrome 149+ with the following flags: `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`
+  Set to true to enable debugging WebMCP tools. Requires Chrome 149+ with the following flags: `--enable-features=WebMCP,DevToolsWebMCPSupport`
   - **Type:** boolean
 
 - **`--chromeArg`/ `--chrome-arg`**

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -204,7 +204,7 @@ export const cliOptions = {
   categoryExperimentalWebmcp: {
     type: 'boolean',
     describe:
-      'Set to true to enable debugging WebMCP tools. Requires Chrome 149+ with the following flags: `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`',
+      'Set to true to enable debugging WebMCP tools. Requires Chrome 149+ with the following flags: `--enable-features=WebMCP,DevToolsWebMCPSupport`',
   },
   chromeArg: {
     type: 'array',

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -1502,7 +1502,7 @@ describe('webmcp', () => {
           ),
         );
       },
-      {args: ['--enable-features=WebMCPTesting,DevToolsWebMCPSupport']},
+      {args: ['--enable-features=WebMCP,DevToolsWebMCPSupport']},
       parseArguments,
     );
   }
@@ -1567,7 +1567,7 @@ describe('webmcp', () => {
           ),
         );
       },
-      {args: ['--enable-features=WebMCPTesting,DevToolsWebMCPSupport']},
+      {args: ['--enable-features=WebMCP,DevToolsWebMCPSupport']},
       {categoryExperimentalWebmcp: true} as ParsedArguments,
     );
   });

--- a/tests/tools/webmcp.test.ts
+++ b/tests/tools/webmcp.test.ts
@@ -77,7 +77,7 @@ describe('webmcp', () => {
             JSON.stringify({status: 'Completed', output: 'hello'}, null, 2),
           );
         },
-        {args: ['--enable-features=WebMCPTesting,DevToolsWebMCPSupport']},
+        {args: ['--enable-features=WebMCP,DevToolsWebMCPSupport']},
         {categoryExperimentalWebmcp: true} as ParsedArguments,
       );
     });
@@ -99,7 +99,7 @@ describe('webmcp', () => {
             {message: /Tool missing-tool not found/},
           );
         },
-        {args: ['--enable-features=WebMCPTesting,DevToolsWebMCPSupport']},
+        {args: ['--enable-features=WebMCP,DevToolsWebMCPSupport']},
         {categoryExperimentalWebmcp: true} as ParsedArguments,
       );
     });
@@ -124,7 +124,7 @@ describe('webmcp', () => {
             },
           );
         },
-        {args: ['--enable-features=WebMCPTesting,DevToolsWebMCPSupport']},
+        {args: ['--enable-features=WebMCP,DevToolsWebMCPSupport']},
         {categoryExperimentalWebmcp: true} as ParsedArguments,
       );
     });


### PR DESCRIPTION
Following https://github.com/puppeteer/puppeteer/pull/15121, this PR updates WebMCP documentation and tests to switch to the blink feature WebMCP instead of WebMCPTesting which is removed in https://chromium-review.googlesource.com/c/chromium/src/+/7921035/comment/1f0982d8_fb3efb91/