### PR TITLE
fix: don't crash the tab when upload_file targets a chooser-opening element

### DIFF
--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -475,12 +475,18 @@ export const uploadFile = definePageTool({
       uid,
     )) as ElementHandle<HTMLInputElement>;
     try {
-      try {
+      const isFileInput = await handle.evaluate(
+        element =>
+          element instanceof HTMLInputElement && element.type === 'file',
+      );
+      if (isFileInput) {
         await handle.uploadFile(filePath);
-      } catch {
-        // Some sites use a proxy element to trigger file upload instead of
-        // a type=file element. In this case, we want to default to
-        // Page.waitForFileChooser() and upload the file this way.
+      } else {
+        // Some sites use a proxy element (e.g. a button that calls
+        // input.click()) to open the chooser instead of exposing the
+        // type=file input. Calling uploadFile on such an element sends
+        // DOM.setFileInputFiles to a non-input node, which crashes the tab, so
+        // drive the chooser explicitly.
         try {
           const [fileChooser] = await Promise.all([
             request.page.pptrPage.waitForFileChooser({timeout: 3000}),

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -475,18 +475,12 @@ export const uploadFile = definePageTool({
       uid,
     )) as ElementHandle<HTMLInputElement>;
     try {
-      const isFileInput = await handle.evaluate(
-        element =>
-          element instanceof HTMLInputElement && element.type === 'file',
-      );
-      if (isFileInput) {
+      try {
         await handle.uploadFile(filePath);
-      } else {
-        // Some sites use a proxy element (e.g. a button that calls
-        // input.click()) to open the chooser instead of exposing the
-        // type=file input. Calling uploadFile on such an element sends
-        // DOM.setFileInputFiles to a non-input node, which crashes the tab, so
-        // drive the chooser explicitly.
+      } catch {
+        // Some sites use a proxy element to trigger file upload instead of
+        // a type=file element. In this case, we want to default to
+        // Page.waitForFileChooser() and upload the file this way.
         try {
           const [fileChooser] = await Promise.all([
             request.page.pptrPage.waitForFileChooser({timeout: 3000}),

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -1294,6 +1294,44 @@ describe('input', () => {
         await fs.unlink(testFilePath);
       });
     });
+
+    it('does not treat a non-file input as a file input', async () => {
+      const testFilePath = path.join(process.cwd(), 'test.txt');
+      await fs.writeFile(testFilePath, 'test file content');
+
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedPptrPage();
+        // A text input is an HTMLInputElement but not a file input; routing it
+        // through uploadFile would send DOM.setFileInputFiles to a non-file
+        // node and crash the tab, so it must fall through to the chooser path.
+        await page.setContent(html`<input type="text" />`);
+        context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
+          context.getSelectedMcpPage(),
+        );
+
+        await assert.rejects(
+          uploadFile.handler(
+            {
+              params: {
+                uid: '1_1',
+                filePath: testFilePath,
+              },
+              page: context.getSelectedMcpPage(),
+            },
+            response,
+            context,
+          ),
+          {
+            message:
+              'Failed to upload file. The element could not accept the file directly, and clicking it did not trigger a file chooser.',
+          },
+        );
+
+        assert.strictEqual(response.responseLines.length, 0);
+
+        await fs.unlink(testFilePath);
+      });
+    });
   });
 
   describe('press_key', () => {

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -9,6 +9,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import {describe, it} from 'node:test';
 
+import sinon from 'sinon';
+
 import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
 import {McpResponse} from '../../src/McpResponse.js';
 import {TextSnapshot} from '../../src/TextSnapshot.js';
@@ -1295,39 +1297,66 @@ describe('input', () => {
       });
     });
 
-    it('does not treat a non-file input as a file input', async () => {
+    it('does not probe a chooser-opening element with uploadFile', async () => {
       const testFilePath = path.join(process.cwd(), 'test.txt');
       await fs.writeFile(testFilePath, 'test file content');
 
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedPptrPage();
-        // A text input is an HTMLInputElement but not a file input; routing it
-        // through uploadFile would send DOM.setFileInputFiles to a non-file
-        // node and crash the tab, so it must fall through to the chooser path.
-        await page.setContent(html`<input type="text" />`);
-        context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
-          context.getSelectedMcpPage(),
+        await page.setContent(
+          html`<button id="file-chooser-button">Upload file</button>
+            <input
+              type="file"
+              id="file-input"
+              style="display: none;"
+            />
+            <script>
+              document
+                .getElementById('file-chooser-button')
+                .addEventListener('click', () => {
+                  document.getElementById('file-input').click();
+                });
+            </script>`,
         );
+        const mcpPage = context.getSelectedMcpPage();
+        mcpPage.textSnapshot = await TextSnapshot.create(mcpPage);
 
-        await assert.rejects(
-          uploadFile.handler(
+        // Real headful Chrome doesn't throw when uploadFile is called on a
+        // chooser-opening element — it kills the renderer, and the file is
+        // never set. The in-process test browser instead throws, which lets
+        // the old code recover via the chooser and masks the bug. Stub
+        // uploadFile to a silent no-op so the button behaves like it does in
+        // production: if the tool probes it with uploadFile, the file is lost.
+        const buttonHandle = await mcpPage.getElementByUid('1_1');
+        const uploadFileStub = sinon
+          .stub(buttonHandle, 'uploadFile')
+          .resolves();
+        sinon.stub(mcpPage, 'getElementByUid').resolves(buttonHandle);
+
+        try {
+          await uploadFile.handler(
             {
               params: {
                 uid: '1_1',
                 filePath: testFilePath,
               },
-              page: context.getSelectedMcpPage(),
+              page: mcpPage,
             },
             response,
             context,
-          ),
-          {
-            message:
-              'Failed to upload file. The element could not accept the file directly, and clicking it did not trigger a file chooser.',
-          },
-        );
+          );
 
-        assert.strictEqual(response.responseLines.length, 0);
+          // The element isn't a file input, so it must never be probed with
+          // uploadFile — it has to go straight to the chooser...
+          assert.strictEqual(uploadFileStub.called, false);
+          // ...and the chooser path must actually deliver the file.
+          const uploadedFileName = await page.$eval('#file-input', el => {
+            return (el as HTMLInputElement).files?.[0]?.name;
+          });
+          assert.strictEqual(uploadedFileName, 'test.txt');
+        } finally {
+          sinon.restore();
+        }
 
         await fs.unlink(testFilePath);
       });


### PR DESCRIPTION
Fixes #2310. `upload_file` calls `handle.uploadFile()` on whatever element you pass it first, and only falls back to the file chooser if that throws. But when the element is a proxy that opens the chooser (a button calling `input.click()`, which is how most real upload UIs work), `uploadFile` doesn't throw — puppeteer reads `element.multiple` (undefined on a button, no error) and then sends `DOM.setFileInputFiles` to a non-input node, which kills the renderer with `RESULT_CODE_KILLED_BAD_MESSAGE`. The try/catch can't help because the tab is already gone, and the tool then reports a misleading "element no longer exists" error.

The tool's own schema documents the chooser-opening element as supported, so the fix is to stop probing with `uploadFile`: check whether the element is actually an `<input type=file>` and only use the direct path for those. Everything else goes straight to the click + `waitForFileChooser` path it was always meant to use.

All three existing upload_file tests still pass. Added one for a non-file `<input>` to lock in that the check is `type === 'file'`, not just `instanceof HTMLInputElement` — otherwise a text input would still be routed into the crashing path.