### PR TITLE
chore: rename misspelled functions, remove duplicate import and dead code

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'node:fs/promises';
 import fsPromises from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -788,7 +787,7 @@ export class McpContext implements Context {
     const filepath = await getTempFilePath(filename);
     await this.validatePath(filepath);
     try {
-      await fs.writeFile(filepath, data);
+      await fsPromises.writeFile(filepath, data);
     } catch (err) {
       throw new Error('Could not save a file', {cause: err});
     }
@@ -806,8 +805,8 @@ export class McpContext implements Context {
         path.resolve(clientProvidedFilePath),
         extension,
       );
-      await fs.mkdir(path.dirname(filePath), {recursive: true});
-      await fs.writeFile(filePath, data);
+      await fsPromises.mkdir(path.dirname(filePath), {recursive: true});
+      await fsPromises.writeFile(filePath, data);
       return {filename: filePath};
     } catch (err) {
       this.logger?.(err);

--- a/src/PageCollector.ts
+++ b/src/PageCollector.ts
@@ -374,7 +374,10 @@ export class NetworkCollector extends PageCollector<HTTPRequest> {
     super(browser, listeners);
   }
   override splitAfterNavigation(page: Page) {
-    const navigations = this.storage.get(page) ?? [];
+    const navigations = this.storage.get(page);
+    if (!navigations) {
+      return;
+    }
 
     const requests = navigations[0];
 

--- a/src/PageCollector.ts
+++ b/src/PageCollector.ts
@@ -335,7 +335,7 @@ class PageEventSubscriber {
         inspectorIssue,
       )[0];
       if (!issue) {
-        logger?.('No issue mapping for for the issue: ', inspectorIssue.code);
+        logger?.('No issue mapping for the issue: ', inspectorIssue.code);
         return;
       }
 
@@ -375,9 +375,6 @@ export class NetworkCollector extends PageCollector<HTTPRequest> {
   }
   override splitAfterNavigation(page: Page) {
     const navigations = this.storage.get(page) ?? [];
-    if (!navigations) {
-      return;
-    }
 
     const requests = navigations[0];
 

--- a/src/WaitForHelper.ts
+++ b/src/WaitForHelper.ts
@@ -153,8 +153,8 @@ export class WaitForHelper {
     }
 
     const navigationFinished = this.waitForNavigationStarted()
-      .then(navigationStated => {
-        if (navigationStated) {
+      .then(navigationStarted => {
+        if (navigationStarted) {
           return this.#page.waitForNavigation({
             timeout: options?.timeout ?? this.#navigationTimeout,
             signal: this.#abortController.signal,

--- a/src/formatters/NetworkFormatter.ts
+++ b/src/formatters/NetworkFormatter.ts
@@ -148,7 +148,7 @@ export class NetworkFormatter {
   }
 
   toStringDetailed(): string {
-    return converNetworkRequestDetailedToStringDetailed(this.toJSONDetailed());
+    return convertNetworkRequestDetailedToStringDetailed(this.toJSONDetailed());
   }
 
   toJSON(): NetworkRequestConcise {
@@ -233,13 +233,13 @@ export class NetworkFormatter {
       const responseBuffer = await httpResponse.buffer();
 
       if (isUtf8(responseBuffer)) {
-        const responseAsTest = responseBuffer.toString('utf-8');
+        const responseAsText = responseBuffer.toString('utf-8');
 
-        if (responseAsTest.length === 0) {
+        if (responseAsText.length === 0) {
           return '<empty response>';
         }
 
-        return getSizeLimitedString(responseAsTest, sizeLimit);
+        return getSizeLimitedString(responseAsText, sizeLimit);
       }
 
       return '<binary data>';
@@ -263,7 +263,7 @@ function convertNetworkRequestConciseToString(
   return `reqid=${data.requestId} ${data.method} ${data.url} [${data.status}]${data.selectedInDevToolsUI ? ` [selected in the DevTools Network panel]` : ''}`;
 }
 
-function formatHeadlers(headers: Record<string, string>): string[] {
+function formatHeaders(headers: Record<string, string>): string[] {
   const response: string[] = [];
   for (const [name, value] of Object.entries(headers)) {
     response.push(`- ${name}:${value}`);
@@ -271,14 +271,14 @@ function formatHeadlers(headers: Record<string, string>): string[] {
   return response;
 }
 
-function converNetworkRequestDetailedToStringDetailed(
+function convertNetworkRequestDetailedToStringDetailed(
   data: NetworkRequestDetailed,
 ): string {
   const response: string[] = [];
   response.push(`## Request ${data.url}`);
   response.push(`Status: ${data.status}`);
   response.push(`### Request Headers`);
-  for (const line of formatHeadlers(data.requestHeaders)) {
+  for (const line of formatHeaders(data.requestHeaders)) {
     response.push(line);
   }
 
@@ -292,7 +292,7 @@ function converNetworkRequestDetailedToStringDetailed(
 
   if (data.responseHeaders) {
     response.push(`### Response Headers`);
-    for (const line of formatHeadlers(data.responseHeaders)) {
+    for (const line of formatHeaders(data.responseHeaders)) {
       response.push(line);
     }
   }


### PR DESCRIPTION
Found a handful of identifier typos in NetworkFormatter.ts while reading through the network capture code:

- \`formatHeadlers\` → \`formatHeaders\` (function def + 2 call sites)
- \`converNetworkRequestDetailedToStringDetailed\` → \`convertNetworkRequestDetailedToStringDetailed\` (missing 't')
- \`responseAsTest\` → \`responseAsText\`

Also fixed a few other small things:
- \`navigationStated\` → \`navigationStarted\` in WaitForHelper.ts
- doubled "for for" in a PageCollector log message
- \`node:fs/promises\` was imported twice under different names in McpContext.ts (\`fs\` and \`fsPromises\`) — consolidated to a single import
- removed a dead \`if (!navigations)\` guard in NetworkCollector.splitAfterNavigation — \`navigations\` is already defaulted to \`[]\` via \`??\` so the check can never be falsy