### PR TITLE
fix: warn evaluate_script not to navigate page because navigation destroys execution context

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -345,8 +345,7 @@
 
 ### `evaluate_script`
 
-**Description:** Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON,
-so returned values have to be JSON-serializable.
+**Description:** Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON, so returned values have to be JSON-serializable. Do not navigate the page inside this script; use `navigate_page` or `new_page` to change URLs because page navigations destroy the execution context.
 
 **Parameters:**
 

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -191,7 +191,7 @@ export const commands: Commands = {
   },
   evaluate_script: {
     description:
-      'Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON,\nso returned values have to be JSON-serializable.',
+      'Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON, so returned values have to be JSON-serializable. Do not navigate the page inside this script; use navigate_page or new_page to change URLs because page navigations destroy the execution context.',
     category: 'Debugging',
     args: {
       function: {

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -17,8 +17,7 @@ export type Evaluatable = Page | Frame | WebWorker;
 export const evaluateScript = defineTool(cliArgs => {
   return {
     name: 'evaluate_script',
-    description: `Evaluate a JavaScript function inside the currently selected page${cliArgs?.categoryExtensions ? ' or service worker' : ''}. Returns the response as JSON,
-so returned values have to be JSON-serializable.`,
+    description: `Evaluate a JavaScript function inside the currently selected page${cliArgs?.categoryExtensions ? ' or service worker' : ''}. Returns the response as JSON, so returned values have to be JSON-serializable. Do not navigate the page inside this script; use the navigate_page or new_page tool to change URLs because page navigations destroy the execution context.`,
     annotations: {
       category: ToolCategory.DEBUGGING,
       readOnlyHint: false,

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -41,8 +41,14 @@ describe('script', () => {
         const lineEvaluation = response.responseLines.at(2)!;
         assert.strictEqual(JSON.parse(lineEvaluation), 10);
       });
-    });
-    it('runs in selected page', async () => {
+    });    it('includes a navigation warning in the tool description', () => {
+      const tool = evaluateScript();
+      assert.ok(
+        tool.description.includes('navigate_page') ||
+          tool.description.includes('new_page'),
+        `Expected evaluate_script description to mention navigate_page or new_page.`,
+      );
+    });    it('runs in selected page', async () => {
       await withMcpContext(async (response, context) => {
         await evaluateScript().handler(
           {


### PR DESCRIPTION
Fixes #1894

## Changes
- Added warning in evaluate_script tool description that navigation 
  (window.location.href) destroys execution context
- Updated CLI help text
- Updated tool-reference.md docs
- Added regression test coverage

## How to test
Run: npm run test:no-build -- tests/tools/script.test.ts