### PR TITLE
fix: hide Windows update check consoles

### DIFF
--- a/src/bin/check-latest-version.ts
+++ b/src/bin/check-latest-version.ts
@@ -21,6 +21,7 @@ function getRegistry(): string {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
+      windowsHide: true,
     })
       .trim()
       .replace(/\/$/, '');

--- a/src/utils/check-for-updates.ts
+++ b/src/utils/check-for-updates.ts
@@ -88,6 +88,7 @@ export async function checkForUpdates(message: string) {
       {
         detached: true,
         stdio: 'ignore',
+        windowsHide: true,
       },
     );
     child.unref();

--- a/tests/check-for-updates.test.ts
+++ b/tests/check-for-updates.test.ts
@@ -139,6 +139,7 @@ describe('checkForUpdates', () => {
     );
     assert.ok(spawnStub.firstCall.args[1][1]?.includes('latest.json'));
     assert.strictEqual(spawnStub.firstCall.args[2]?.detached, true);
+    assert.strictEqual(spawnStub.firstCall.args[2]?.windowsHide, true);
     assert.ok(unrefSpy.calledOnce);
   });
 
@@ -163,6 +164,7 @@ describe('checkForUpdates', () => {
     );
     assert.ok(spawnStub.firstCall.args[1][1]?.includes('latest.json'));
     assert.strictEqual(spawnStub.firstCall.args[2]?.detached, true);
+    assert.strictEqual(spawnStub.firstCall.args[2]?.windowsHide, true);
     assert.ok(unrefSpy.calledOnce);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2230.

- Sets `windowsHide: true` on the detached update-check process so Windows does not flash a console window.
- Also hides the `npm config get registry` subprocess used by the updater helper.
- Covers the update-check spawn options in the existing tests.

## Verification

- `NODE_OPTIONS=--max-old-space-size=4096 npm run build`
- `npm run test:no-build -- tests/check-for-updates.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 npx eslint src/utils/check-for-updates.ts src/bin/check-latest-version.ts tests/check-for-updates.test.ts`
- `npx prettier --check src/utils/check-for-updates.ts src/bin/check-latest-version.ts tests/check-for-updates.test.ts`
- `git diff --check`

Note: plain `npm run build` and full-repo `npm run check-format` hit the local Node heap limit in this runner; the same build passed with the heap limit raised, and touched-file lint/format checks passed.
