### PR TITLE
chore: make TOON dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,14 @@
     "urlpattern-polyfill": "^10.1.0",
     "yargs": "18.0.0"
   },
+  "peerDependencies": {
+    "@toon-format/toon": "^2.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@toon-format/toon": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=23"
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -277,6 +277,13 @@ export default [
         return true;
       }
 
+      if (
+        source === '@toon-format/toon' ||
+        source.startsWith('@toon-format/toon/')
+      ) {
+        return true;
+      }
+
       const existingExternals = [
         './bidi.js',
         '../bidi/bidi.js',

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -847,7 +847,7 @@ export class McpResponse implements Response {
         throw new Error(
           'The `@toon-format/toon` package is required to use the experimental TOON format. ' +
             'Make sure the peer dependency is installed:\n' +
-            '- For npx: npx --package chrome-devtools-mcp@latest --package @toon-format/toon chrome-devtools-mcp --experimentalToonFormat\n' +
+            '- For npx: npx --package chrome-devtools-mcp@latest --package @toon-format/toon@latest chrome-devtools-mcp --experimentalToonFormat\n' +
             '- For npm: npm install @toon-format/toon (add -g if installed globally)',
         );
       }

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -17,7 +17,7 @@ import type {McpContext} from './McpContext.js';
 import type {McpPage} from './McpPage.js';
 import {UncaughtError} from './PageCollector.js';
 import {TextSnapshot} from './TextSnapshot.js';
-import {DevTools, toonEncode, type Protocol} from './third_party/index.js';
+import {DevTools, getToonEncode, type Protocol} from './third_party/index.js';
 import type {
   ConsoleMessage,
   ImageContent,
@@ -839,6 +839,20 @@ export class McpResponse implements Response {
       geolocation?: {latitude: number; longitude: number};
     } = {};
 
+    let toonEncode: ((val: unknown) => string) | undefined;
+    if (useToon) {
+      try {
+        toonEncode = await getToonEncode();
+      } catch {
+        throw new Error(
+          'The `@toon-format/toon` package is required to use the experimental TOON format. ' +
+            'Make sure the peer dependency is installed:\n' +
+            '- For npx: npx --package chrome-devtools-mcp@latest --package @toon-format/toon chrome-devtools-mcp --experimentalToonFormat\n' +
+            '- For npm: npm install @toon-format/toon (add -g if installed globally)',
+        );
+      }
+    }
+
     const response = [];
     if (this.#textResponseLines.length) {
       structuredContent.message = this.#textResponseLines.join('\n');
@@ -1057,7 +1071,7 @@ Call ${handleDialog.name} to handle it before continuing.`);
         structuredContent.snapshot = data.snapshot.toJSON();
         response.push('## Latest page snapshot');
         response.push(
-          useToon
+          useToon && toonEncode
             ? toonEncode(structuredContent.snapshot)
             : data.snapshot.toString(),
         );
@@ -1095,7 +1109,7 @@ Call ${handleDialog.name} to handle it before continuing.`);
 
         structuredContent.heapSnapshotData = formatter.toJSON();
         response.push(
-          useToon
+          useToon && toonEncode
             ? toonEncode(structuredContent.heapSnapshotData)
             : formatter.toString(),
         );
@@ -1244,7 +1258,7 @@ Call ${handleDialog.name} to handle it before continuing.`);
             i.toJSON(),
           );
           response.push(
-            ...(useToon
+            ...(useToon && toonEncode
               ? [toonEncode(structuredContent.networkRequests)]
               : paginationData.items.map(i => i.toString())),
           );
@@ -1269,7 +1283,7 @@ Call ${handleDialog.name} to handle it before continuing.`);
           item.toJSON(),
         );
         response.push(...paginationData.info);
-        if (useToon) {
+        if (useToon && toonEncode) {
           response.push(toonEncode(structuredContent.consoleMessages));
         } else {
           response.push(...paginationData.items.map(item => item.toString()));

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -173,7 +173,7 @@ export const cliOptions = {
   experimentalToonFormat: {
     type: 'boolean',
     describe:
-      'Whether to format structured data in text response using Token-Oriented Object Notation. Defaults to false which represents the embedded content as formatted JSON instead.',
+      'Whether to format structured data in text response using Token-Oriented Object Notation (requires @toon-format/toon). If running via npx, use: npx --package chrome-devtools-mcp@latest --package @toon-format/toon chrome-devtools-mcp --experimentalToonFormat',
     hidden: true,
   },
   experimentalIncludeAllPages: {

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -173,7 +173,7 @@ export const cliOptions = {
   experimentalToonFormat: {
     type: 'boolean',
     describe:
-      'Whether to format structured data in text response using Token-Oriented Object Notation (requires @toon-format/toon). If running via npx, use: npx --package chrome-devtools-mcp@latest --package @toon-format/toon chrome-devtools-mcp --experimentalToonFormat',
+      'Whether to format structured data in text response using Token-Oriented Object Notation (requires @toon-format/toon). If running via npx, use: npx --package chrome-devtools-mcp@latest --package @toon-format/toon@latest chrome-devtools-mcp --experimentalToonFormat',
     hidden: true,
   },
   experimentalIncludeAllPages: {

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -57,7 +57,10 @@ export {
   Browser as BrowserEnum,
   type ChromeReleaseChannel as BrowsersChromeReleaseChannel,
 } from '@puppeteer/browsers';
-export {encode as toonEncode} from '@toon-format/toon';
+export async function getToonEncode(): Promise<(val: unknown) => string> {
+  const {encode} = await import('@toon-format/toon');
+  return encode;
+}
 
 import {
   snapshot as snapshotImpl,

--- a/tests/third_party_notices.test.js.snapshot
+++ b/tests/third_party_notices.test.js.snapshot
@@ -909,36 +909,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -------------------- DEPENDENCY DIVIDER --------------------
 
-Name: @toon-format/toon
-URL: https://toonformat.dev
-Version: <VERSION>
-License: MIT
-
-MIT License
-
-Copyright (c) 2025-PRESENT Johann Schopplich
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
--------------------- DEPENDENCY DIVIDER --------------------
-
 Name: chrome-devtools-frontend
 License: Apache-2.0
 


### PR DESCRIPTION
Since toon dependency is only needed for `--experimentalToonFormat` flag, we can make it optional to decrease package size and security footprint for users that don't use it. 

Testing npx optional peer dependency resolution before the release:
```
npm i -g verdaccio
verdaccio
```
On a separate terminal:
```
npm adduser --registry http://localhost:4873/
# follow prompts to create user and login

# replace the published package in verdaccio
npm unpublish chrome-devtools-mcp@1.4.0 --force --registry http://localhost:4873
npm publish --registry http://localhost:4873

# clear npx cache
rm -rf ~/.npm/_npx

# run the server from commandline and observe both packages being installed:
npx --registry http://localhost:4873 --package chrome-devtools-mcp@latest --package @toon-format/toon chrome-devtools-mcp --experimentalToonFormat
```
Paste the following commands (each line separately) to manually interact with the mcp server and observe TOON formatted response directly

### 1. Initialize the session

    {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}
    
  ### 2. Confirm initialization
    {"jsonrpc":"2.0","method":"notifications/initialized"}
    
  ### 3. Navigate to Google (this will already create snapshot in most recent versions)

    {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"navigate_page","arguments":{"url":"https://google.com"}}}
    
  ### 4. Take Snapshot (if not returned by the previous command)

    {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"take_snapshot","arguments":{}}}
