### PR TITLE
feat: expose screencast first frame timestamp

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -213,6 +213,7 @@ export class McpResponse implements Response {
   #attachedLighthouseResult?: LighthouseData;
   #textResponseLines: string[] = [];
   #images: ImageContentData[] = [];
+  #screencastFirstFrameTimestamp: number | undefined;
   #heapSnapshotOptions?: {
     include: boolean;
     aggregates?: Record<
@@ -436,6 +437,10 @@ export class McpResponse implements Response {
 
   appendResponseLine(value: string): void {
     this.#textResponseLines.push(value);
+  }
+
+  setScreencastFirstFrameTimestamp(timestamp: number): void {
+    this.#screencastFirstFrameTimestamp = timestamp;
   }
 
   attachWaitForResult(result: WaitForEventsResult): void {
@@ -811,6 +816,7 @@ export class McpResponse implements Response {
       thirdPartyDeveloperTools?: object[];
       webmcpTools?: object[];
       message?: string;
+      firstFrameTimestamp?: number;
       networkConditions?: string;
       navigationTimeout?: number;
       viewport?: object;
@@ -843,6 +849,11 @@ export class McpResponse implements Response {
     if (this.#textResponseLines.length) {
       structuredContent.message = this.#textResponseLines.join('\n');
       response.push(...this.#textResponseLines);
+    }
+
+    if (this.#screencastFirstFrameTimestamp !== undefined) {
+      structuredContent.firstFrameTimestamp =
+        this.#screencastFirstFrameTimestamp;
     }
 
     if (this.#attachedWaitForResult) {

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -101,6 +101,7 @@ export interface DevToolsData {
 
 export interface Response {
   appendResponseLine(value: string): void;
+  setScreencastFirstFrameTimestamp(timestamp: number): void;
   setHeapSnapshotAggregates(
     aggregates: Record<
       string,

--- a/src/tools/screencast.ts
+++ b/src/tools/screencast.ts
@@ -9,7 +9,11 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {zod} from '../third_party/index.js';
-import type {ScreenRecorder, VideoFormat} from '../third_party/index.js';
+import type {
+  CDPEvents,
+  ScreenRecorder,
+  VideoFormat,
+} from '../third_party/index.js';
 import {ensureExtension} from '../utils/files.js';
 
 import {ToolCategory} from './categories.js';
@@ -21,6 +25,24 @@ async function generateTempFilePath(): Promise<string> {
 }
 
 const supportedExtensions: Array<`.${string}`> = ['.webm', '.mp4'];
+
+type ScreencastFrameHandler = (
+  event: CDPEvents['Page.screencastFrame'],
+) => void;
+
+interface ScreencastClient {
+  once(type: 'Page.screencastFrame', handler: ScreencastFrameHandler): void;
+  off(type: 'Page.screencastFrame', handler: ScreencastFrameHandler): void;
+}
+
+interface ScreencastPage {
+  mainFrame(): {client: ScreencastClient};
+  screencast(options: {
+    path: `${string}.webm`;
+    format: VideoFormat;
+    ffmpegPath?: string;
+  }): Promise<ScreenRecorder>;
+}
 
 export const startScreencast = definePageTool(args => ({
   name: 'screencast_start',
@@ -78,15 +100,25 @@ export const startScreencast = definePageTool(args => ({
     ) as `${string}.webm`;
 
     const page = request.page;
+    const pptrPage = page.pptrPage as unknown as ScreencastPage;
+    const client = pptrPage.mainFrame().client;
+    let firstFrameTimestamp: number | undefined;
+    const onFirstScreencastFrame = (
+      event: CDPEvents['Page.screencastFrame'],
+    ) => {
+      firstFrameTimestamp = event.metadata.timestamp;
+    };
+    client.once('Page.screencastFrame', onFirstScreencastFrame);
 
     let recorder: ScreenRecorder;
     try {
-      recorder = await page.pptrPage.screencast({
+      recorder = await pptrPage.screencast({
         path: resolvedPath,
         format: format,
         ffmpegPath: args?.experimentalFfmpegPath,
       });
     } catch (err) {
+      client.off('Page.screencastFrame', onFirstScreencastFrame);
       // If we generated a temporary directory for this recording, remove it so
       // a failed start (e.g. ffmpeg missing) does not leak an empty directory.
       if (requestedFilePath === undefined) {
@@ -108,12 +140,19 @@ export const startScreencast = definePageTool(args => ({
       }
       throw err;
     }
+    client.off('Page.screencastFrame', onFirstScreencastFrame);
 
     context.setScreenRecorder({recorder, filePath: resolvedPath});
 
     response.appendResponseLine(
       `Screencast recording started. The recording will be saved to ${resolvedPath}. Use ${stopScreencast.name} to stop recording.`,
     );
+    if (firstFrameTimestamp !== undefined) {
+      response.setScreencastFirstFrameTimestamp(firstFrameTimestamp);
+      response.appendResponseLine(
+        `First frame timestamp: ${firstFrameTimestamp}`,
+      );
+    }
   },
 }));
 

--- a/tests/tools/screencast.test.ts
+++ b/tests/tools/screencast.test.ts
@@ -12,8 +12,17 @@ import {describe, it, afterEach} from 'node:test';
 import sinon from 'sinon';
 
 import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
+import type {CDPEvents} from '../../src/third_party/index.js';
 import {startScreencast, stopScreencast} from '../../src/tools/screencast.js';
 import {withMcpContext} from '../utils.js';
+
+interface ScreencastTestPage {
+  mainFrame(): {
+    client: {
+      emit(type: 'Page.screencastFrame', event: CDPEvents['Page.screencastFrame']): boolean;
+    };
+  };
+}
 
 function createMockRecorder() {
   return {
@@ -31,9 +40,25 @@ describe('screencast', () => {
       await withMcpContext(async (response, context) => {
         const mockRecorder = createMockRecorder();
         const selectedPage = context.getSelectedPptrPage();
+        const {client} = (selectedPage as unknown as ScreencastTestPage).mainFrame();
         const screencastStub = sinon
           .stub(selectedPage, 'screencast')
-          .resolves(mockRecorder as never);
+          .callsFake(async () => {
+            client.emit('Page.screencastFrame', {
+              data: '',
+              metadata: {
+                timestamp: 123.456,
+                offsetTop: 0,
+                pageScaleFactor: 1,
+                deviceWidth: 800,
+                deviceHeight: 600,
+                scrollOffsetX: 0,
+                scrollOffsetY: 0,
+              },
+              sessionId: 1,
+            });
+            return mockRecorder as never;
+          });
 
         await startScreencast().handler(
           {
@@ -54,6 +79,17 @@ describe('screencast', () => {
           response.responseLines
             .join('\n')
             .includes('Screencast recording started'),
+        );
+        assert.ok(
+          response.responseLines
+            .join('\n')
+            .includes('First frame timestamp: 123.456'),
+        );
+        const result = await response.handle('screencast_start', context);
+        assert.ok('firstFrameTimestamp' in result.structuredContent);
+        assert.strictEqual(
+          result.structuredContent.firstFrameTimestamp,
+          123.456,
         );
       });
     });


### PR DESCRIPTION
## Summary
- capture the first `Page.screencastFrame` metadata timestamp while starting a screencast
- include the timestamp in the human-readable `screencast_start` response
- expose the timestamp as `structuredContent.firstFrameTimestamp` for clients that need precise video annotation alignment
- add regression coverage for the response text and structured content

## Verification
- npm run test tests/tools/screencast.test.ts
- npm run typecheck
- npm run check-format

Note: on Windows, `npm run check-format` runs ESLint and Prettier successfully, then fails because the package script's trailing semicolon is passed to Prettier as a `".;"` file pattern.

Closes #2216
