### PR TITLE
chore: support setting sessionId for CLI via env variable

### DIFF
--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -71,7 +71,7 @@ const y = yargs(hideBin(process.argv))
   .option('sessionId', {
     type: 'string',
     description: 'Session ID for daemon scoping',
-    default: '',
+    default: process.env.CHROME_DEVTOOLS_MCP_SESSION_ID || '',
     hidden: true,
   })
   .demandCommand()


### PR DESCRIPTION
Let sessionId be set via `CHROME_DEVTOOLS_MCP_SESSION_ID` environment variable.