### PR TITLE
feat: restart active performance traces

### DIFF
--- a/src/tools/performance.ts
+++ b/src/tools/performance.ts
@@ -51,10 +51,7 @@ export const startTrace = definePageTool({
   verifyFilesSchema: ['filePath'],
   handler: async (request, response, context) => {
     if (context.isRunningPerformanceTrace()) {
-      response.appendResponseLine(
-        'Error: a performance trace is already running. Use performance_stop_trace to stop it. Only one trace can be running at any given time.',
-      );
-      return;
+      await stopActiveTraceWithoutParsing(request.page, response, context);
     }
     context.setIsRunningPerformanceTrace(true);
 
@@ -114,6 +111,21 @@ export const startTrace = definePageTool({
     }
   },
 });
+
+async function stopActiveTraceWithoutParsing(
+  page: ContextPage,
+  response: Response,
+  context: Context,
+): Promise<void> {
+  try {
+    await page.pptrPage.tracing.stop();
+    response.appendResponseLine(
+      'Stopped the previous performance trace before starting a new one.',
+    );
+  } finally {
+    context.setIsRunningPerformanceTrace(false);
+  }
+}
 
 export const stopTrace = definePageTool({
   name: 'performance_stop_trace',

--- a/tests/tools/performance.test.ts
+++ b/tests/tools/performance.test.ts
@@ -144,24 +144,32 @@ describe('performance', () => {
       });
     });
 
-    it('errors if a recording is already active', async () => {
+    it('stops an active trace before starting a new recording', async () => {
+      const rawData = loadTraceAsBuffer('basic-trace.json.gz');
+
       await withMcpContext(async (response, context) => {
         context.setIsRunningPerformanceTrace(true);
         const selectedPage = context.getSelectedPptrPage();
+        const stopTracingStub = sinon
+          .stub(selectedPage.tracing, 'stop')
+          .resolves(rawData);
         const startTracingStub = sinon.stub(selectedPage.tracing, 'start');
         await startTrace.handler(
           {
-            params: {reload: true, autoStop: false},
+            params: {reload: false, autoStop: false},
             page: context.getSelectedMcpPage(),
           },
           response,
           context,
         );
-        sinon.assert.notCalled(startTracingStub);
+        sinon.assert.calledOnce(stopTracingStub);
+        sinon.assert.calledOnce(startTracingStub);
+        assert.strictEqual(context.recordedTraces().length, 0);
+        assert.ok(context.isRunningPerformanceTrace());
         assert.ok(
           response.responseLines
             .join('\n')
-            .match(/a performance trace is already running/),
+            .match(/Stopped the previous performance trace/),
         );
       });
     });


### PR DESCRIPTION
## Summary

- stop any currently running performance trace before starting a new one
- add a short notice when an existing trace is replaced
- cover the restart path with a regression test

Fixes #808.

## Validation

- npm run test tests/tools/performance.test.ts
- npm run build
- npm run check-format
