### PR TITLE
fix(snapshot): resolve element ids on the correct snapshot

### DIFF
--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -296,7 +296,8 @@ export class McpPage implements ContextPage {
           );
           return `stashed-${index}`;
         }
-        const cdpElementId = this.resolveCdpElementId(backendNodeId);
+        const cdpElementId =
+          this.textSnapshot?.resolveCdpElementId(backendNodeId);
         if (!cdpElementId) {
           logger?.(
             `Could not get cdpElementId for backend node ${backendNodeId}`,
@@ -367,30 +368,6 @@ export class McpPage implements ContextPage {
 
   getAXNodeByUid(uid: string) {
     return this.textSnapshot?.idToNode.get(uid);
-  }
-
-  resolveCdpElementId(cdpBackendNodeId: number): string | undefined {
-    if (!cdpBackendNodeId) {
-      logger?.('no cdpBackendNodeId');
-      return;
-    }
-    const snapshot = this.textSnapshot;
-    if (!snapshot) {
-      logger?.('no text snapshot');
-      return;
-    }
-    // TODO: index by backendNodeId instead.
-    const queue = [snapshot.root];
-    while (queue.length) {
-      const current = queue.pop()!;
-      if (current.backendNodeId === cdpBackendNodeId) {
-        return current.id;
-      }
-      for (const child of current.children) {
-        queue.push(child);
-      }
-    }
-    return;
   }
 
   async getDevToolsData(): Promise<DevToolsData> {

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -652,7 +652,9 @@ export class McpResponse implements Response {
             context,
             this.#page,
           ),
-          elementIdResolver: this.#page.resolveCdpElementId.bind(this.#page),
+          elementIdResolver: this.#page.textSnapshot?.resolveCdpElementId.bind(
+            this.#page.textSnapshot,
+          ),
         });
         if (!formatter.isValid()) {
           throw new Error(

--- a/src/TextSnapshot.ts
+++ b/src/TextSnapshot.ts
@@ -133,7 +133,7 @@ export class TextSnapshot {
     const data = options.devtoolsData ?? (await page.getDevToolsData());
     if (data?.cdpBackendNodeId) {
       snapshot.hasSelectedElement = true;
-      snapshot.selectedElementUid = page.resolveCdpElementId(
+      snapshot.selectedElementUid = snapshot.resolveCdpElementId(
         data.cdpBackendNodeId,
       );
     }
@@ -146,6 +146,25 @@ export class TextSnapshot {
     }
 
     return snapshot;
+  }
+
+  resolveCdpElementId(cdpBackendNodeId: number): string | undefined {
+    if (!cdpBackendNodeId) {
+      logger?.('no cdpBackendNodeId');
+      return;
+    }
+    // TODO: index by backendNodeId instead.
+    const queue = [this.root];
+    while (queue.length) {
+      const current = queue.pop()!;
+      if (current.backendNodeId === cdpBackendNodeId) {
+        return current.id;
+      }
+      for (const child of current.children) {
+        queue.push(child);
+      }
+    }
+    return;
   }
 
   // ExtraHandles represent DOM nodes which might not be part of the accessibility tree, e.g. DOM nodes

--- a/tests/formatters/snapshotFormatter.test.ts
+++ b/tests/formatters/snapshotFormatter.test.ts
@@ -188,6 +188,9 @@ describe('snapshotFormatter', () => {
       idToNode: new Map(),
       hasSelectedElement: true,
       verbose: false,
+      resolveCdpElementId() {
+        return undefined;
+      },
     });
     const formatted = formatter.toString();
 
@@ -222,6 +225,9 @@ describe('snapshotFormatter', () => {
       idToNode: new Map(),
       hasSelectedElement: true,
       verbose: true,
+      resolveCdpElementId() {
+        return undefined;
+      },
     });
     const formatted = formatter.toString();
 
@@ -257,6 +263,9 @@ describe('snapshotFormatter', () => {
       hasSelectedElement: true,
       selectedElementUid: '1_1',
       verbose: false,
+      resolveCdpElementId() {
+        return '1_1';
+      },
     });
     const formatted = formatter.toString();
 

--- a/tests/tools/thirdPartyDeveloper.test.ts
+++ b/tests/tools/thirdPartyDeveloper.test.ts
@@ -767,10 +767,6 @@ describe('thirdPartyDeveloperTools', () => {
             };
           });
 
-          const stub = sinon
-            .stub(page, 'resolveCdpElementId')
-            .returns('mock-uid');
-
           await executeThirdPartyDeveloperTool.handler(
             {
               params: {
@@ -785,10 +781,8 @@ describe('thirdPartyDeveloperTools', () => {
 
           assert.strictEqual(
             response.responseLines[0],
-            JSON.stringify({uid: 'mock-uid'}, null, 2),
+            JSON.stringify({uid: '1_1'}, null, 2),
           );
-
-          stub.restore();
         },
         undefined,
         {categoryExperimentalThirdParty: true},
@@ -826,14 +820,6 @@ describe('thirdPartyDeveloperTools', () => {
             };
           });
 
-          const stubSnapshot = sinon
-            .stub(TextSnapshot, 'create')
-            .resolves({} as TextSnapshot);
-
-          const stubResolve = sinon
-            .stub(page, 'resolveCdpElementId')
-            .returns('mock-uid');
-
           await executeThirdPartyDeveloperTool.handler(
             {
               params: {
@@ -846,17 +832,10 @@ describe('thirdPartyDeveloperTools', () => {
             context,
           );
 
-          assert.ok(
-            stubSnapshot.calledOnce,
-            'Expected TextSnapshot.create to be called',
-          );
           assert.strictEqual(
             response.responseLines[0],
-            JSON.stringify({uid: 'mock-uid'}, null, 2),
+            JSON.stringify({uid: '1_1'}, null, 2),
           );
-
-          stubResolve.restore();
-          stubSnapshot.restore();
         },
         undefined,
         {categoryExperimentalThirdParty: true},


### PR DESCRIPTION
closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/2243

This probably regressed with the addition of third party developer tools because the resolveCdpElementId was not moved from page to TextSnapshot.