### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ Chrome DevTools MCP will not start the browser instance automatically using this
 </details>
 
 <details>
+  <summary>Autohand Code</summary>
+
+Use the [Autohand Code CLI](https://github.com/autohandai/code-cli/) to add the Chrome DevTools MCP server:
+
+```bash
+autohand mcp add chrome-devtools npx -y chrome-devtools-mcp@latest
+```
+
+Add `--scope project` before `chrome-devtools` to save the server in the current project's `.autohand` configuration instead of your user configuration.
+
+</details>
+
+<details>
   <summary>Claude Code</summary>
 
 **Install via CLI (MCP only)**


### PR DESCRIPTION
## What changed

Added an Autohand Code entry to the existing MCP client configuration section, using the same `chrome-devtools-mcp@latest` package as the surrounding CLI examples.

## Why

Autohand Code supports stdio MCP servers directly, so users can configure Chrome DevTools with one CLI command alongside the other documented coding agents.

## Validation

- Verified the command against the current Autohand Code MCP CLI implementation
- Ran `git diff --check`
