### PR TITLE
chore: report exact bundled package versions during release

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -50,6 +50,15 @@ const {devDependencies = {}} = JSON.parse(
 // special case for puppeteer, from which we only bundle puppeteer-core
 devDependencies['puppeteer-core'] = devDependencies['puppeteer'];
 
+const packageLock = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), 'package-lock.json'), 'utf-8'),
+);
+
+function getResolvedVersion(packageName) {
+  const packageEntry = packageLock.packages?.[`node_modules/${packageName}`];
+  return packageEntry?.version || null;
+}
+
 const aggregatedStats = {
   bundlesProcessed: 0,
   totalBundles: 0,
@@ -103,14 +112,17 @@ function listBundledDeps() {
       if (aggregatedStats.bundlesProcessed === aggregatedStats.totalBundles) {
         const outputPath = path.join(thirdPartyDir, 'bundled-packages.json');
 
-        const bundledDevDeps = Object.fromEntries(
-          Object.entries(devDependencies).filter(
-            ([name]) =>
-              aggregatedStats.bundledPackages.has(name) ||
-              name === 'chrome-devtools-frontend' ||
-              name === 'lighthouse',
-          ),
-        );
+        const bundledDevDeps = {};
+        for (const [name, versionRange] of Object.entries(devDependencies)) {
+          if (
+            aggregatedStats.bundledPackages.has(name) ||
+            name === 'chrome-devtools-frontend' ||
+            name === 'lighthouse'
+          ) {
+            const resolvedVersion = getResolvedVersion(name);
+            bundledDevDeps[name] = resolvedVersion || versionRange;
+          }
+        }
 
         fs.writeFileSync(outputPath, JSON.stringify(bundledDevDeps, null, 2));
       }


### PR DESCRIPTION
At bundle time, we know exactly which version of the package is installed, we should report exact version instead of a range from package.json.

This change parses package-lock.json to obtain this information.

This approach aligns better with upstream security analyzers relying on dependency version information.