### PR TITLE
fix(cli): apply headless default on implicit daemon auto-start

### DIFF
--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -39,6 +39,18 @@ async function start(args: string[], sessionId: string) {
 
 const defaultArgs = ['--viaCli', '--experimentalStructuredContent'];
 
+function getDefaultedStartArgs(
+  argv: Record<string, unknown>,
+): string[] {
+  if (argv.isolated === undefined && argv.userDataDir === undefined) {
+    argv.isolated = true;
+  }
+  if (argv.headless === undefined) {
+    argv.headless = true;
+  }
+  return serializeArgs(cliOptions, argv);
+}
+
 const startCliOptions = {
   ...cliOptions,
 } as Partial<typeof cliOptions>;
@@ -96,13 +108,7 @@ y.command(
       await stopDaemon(argv.sessionId);
     }
     // Defaults but we do not want to affect the yargs conflict resolution.
-    if (argv.isolated === undefined && argv.userDataDir === undefined) {
-      argv.isolated = true;
-    }
-    if (argv.headless === undefined) {
-      argv.headless = true;
-    }
-    const args = serializeArgs(cliOptions, argv);
+    const args = getDefaultedStartArgs(argv);
     await start(args, argv.sessionId);
     process.exit(0);
   },
@@ -226,7 +232,8 @@ for (const [commandName, commandDef] of Object.entries(commands)) {
       const sessionId = argv.sessionId as string;
       try {
         if (!isDaemonRunning(sessionId)) {
-          await start([], sessionId);
+          const args = getDefaultedStartArgs({});
+          await start(args, sessionId);
         }
 
         const commandArgs: Record<string, unknown> = {};


### PR DESCRIPTION
The `chrome-devtools start` command handler defaults `headless: true` when not explicitly provided, but the implicit auto-start path (triggered transparently when running a tool command like `new_page` with no running daemon) bypassed this logic entirely. This meant the daemon would launch in headful mode by default when auto-started from a tool command, causing failures in environments without an X server (e.g., devcontainers, CI).

This PR extracts a shared `getDefaultedStartArgs()` helper that applies the same defaults (`headless: true`, `isolated: true`) for both the explicit `start` command and the implicit auto-start path.

Related: the `start` command handler also had a `// Defaults but we do not want to affect the yargs conflict resolution.` comment explaining why defaults are applied after yargs parsing rather than via the option definitions — this behavior is preserved in the extracted helper.