### PR TITLE
fix: don't double multi-part extensions when saving files

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -260,6 +260,13 @@ export class McpContext implements Context {
     extension: Extension,
   ): Promise<`${string}${Extension}`> {
     const resolvedPath = path.resolve(filePath);
+    // path.extname only strips the final segment, so a multi-part extension
+    // like `.json.gz` would be doubled (trace.json.gz -> trace.json.json.gz).
+    // Keep the path as-is when it already carries the requested extension.
+    if (resolvedPath.toLowerCase().endsWith(extension.toLowerCase())) {
+      await this.validatePath(resolvedPath);
+      return resolvedPath as `${string}${Extension}`;
+    }
     const currentExtension = path.extname(resolvedPath);
     const outputPath: `${string}${Extension}` = `${resolvedPath.slice(
       0,

--- a/tests/roots.test.ts
+++ b/tests/roots.test.ts
@@ -67,7 +67,7 @@ describe('McpContext Roots', () => {
 
         const testCases: Array<{
           filePath: string;
-          extension: '.json' | '.txt' | '.png' | '.zip';
+          extension: '.json' | '.txt' | '.png' | '.zip' | '.json.gz';
           expected: string;
         }> = [
           {
@@ -94,6 +94,17 @@ describe('McpContext Roots', () => {
             filePath: 'file.tar.gz',
             extension: '.zip',
             expected: 'file.tar.zip',
+          },
+          {
+            // Multi-part extension already present: must not be doubled.
+            filePath: 'trace.json.gz',
+            extension: '.json.gz',
+            expected: 'trace.json.gz',
+          },
+          {
+            filePath: 'trace.gz',
+            extension: '.json.gz',
+            expected: 'trace.json.gz',
           },
         ];
 


### PR DESCRIPTION
Saving a performance trace to a compressed path like `trace.json.gz` (the exact example in the `performance_start_trace`/`performance_stop_trace` schema) writes it to `trace.json.json.gz` instead.

The cause is in `ensureExtension`: it strips the current extension with `path.extname` and re-appends the target one, but `path.extname("trace.json.gz")` only returns `.gz`. So it strips `.gz` → `trace.json`, then appends `.json.gz` → `trace.json.json.gz`. The compressed-trace tools pass `.json.gz` as the extension, so this hits any trace saved to a `.gz` path.

Fix is to skip the strip-and-reappend when the path already ends with the requested extension. Single-segment extensions and the replace-a-different-extension case (e.g. `result.jpg` → `.png`) are unchanged; added a couple of cases to the existing `ensureExtension` test to lock in the `.json.gz` behavior.