### PR TITLE
fix: cap concurrency in detectOpenDevToolsWindows to avoid CDP fan-out on many-tab profiles

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -61,6 +61,53 @@ import {
 } from './utils/files.js';
 import {getNetworkMultiplierFromString} from './WaitForHelper.js';
 
+// Bounds concurrent DevTools detection CDP round-trips for large profiles.
+const DEVTOOLS_DETECTION_CONCURRENCY = 10;
+
+export async function mapWithConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  if (limit < 1) {
+    throw new Error('Concurrency limit must be at least 1.');
+  }
+
+  let nextIndex = 0;
+  let firstError: {error: unknown} | undefined;
+
+  async function runWorker(): Promise<void> {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+
+      if (index >= items.length) {
+        return;
+      }
+
+      try {
+        await worker(items[index]);
+      } catch (error) {
+        if (firstError === undefined) {
+          firstError = {error};
+        }
+      }
+    }
+  }
+
+  const workers: Array<Promise<void>> = [];
+  const workerCount = Math.min(limit, items.length);
+  for (let i = 0; i < workerCount; i++) {
+    workers.push(runWorker());
+  }
+
+  await Promise.all(workers);
+
+  if (firstError !== undefined) {
+    throw firstError.error;
+  }
+}
+
 interface McpContextOptions {
   // Whether the DevTools windows are exposed as pages for debugging of DevTools.
   experimentalDevToolsDebugging: boolean;
@@ -740,8 +787,10 @@ export class McpContext implements Context {
     this.logger?.('Detecting open DevTools windows');
     const {pages} = await this.#getAllPages();
 
-    await Promise.all(
-      pages.map(async page => {
+    await mapWithConcurrency(
+      pages,
+      DEVTOOLS_DETECTION_CONCURRENCY,
+      async page => {
         const mcpPage = this.#mcpPages.get(page);
         if (!mcpPage) {
           return;
@@ -759,7 +808,7 @@ export class McpContext implements Context {
         } catch {
           mcpPage.devToolsPage = undefined;
         }
-      }),
+      },
     );
   }
 

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -14,11 +14,69 @@ import {pathToFileURL} from 'node:url';
 import sinon from 'sinon';
 
 import {NetworkFormatter} from '../src/formatters/NetworkFormatter.js';
+import {mapWithConcurrency} from '../src/McpContext.js';
 import {TextSnapshot} from '../src/TextSnapshot.js';
 import type {HTTPResponse} from '../src/third_party/index.js';
 import type {TraceResult} from '../src/trace-processing/parse.js';
 
 import {getMockRequest, html, withMcpContext} from './utils.js';
+
+describe('mapWithConcurrency', () => {
+  it('runs the worker exactly once for each item below the limit', async () => {
+    const items = [1, 2, 3];
+    const processed = new Set<number>();
+
+    await mapWithConcurrency(items, 10, async item => {
+      assert.strictEqual(processed.has(item), false);
+      processed.add(item);
+    });
+
+    assert.deepStrictEqual(processed, new Set(items));
+  });
+
+  it('does not exceed the concurrency limit', async () => {
+    const items = Array.from({length: 50}, (_value, index) => index);
+    const limit = 3;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let processedCount = 0;
+
+    await mapWithConcurrency(items, limit, async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        processedCount++;
+      } finally {
+        inFlight--;
+      }
+    });
+
+    assert.strictEqual(processedCount, items.length);
+    assert.ok(maxInFlight <= limit);
+  });
+
+  it('continues processing after a worker rejects', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const started = new Set<number>();
+    const completed = new Set<number>();
+
+    await assert.rejects(
+      mapWithConcurrency(items, 2, async item => {
+        started.add(item);
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        if (item === 3) {
+          throw new Error('failed item');
+        }
+        completed.add(item);
+      }),
+      /failed item/,
+    );
+
+    assert.deepStrictEqual(started, new Set(items));
+    assert.deepStrictEqual(completed, new Set([1, 2, 4, 5]));
+  });
+});
 
 describe('McpContext', () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary

Caps the concurrency of the DevTools-window detection pass so it no longer issues one simultaneous CDP call per open tab.

## Why

`detectOpenDevToolsWindows()` in `src/McpContext.ts` fanned out an unbounded `Promise.all(pages.map(...))` over every open page, so each tab issued its own `hasDevTools()` / `openDevTools()` CDP round-trip at the same time. This method runs on init and again on every response that carries `includePages`, so a single tool call could put one concurrent CDP call in flight per tab.

On a profile with a very large number of tabs this becomes hundreds to thousands of simultaneous CDP calls on the first tool call, which is one of the paths that can make the browser hang or crash (Refs #1921).

## Change

Bound the fan-out with a small fixed-size worker pool. A new `mapWithConcurrency(items, limit, worker)` helper runs at most `limit` workers at once (default cap `10`, `DEVTOOLS_DETECTION_CONCURRENCY`), each pulling the next page from a shared index. `detectOpenDevToolsWindows()` now walks the pages through this helper with the exact same per-page body it had before.

- Profiles at or below the cap behave identically to before.
- The existing per-page `try/catch` fallback for pre-`144.0.7559.59` Chrome/Electron (where the DevTools command throws) is preserved, and one page failing does not abort detection for the rest.

This is deliberately narrow: it only caps the concurrency of the existing detection pass and does not change what gets detected or attached. It is one piece of the broader many-tab hardening tracked in #1921, not a full fix for it.

## Testing

Added unit tests for `mapWithConcurrency` in `tests/McpContext.test.ts` covering:
- every item is processed exactly once below the limit;
- the observed maximum in-flight worker count never exceeds the limit while all items still complete (50 items, limit 3);
- a rejecting worker does not prevent the remaining items from being processed.

`npm run check-format`, `npm run build`, and `npm test` all pass locally.
