### PR TITLE
docs: fix contributor inspector build paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ npm run build
 ### Testing with @modelcontextprotocol/inspector
 
 ```sh
-npx @modelcontextprotocol/inspector node /build/src/bin/chrome-devtools-mcp.js
+npx @modelcontextprotocol/inspector node "$PWD/build/src/bin/chrome-devtools-mcp.js"
 ```
 
 ### Testing with an MCP client
@@ -93,7 +93,9 @@ Add the MCP server to your client's config.
   "mcpServers": {
     "chrome-devtools": {
       "command": "node",
-      "args": ["/path-to/build/src/bin/chrome-devtools-mcp.js"]
+      "args": [
+        "/path-to/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
+      ]
     }
   }
 }
@@ -109,7 +111,7 @@ Usually VS Code automatically detects and forwards `6274` but fails to detect `6
 To write debug logs to `log.txt` in the working directory, run with the following commands:
 
 ```sh
-npx @modelcontextprotocol/inspector node /build/src/bin/chrome-devtools-mcp.js --log-file=/your/desired/path/log.txt
+npx @modelcontextprotocol/inspector node "$PWD/build/src/bin/chrome-devtools-mcp.js" --log-file=/your/desired/path/log.txt
 ```
 
 You can use the `DEBUG` environment variable as usual to control categories that are logged.


### PR DESCRIPTION
## Summary
- update contributor inspector commands to use the checkout's built MCP binary instead of /build at filesystem root
- clarify the MCP client config placeholder path so it includes the repository directory

## Verification
- npm ci
- npm run build
- npm run check-format
- git diff --check
- checked package.json bin path for chrome-devtools-mcp matches build/src/bin/chrome-devtools-mcp.js