### PR TITLE
fix: make check-format portable on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "tsc && node scripts/post-build.ts",
     "typecheck": "tsc --noEmit",
     "format": "eslint --cache --fix . && prettier --write --cache .",
-    "check-format": "eslint --cache . && prettier --check --cache .;",
+    "check-format": "eslint --cache . && prettier --check --cache .",
     "gen": "npm run build && npm run docs:generate && npm run cli:generate && npm run update-metrics && npm run format",
     "docs:generate": "node scripts/generate-docs.ts",
     "start": "npm run build && node build/src/bin/chrome-devtools-mcp.js",


### PR DESCRIPTION
## Summary

- Remove the trailing semicolon from the `check-format` npm script.

## Why

- Two upstream PR validation notes (`#2212`, `#2250`) report that
  `npm run check-format` passes ESLint and Prettier on Windows, then exits
  non-zero because the script's trailing `.;` is parsed as an extra Prettier
  path.
- Upstream `package.json` still contained the trailing semicolon. This keeps the
  same ESLint/Prettier checks and removes only the shell-sensitive terminator.

## Tests

- `npm ci` (passed; npm reported 17 moderate audit findings unrelated to this
  dependency-free diff)
- `npm run check-format` (passed)
- `git diff --check` (passed)
- `npm run build` (fails with an unrelated TypeScript declaration conflict in
  `node_modules/chrome-devtools-frontend/front_end/models/trace/ModelImpl.ts:230`)

## Scope / non-goals

- Scope: `package.json` script cleanup only.
- Non-goals: no lint/format toolchain changes, dependency changes, generated
  file updates, or issue creation.

## Caveats

- No dedicated issue exists; this references the PR validation notes as evidence
  rather than closing an issue.
- Windows-specific behavior was not reproduced locally on this macOS checkout;
  the premise comes from the linked upstream validation notes.
- Broader `npm run build` currently fails in an unrelated dependency TypeScript
  declaration.
