### PR TITLE
fix: enforce .gz instead of json.gz in performance tools

### DIFF
--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -185,7 +185,7 @@ export type SupportedExtensions =
   | '.html'
   | '.txt'
   | '.csv'
-  | '.json.gz';
+  | '.gz';
 
 /**
  * Only add methods used by tools/*.

--- a/src/tools/performance.ts
+++ b/src/tools/performance.ts
@@ -205,7 +205,7 @@ async function stopTracingAndAppendOutput(
       const file = await context.saveFile(
         dataToWrite,
         filePath,
-        filePath.endsWith('.gz') ? '.json.gz' : '.json',
+        filePath.endsWith('.gz') ? '.gz' : '.json',
       );
       response.appendResponseLine(
         `The raw trace data was saved to ${file.filename}.`,


### PR DESCRIPTION
Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/pull/2303