### PR TITLE
fix: create PID directory with secure permissions (0o700)

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -41,7 +41,7 @@ const pidDir = path.dirname(pidFilePath);
 const currentUserUid = os.userInfo().uid;
 
 try {
-  fs.mkdirSync(pidDir, {recursive: true});
+  fs.mkdirSync(pidDir, {recursive: true, mode: 0o700});
   if (os.platform() !== 'win32') {
     // POSIX specific checks
     try {


### PR DESCRIPTION
## Summary

- Add `mode: 0o700` to `fs.mkdirSync` when creating the PID directory
- Ensures the directory is always created with owner-only access regardless of system umask

## Problem

The daemon creates the PID directory with `fs.mkdirSync(pidDir, {recursive: true})` without specifying a mode. On systems with `umask 002`, the directory lands at mode 0775, which the daemon's own security check rejects as "insecure permissions" and exits.

The daemon's test (`tests/daemon/symlink.test.ts`) already expects 0700 permissions, but nothing enforced it at runtime.

Fixes #2258

## Test Plan

- [ ] `umask 0002 && npx chrome-devtools-mcp@latest` no longer crashes
- [ ] `umask 0077 && npx chrome-devtools-mcp@latest` still works
- [ ] Existing daemon tests pass