### PR TITLE
fix: handle missing third-party tool toolGroup description gracefully

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -130,7 +130,8 @@ async function getToolGroups(page: McpPage): Promise<ToolGroups> {
 
         if (
           typeof toolGroup.name !== 'string' ||
-          (toolGroup.description && typeof toolGroup.description !== 'string') ||
+          (toolGroup.description &&
+            typeof toolGroup.description !== 'string') ||
           !Array.isArray(toolGroup.tools)
         ) {
           console.error('Invalid toolGroup:', toolGroup);

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -130,7 +130,7 @@ async function getToolGroups(page: McpPage): Promise<ToolGroups> {
 
         if (
           typeof toolGroup.name !== 'string' ||
-          typeof toolGroup.description !== 'string' ||
+          (toolGroup.description && typeof toolGroup.description !== 'string') ||
           !Array.isArray(toolGroup.tools)
         ) {
           console.error('Invalid toolGroup:', toolGroup);


### PR DESCRIPTION
Angular's third-party tools currently do not provide a description of the toolGroup, only of the individual tools. We don't want to fail in this case.