### PR TITLE
perf: defer focus emulation until page selection

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -397,6 +397,7 @@ export class McpContext implements Context {
 
   selectPage(newPage: McpPage): void {
     this.#selectedPage = newPage;
+    void newPage.enableFocusEmulation();
     newPage.updateTimeouts();
   }
 

--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -73,6 +73,8 @@ export class McpPage implements ContextPage {
   // Metadata
   isolatedContextName?: string;
   #devtoolsUniverse?: TargetUniverse;
+  #focusEmulationEnabled = false;
+  #focusEmulationPromise?: Promise<void>;
 
   // Dialog
   #dialog?: Dialog;
@@ -122,17 +124,27 @@ export class McpPage implements ContextPage {
   }
 
   async init(): Promise<void> {
-    await Promise.allSettled([
-      this.#initDevToolsUniverseNoThrow(),
-      this.#initFocusEmulationNoThrow(),
-    ]);
+    await this.#initDevToolsUniverseNoThrow();
   }
 
-  async #initFocusEmulationNoThrow(): Promise<void> {
-    // We emulate a focused page for all pages to support multi-agent workflows.
-    void this.pptrPage.emulateFocusedPage(true).catch(error => {
-      logger?.('Error turning on focused page emulation', error);
-    });
+  enableFocusEmulation(): Promise<void> {
+    if (this.#focusEmulationEnabled) {
+      return Promise.resolve();
+    }
+    if (!this.#focusEmulationPromise) {
+      this.#focusEmulationPromise = this.pptrPage
+        .emulateFocusedPage(true)
+        .then(() => {
+          this.#focusEmulationEnabled = true;
+        })
+        .catch(error => {
+          logger?.('Error turning on focused page emulation', error);
+        })
+        .finally(() => {
+          this.#focusEmulationPromise = undefined;
+        });
+    }
+    return this.#focusEmulationPromise;
   }
 
   async #initDevToolsUniverseNoThrow(): Promise<void> {

--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -238,6 +238,7 @@ export class ToolHandler {
             !this.serverArgs.slim
               ? context.getPageById(pageId)
               : context.getSelectedMcpPage();
+          await page.enableFocusEmulation();
           response.setPage(page);
           if (this.tool.blockedByDialog) {
             page.throwIfDialogOpen();

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -17,6 +17,7 @@ import sinon from 'sinon';
 
 import {NetworkFormatter} from '../src/formatters/NetworkFormatter.js';
 import {McpContext} from '../src/McpContext.js';
+import {McpPage} from '../src/McpPage.js';
 import {TextSnapshot} from '../src/TextSnapshot.js';
 import type {HTTPResponse} from '../src/third_party/index.js';
 import type {TraceResult} from '../src/trace-processing/parse.js';
@@ -26,6 +27,42 @@ import {getMockRequest, html, withBrowser, withMcpContext} from './utils.js';
 describe('McpContext', () => {
   afterEach(() => {
     sinon.restore();
+  });
+
+  it('enables focused-page emulation only after selection and retries failures', async () => {
+    await withMcpContext(async (_response, context) => {
+      const page2 = new McpPage(await context.browser.newPage(), 999, {
+        hasNetworkBlockOrAllowlist: false,
+        locatorClass: Locator,
+      });
+      const page2Emulate = sinon.spy(page2.pptrPage, 'emulateFocusedPage');
+      await page2.init();
+      sinon.assert.notCalled(page2Emulate);
+      context.selectPage(page2);
+      context.selectPage(page2);
+      await new Promise(resolve => setImmediate(resolve));
+      sinon.assert.calledOnceWithExactly(page2Emulate, true);
+
+      const retryPage = new McpPage(await context.browser.newPage(), 1000, {
+        hasNetworkBlockOrAllowlist: false,
+        locatorClass: Locator,
+      });
+      const retryEmulate = sinon
+        .stub(retryPage.pptrPage, 'emulateFocusedPage')
+        .onFirstCall()
+        .rejects(new Error('focus failed'))
+        .onSecondCall()
+        .resolves();
+      await retryPage.init();
+      sinon.assert.notCalled(retryEmulate);
+      context.selectPage(retryPage);
+      await new Promise(resolve => setImmediate(resolve));
+      context.selectPage(retryPage);
+      await new Promise(resolve => setImmediate(resolve));
+      sinon.assert.calledTwice(retryEmulate);
+      page2.dispose();
+      retryPage.dispose();
+    });
   });
 
   it('list pages', async () => {

--- a/tests/ToolHandler.test.ts
+++ b/tests/ToolHandler.test.ts
@@ -47,6 +47,7 @@ describe('ToolHandler', () => {
     const mockContext = sinon.createStubInstance(McpContext);
     const mockPage = sinon.createStubInstance(McpPage);
     mockContext.getSelectedMcpPage.returns(mockPage);
+    mockPage.enableFocusEmulation.resolves();
 
     const toolMutex = new Mutex();
     const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
@@ -64,6 +65,62 @@ describe('ToolHandler', () => {
     await toolHandler.handle({});
 
     assert.strictEqual(mockContext.getSelectedMcpPage.calledOnce, true);
+    assert.strictEqual(mockPage.enableFocusEmulation.calledOnce, true);
+    assert.strictEqual(handlerCalled, true);
+  });
+
+  it('enables focus emulation for pages targeted by page ID', async () => {
+    let handlerCalled = false;
+    const tool: DefinedPageTool = {
+      name: 'page_tool',
+      description: 'A page scoped tool',
+      annotations: {
+        category: ToolCategory.INPUT,
+        readOnlyHint: false,
+      },
+      schema: {},
+      blockedByDialog: false,
+      verifyFilesSchema: [],
+      pageScoped: true,
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    const mockPage = sinon.createStubInstance(McpPage);
+    mockContext.getPageById.withArgs(7).returns(mockPage);
+    let resolveFocus: (() => void) | undefined;
+    mockPage.enableFocusEmulation.returns(
+      new Promise(resolve => {
+        resolveFocus = resolve;
+      }),
+    );
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments(
+      '1.0.0',
+      ['node', 'script.js', '--experimental-page-id-routing'],
+      {CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true'},
+    );
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    assert.strictEqual(toolHandler.shouldRegister, true);
+    const handling = toolHandler.handle({pageId: 7});
+    await new Promise(resolve => setImmediate(resolve));
+    assert.strictEqual(handlerCalled, false);
+    resolveFocus?.();
+    await handling;
+
+    assert.strictEqual(mockContext.getPageById.calledOnceWithExactly(7), true);
+    assert.strictEqual(mockContext.getSelectedMcpPage.called, false);
+    assert.strictEqual(mockPage.enableFocusEmulation.calledOnce, true);
     assert.strictEqual(handlerCalled, true);
   });
 


### PR DESCRIPTION
## Summary

- Defer `emulateFocusedPage(true)` until an `McpPage` is first used instead of applying it to every discovered page during initialization.
- Cover both explicit selection and direct `--experimental-page-id-routing` targets, awaiting the first enable attempt before the page-scoped handler runs.
- Share one in-flight enable promise per page, remember successful enables, and allow a later operation to retry after a protocol failure.
- Keep previously used pages emulated and leave eager target attachment and console/network collection unchanged.

Related to #1921.

## Why

`McpPage.init()` currently enables focused-page emulation for every discovered tab. On a 35-tab profile, that sends 35 focus-emulation commands even though only one page is initially selected. The other 34 calls disable normal background-page throttling for pages the MCP has never used.

This change applies the existing behavior on first use. The initially selected page is still emulated, a page selected later is enabled once, and a page targeted directly by `pageId` is enabled before its first page-scoped operation. A previously used page is not disabled. This preserves shared-browser and multi-agent behavior without eagerly changing never-used tabs.

This is deliberately one narrow part of #1921. It does not change Puppeteer's page attachment, DevTools universe creation, collectors, or page enumeration. PR #2271 proposes a global opt-out flag; this patch instead retains emulation automatically for every used page while avoiding eager calls for unused pages.

## Measurement

The strict evaluator launches real Chrome, connects the built production MCP over CDP, and attributes focus-emulation protocol calls to selected and non-selected targets.

| Revision | Initialization calls, 35 tabs | Calls for non-selected tabs |
| --- | ---: | ---: |
| Current `main` | 35 | 34 |
| This PR | 1 | 0 |

With `--experimental-page-id-routing`, the evaluator also targets an unselected page directly: the first page-scoped call produces exactly one focus-emulation command, and a repeated call produces zero additional commands.

The selection-gated direction was identified while running autoresearch with Weco. The 14-step trajectory, baseline, and evaluated candidates are available in this [public autoresearch run](https://dashboard.weco.ai/share/VX3kq2eqGPwHmq6I4G_srwdTqeSIfZ).

## Validation

- `npm run build`
- `node scripts/test.mjs tests/ToolHandler.test.ts tests/McpContext.test.ts`
- `npm run check-format`
- `npm run typecheck`
- strict real-Chrome evaluator: `focused_page_emulation_nonselected_calls: 34 -> 0`
- strict page-ID gates: first direct use `1` call, repeated use `0` calls
- `git diff --check`

## Page-ID routing compatibility

This remains compatible with the experimental page-ID routing option: a page-scoped request resolves the requested pageId and awaits enableFocusEmulation before the handler runs. select_page follows the same path. The first request for a page sends one enable command and later requests send none. PR #2271's opt-out flag is a separate product choice; this PR keeps emulation for every page that is actually used while avoiding calls for unused pages.