### PR TITLE
fix: paginate page 0 in list_network_requests and list_console_messages

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -346,7 +346,7 @@ export class McpResponse implements Response {
     this.#networkRequestsOptions = {
       include: value,
       pagination:
-        options?.pageSize || options?.pageIdx
+        options?.pageSize !== undefined || options?.pageIdx !== undefined
           ? {
               pageSize: options.pageSize,
               pageIdx: options.pageIdx,
@@ -374,7 +374,7 @@ export class McpResponse implements Response {
     this.#consoleDataOptions = {
       include: value,
       pagination:
-        options?.pageSize || options?.pageIdx
+        options?.pageSize !== undefined || options?.pageIdx !== undefined
           ? {
               pageSize: options.pageSize,
               pageIdx: options.pageIdx,

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -856,6 +856,23 @@ describe('McpResponse network pagination', () => {
     });
   });
 
+  it('paginates the first page when pageIdx is 0 without pageSize', async () => {
+    await withMcpContext(async (response, context) => {
+      const requests = Array.from({length: 30}, (_, idx) =>
+        getMockRequest({method: `GET-${idx}`}),
+      );
+      context.getSelectedMcpPage().getNetworkRequests = () => requests;
+      // pageIdx 0 is a valid page, not "no pagination" — it must apply the
+      // default page size like any other page.
+      response.setIncludeNetworkRequests(true, {pageIdx: 0});
+      const {content} = await response.handle('test', context);
+      const text = getTextContent(content[0]);
+      assert.ok(text.includes('Showing 1-20 of 30 (Page 1 of 2).'));
+      assert.ok(text.includes('Next page: 1'));
+      assert.ok(!text.includes('Previous page:'));
+    });
+  });
+
   it('handles invalid page number by showing first page', async t => {
     await withMcpContext(async (response, context) => {
       const requests = Array.from({length: 5}, () => getMockRequest());


### PR DESCRIPTION
`list_network_requests` and `list_console_messages` treat an explicit `pageIdx: 0` as "no pagination" and dump every result, while `pageIdx: 1` and up paginate correctly.

The guards in `setIncludeNetworkRequests`/`setIncludeConsoleData` build the pagination options with `options?.pageSize || options?.pageIdx`, so a bare `{pageIdx: 0}` collapses to `undefined` — 0 is falsy — and `paginate()` never runs. That's a bit odd since `paginate()` already decides for itself when there's nothing to paginate (`noPaginationOptions` checks `pageSize === undefined && pageIdx === undefined`), so page 0 is a perfectly valid first page there. The memory tools, which pass their options straight through to `paginate()`, handle `pageIdx: 0` fine — only these two guards get it wrong, so an agent walking pages 0, 1, 2… gets the full list on page 0 and a 20-item window from page 1 on.

Switched both guards to an explicit `!== undefined` check so `pageIdx: 0` reaches `paginate()` and gets the default page size like every other page. Both-omitted still short-circuits to the full list, so nothing else changes. Added a regression test for the `{pageIdx: 0}` case.