### PR TITLE
docs: fix Antigravity config -y flag before npx positional args

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ To use the Chrome DevTools MCP server follow the instructions from <a href="http
     "chrome-devtools": {
       "command": "npx",
       "args": [
+        "-y",
         "chrome-devtools-mcp@latest",
-        "--browser-url=http://127.0.0.1:9222",
-        "-y"
+        "--browser-url=http://127.0.0.1:9222"
       ]
     }
   }


### PR DESCRIPTION
Moves the `-y` flag before the package name in the Antigravity JSON configuration example.

According to official npm documentation, `npx` requires all flags to precede positional arguments. Placing `-y` at the end caused `npx` to treat it as an argument for the MCP server, triggering an interactive installation prompt that hangs indefinitely in headless CLI environments.