### PR TITLE
fix(snapshot): resolve DevTools selected element in take_snapshot output

### DIFF
--- a/src/TextSnapshot.ts
+++ b/src/TextSnapshot.ts
@@ -133,9 +133,18 @@ export class TextSnapshot {
     const data = options.devtoolsData ?? (await page.getDevToolsData());
     if (data?.cdpBackendNodeId) {
       snapshot.hasSelectedElement = true;
-      snapshot.selectedElementUid = page.resolveCdpElementId(
-        data.cdpBackendNodeId,
-      );
+      snapshot.selectedElementUid =
+        await TextSnapshot.resolveSelectedElementUid(
+          page,
+          data.cdpBackendNodeId,
+          {
+            idToNode,
+            rootNodeWithId,
+            seenBackendNodeIds,
+            seenUniqueIds,
+            snapshotId,
+          },
+        );
     }
 
     // Clean up unique IDs that we did not see anymore.
@@ -321,5 +330,115 @@ export class TextSnapshot {
       const index = moveChildNodes(attachTarget, extraNode, descendantIds);
       attachTarget.children.splice(index, 0, extraNode);
     }
+  }
+
+  static findNodeUidByBackendNodeId(
+    idToNode: Map<string, TextSnapshotNode>,
+    backendNodeId: number,
+  ): string | undefined {
+    for (const node of idToNode.values()) {
+      if (node.backendNodeId === backendNodeId) {
+        return node.id;
+      }
+    }
+    return;
+  }
+
+  static getNextIdCounter(
+    idToNode: Map<string, TextSnapshotNode>,
+    snapshotId: number,
+  ): number {
+    const prefix = `${snapshotId}_`;
+    let max = -1;
+    for (const node of idToNode.values()) {
+      if (!node.id.startsWith(prefix)) {
+        continue;
+      }
+      const suffix = Number(node.id.slice(prefix.length));
+      if (!Number.isNaN(suffix)) {
+        max = Math.max(max, suffix);
+      }
+    }
+    return max + 1;
+  }
+
+  static async resolveElementHandleFromBackendNodeId(
+    page: McpPage,
+    backendNodeId: number,
+  ): Promise<ElementHandle<Element> | null> {
+    try {
+      interface CdpMainRealm {
+        adoptBackendNode(backendNodeId: number): Promise<ElementHandle>;
+      }
+      interface CdpFrame {
+        mainRealm(): CdpMainRealm;
+      }
+      const handle = await (page.pptrPage.mainFrame() as unknown as CdpFrame)
+        .mainRealm()
+        .adoptBackendNode(backendNodeId);
+      const element = handle.asElement();
+      if (!element) {
+        await handle.dispose();
+        return null;
+      }
+      return element as ElementHandle<Element>;
+    } catch (error) {
+      logger?.('Failed to resolve selected element handle', error);
+      return null;
+    }
+  }
+
+  static async resolveSelectedElementUid(
+    page: McpPage,
+    backendNodeId: number,
+    context: {
+      idToNode: Map<string, TextSnapshotNode>;
+      rootNodeWithId: TextSnapshotNode;
+      seenBackendNodeIds: Set<number>;
+      seenUniqueIds: Set<string>;
+      snapshotId: number;
+    },
+  ): Promise<string | undefined> {
+    let selectedUid = TextSnapshot.findNodeUidByBackendNodeId(
+      context.idToNode,
+      backendNodeId,
+    );
+    if (selectedUid) {
+      return selectedUid;
+    }
+
+    const selectedHandle =
+      await TextSnapshot.resolveElementHandleFromBackendNodeId(
+        page,
+        backendNodeId,
+      );
+    if (!selectedHandle) {
+      return;
+    }
+
+    const previousExtraHandles = page.extraHandles;
+    try {
+      await TextSnapshot.insertExtraNodes(
+        page,
+        context.idToNode,
+        context.seenUniqueIds,
+        context.snapshotId,
+        TextSnapshot.getNextIdCounter(context.idToNode, context.snapshotId),
+        context.rootNodeWithId,
+        context.seenBackendNodeIds,
+        [selectedHandle],
+      );
+    } finally {
+      page.extraHandles = previousExtraHandles;
+    }
+
+    selectedUid = TextSnapshot.findNodeUidByBackendNodeId(
+      context.idToNode,
+      backendNodeId,
+    );
+    if (!selectedUid) {
+      await selectedHandle.dispose();
+    }
+    return selectedUid;
   }
 }

--- a/src/formatters/SnapshotFormatter.ts
+++ b/src/formatters/SnapshotFormatter.ts
@@ -20,12 +20,11 @@ export class SnapshotFormatter {
 
     // Top-level content of the snapshot.
     if (
-      !this.#snapshot.verbose &&
       this.#snapshot.hasSelectedElement &&
       !this.#snapshot.selectedElementUid
     ) {
-      chunks.push(`Note: there is a selected element in the DevTools Elements panel but it is not included into the current a11y tree snapshot.
-Get a verbose snapshot to include all elements if you are interested in the selected element.\n\n`);
+      chunks.push(`Note: there is a selected element in the DevTools Elements panel but it could not be resolved in this snapshot.
+The element may be detached, inside a closed shadow root, or in another frame.\n\n`);
     }
 
     chunks.push(this.#formatNode(root, 0));

--- a/tests/TextSnapshot.test.ts
+++ b/tests/TextSnapshot.test.ts
@@ -172,4 +172,112 @@ describe('TextSnapshot', () => {
       );
     });
   });
+
+  it('marks the DevTools selected element when it is in the a11y tree', async () => {
+    await withMcpContext(async (_response, context) => {
+      const page = context.getSelectedMcpPage();
+      await page.pptrPage.setContent(html`<button id="btn">Click me</button>`);
+
+      const buttonHandle = await page.pptrPage.$('#btn');
+      if (!buttonHandle) {
+        throw new Error('button element not found');
+      }
+      const backendNodeId = await buttonHandle.backendNodeId();
+      if (!backendNodeId) {
+        throw new Error('Failed to get backendNodeId');
+      }
+
+      const snapshot = await TextSnapshot.create(page, {
+        devtoolsData: {cdpBackendNodeId: backendNodeId},
+      });
+
+      assert.strictEqual(snapshot.hasSelectedElement, true);
+      assert.ok(snapshot.selectedElementUid);
+      const selectedNode = snapshot.idToNode.get(snapshot.selectedElementUid!);
+      assert.strictEqual(selectedNode?.role, 'button');
+      assert.strictEqual(selectedNode?.name, 'Click me');
+    });
+  });
+
+  it('inserts the DevTools selected element when it is missing from the a11y tree', async () => {
+    await withMcpContext(async (_response, context) => {
+      const page = context.getSelectedMcpPage();
+      await page.pptrPage.setContent(html`
+        <div id="parent">
+          <div
+            id="hidden"
+            style="display: none"
+          >
+            Hidden content
+          </div>
+        </div>
+      `);
+
+      const hiddenHandle = await page.pptrPage.$('#hidden');
+      if (!hiddenHandle) {
+        throw new Error('hidden element not found');
+      }
+      const backendNodeId = await hiddenHandle.backendNodeId();
+      if (!backendNodeId) {
+        throw new Error('Failed to get backendNodeId');
+      }
+
+      const snapshotBefore = await TextSnapshot.create(page, {
+        verbose: true,
+        devtoolsData: {},
+      });
+      assert.strictEqual(
+        TextSnapshot.findNodeUidByBackendNodeId(
+          snapshotBefore.idToNode,
+          backendNodeId,
+        ),
+        undefined,
+        'Hidden element should not be in the snapshot before selection',
+      );
+
+      const snapshot = await TextSnapshot.create(page, {
+        verbose: true,
+        devtoolsData: {cdpBackendNodeId: backendNodeId},
+      });
+
+      assert.strictEqual(snapshot.hasSelectedElement, true);
+      assert.ok(snapshot.selectedElementUid);
+      const selectedNode = snapshot.idToNode.get(snapshot.selectedElementUid!);
+      assert.strictEqual(selectedNode?.backendNodeId, backendNodeId);
+      assert.strictEqual(selectedNode?.role, 'div');
+    });
+  });
+
+  it('does not persist selected element handles across snapshots', async () => {
+    await withMcpContext(async (_response, context) => {
+      const page = context.getSelectedMcpPage();
+      await page.pptrPage.setContent(html`
+        <div id="hidden" style="display: none">Hidden content</div>
+      `);
+
+      const hiddenHandle = await page.pptrPage.$('#hidden');
+      if (!hiddenHandle) {
+        throw new Error('hidden element not found');
+      }
+      const backendNodeId = await hiddenHandle.backendNodeId();
+      if (!backendNodeId) {
+        throw new Error('Failed to get backendNodeId');
+      }
+
+      await TextSnapshot.create(page, {
+        devtoolsData: {cdpBackendNodeId: backendNodeId},
+      });
+      assert.deepStrictEqual(page.extraHandles, []);
+
+      const snapshot = await TextSnapshot.create(page, {devtoolsData: {}});
+      assert.strictEqual(snapshot.hasSelectedElement, false);
+      assert.strictEqual(
+        TextSnapshot.findNodeUidByBackendNodeId(
+          snapshot.idToNode,
+          backendNodeId,
+        ),
+        undefined,
+      );
+    });
+  });
 });

--- a/tests/TextSnapshot.test.ts
+++ b/tests/TextSnapshot.test.ts
@@ -252,7 +252,11 @@ describe('TextSnapshot', () => {
     await withMcpContext(async (_response, context) => {
       const page = context.getSelectedMcpPage();
       await page.pptrPage.setContent(html`
-        <div id="hidden" style="display: none">Hidden content</div>
+        <div
+          id="hidden"
+          style="display: none"
+          >Hidden content</div
+        >
       `);
 
       const hiddenHandle = await page.pptrPage.$('#hidden');

--- a/tests/formatters/snapshotFormatter.test.js.snapshot
+++ b/tests/formatters/snapshotFormatter.test.js.snapshot
@@ -1,9 +1,3 @@
-exports[`snapshotFormatter > does not include a note if the snapshot is already verbose 1`] = `
-uid=1_1 checkbox "checkbox" checked
-  uid=1_2 statictext "text"
-
-`;
-
 exports[`snapshotFormatter > formats with DevTools data included into a snapshot 1`] = `
 uid=1_1 checkbox "checkbox" checked [selected in the DevTools Elements panel]
   uid=1_2 statictext "text"
@@ -11,8 +5,17 @@ uid=1_1 checkbox "checkbox" checked [selected in the DevTools Elements panel]
 `;
 
 exports[`snapshotFormatter > formats with DevTools data not included into a snapshot 1`] = `
-Note: there is a selected element in the DevTools Elements panel but it is not included into the current a11y tree snapshot.
-Get a verbose snapshot to include all elements if you are interested in the selected element.
+Note: there is a selected element in the DevTools Elements panel but it could not be resolved in this snapshot.
+The element may be detached, inside a closed shadow root, or in another frame.
+
+uid=1_1 checkbox "checkbox" checked
+  uid=1_2 statictext "text"
+
+`;
+
+exports[`snapshotFormatter > includes a note when the selected element cannot be resolved 1`] = `
+Note: there is a selected element in the DevTools Elements panel but it could not be resolved in this snapshot.
+The element may be detached, inside a closed shadow root, or in another frame.
 
 uid=1_1 checkbox "checkbox" checked
   uid=1_2 statictext "text"

--- a/tests/formatters/snapshotFormatter.test.ts
+++ b/tests/formatters/snapshotFormatter.test.ts
@@ -194,7 +194,7 @@ describe('snapshotFormatter', () => {
     t.assert.snapshot(formatted);
   });
 
-  it('does not include a note if the snapshot is already verbose', t => {
+  it('includes a note when the selected element cannot be resolved', t => {
     const node: TextSnapshotNode = {
       id: '1_1',
       role: 'checkbox',


### PR DESCRIPTION
## Summary

Fix `take_snapshot` so the element selected in the Chrome DevTools Elements panel is exposed with a stable `uid` and `[selected in the DevTools Elements panel]` marker.

## Motivation

Fixes #2243. When users select an element in DevTools and ask an agent to inspect it, the snapshot reported that an element was selected but did not identify which one. This happened because:

1. `selectedElementUid` was resolved against the **previous** `textSnapshot`, not the snapshot being built.
2. Elements outside the accessibility tree were never inserted, even in verbose mode.

## Changes

- Resolve `selectedElementUid` from the in-progress snapshot tree (`idToNode`).
- When the selected element is missing from the a11y tree, resolve it via `adoptBackendNode` and insert it with the existing `insertExtraNodes` path.
- Restore `page.extraHandles` after the temporary selected-element insertion to avoid leaking state across snapshots.
- Update the unresolved-selection note to stop recommending verbose mode (which does not fix this case).

## Tests

- `node scripts/test.mjs tests/TextSnapshot.test.ts tests/formatters/snapshotFormatter.test.ts` — all pass
- `npm run check-format` — pass

## Notes

- Selection inside iframes or closed shadow roots may still fail to resolve; the note now explains likely causes.
- Google CLA signature may be required for this repository.