### PR TITLE
feat: include the CDP targetId in list_pages output

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -1374,12 +1374,17 @@ function createStructuredPage(
     url: string;
     title: string;
     selected: boolean;
+    targetId: string;
     isolatedContext?: string;
   } = {
     id: mcpPage.id,
     url: mcpPage.pptrPage.url(),
     title,
     selected: context.isPageSelected(mcpPage),
+    // CDP target id, stable per tab within a browser session, so clients can
+    // correlate an MCP page to its underlying CDP target.
+    // @ts-expect-error use internal Puppeteer API to get target ID
+    targetId: mcpPage.pptrPage.target()._targetId,
   };
   if (isolatedContextName) {
     entry.isolatedContext = isolatedContextName;

--- a/tests/McpResponse.test.js.snapshot
+++ b/tests/McpResponse.test.js.snapshot
@@ -325,7 +325,8 @@ exports[`McpResponse > list pages 2`] = `
       "id": 1,
       "url": "about:blank",
       "title": "",
-      "selected": true
+      "selected": true,
+      "targetId": "<targetId>"
     }
   ]
 }
@@ -1299,7 +1300,8 @@ exports[`webmcp > includes webmcp tools in list_pages response 2`] = `
       "id": 1,
       "url": "about:blank",
       "title": "My test page",
-      "selected": true
+      "selected": true,
+      "targetId": "<targetId>"
     }
   ],
   "webmcpTools": [
@@ -1332,7 +1334,8 @@ exports[`webmcp > includes webmcp tools in navigate_page response 2`] = `
       "id": 1,
       "url": "about:blank",
       "title": "My test page",
-      "selected": true
+      "selected": true,
+      "targetId": "<targetId>"
     }
   ],
   "webmcpTools": [
@@ -1363,7 +1366,8 @@ exports[`webmcp > includes webmcp tools in select_page response 2`] = `
       "id": 1,
       "url": "about:blank",
       "title": "My test page",
-      "selected": true
+      "selected": true,
+      "targetId": "<targetId>"
     }
   ],
   "webmcpTools": [
@@ -1394,7 +1398,8 @@ exports[`webmcp > list no webmcp tools if experimentalWebmcp is false 2`] = `
       "id": 1,
       "url": "about:blank",
       "title": "My test page",
-      "selected": true
+      "selected": true,
+      "targetId": "<targetId>"
     }
   ]
 }

--- a/tests/tools/pages.test.js.snapshot
+++ b/tests/tools/pages.test.js.snapshot
@@ -1,5 +1,5 @@
 exports[`pages > close_page > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"Note: the previously selected page was closed. Page 1 is now selected.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"pages":[{"id":1,"url":"about:blank","title":"","selected":true}]}}
+{"content":[{"type":"text","text":"Note: the previously selected page was closed. Page 1 is now selected.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"pages":[{"id":1,"url":"about:blank","title":"","selected":true,"targetId":"<targetId>"}]}}
 `;
 
 exports[`pages > list_pages > list pages for extension pages with --category-extensions 1`] = `
@@ -31,21 +31,21 @@ sw-1: chrome-extension://<extension-id>/sw.js
 `;
 
 exports[`pages > list_pages > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"","selected":true}]}}
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"","selected":true,"targetId":"<targetId>"}]}}
 `;
 
 exports[`pages > navigate_page > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"Successfully navigated to data:text/html,<div>Navigated</div>.\\n# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: data:text/html,<div>Navigated</div> [selected]"}],"structuredContent":{"message":"Successfully navigated to data:text/html,<div>Navigated</div>.","dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"data:text/html,<div>Navigated</div>","title":"","selected":true}]}}
+{"content":[{"type":"text","text":"Successfully navigated to data:text/html,<div>Navigated</div>.\\n# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: data:text/html,<div>Navigated</div> [selected]"}],"structuredContent":{"message":"Successfully navigated to data:text/html,<div>Navigated</div>.","dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"data:text/html,<div>Navigated</div>","title":"","selected":true,"targetId":"<targetId>"}]}}
 `;
 
 exports[`pages > new_page with isolatedContext > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank\\n2: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"","selected":false},{"id":2,"url":"about:blank","title":"","selected":true}]}}
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank\\n2: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"","selected":false,"targetId":"<targetId>"},{"id":2,"url":"about:blank","title":"","selected":true,"targetId":"<targetId>"}]}}
 `;
 
 exports[`pages > resize > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"","selected":true}]}}
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"","selected":true,"targetId":"<targetId>"}]}}
 `;
 
 exports[`pages > select_page > when dialog is open 1`] = `
-{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"","selected":true}]}}
+{"content":[{"type":"text","text":"# Open dialog\\nalert: test dialog.\\nCall handle_dialog to handle it before continuing.\\n## Pages\\n1: about:blank [selected]"}],"structuredContent":{"dialog":{"type":"alert","message":"test dialog","defaultValue":""},"pages":[{"id":1,"url":"about:blank","title":"","selected":true,"targetId":"<targetId>"}]}}
 `;

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -22,7 +22,12 @@ import {
   handleDialog,
   getTabId,
 } from '../../src/tools/pages.js';
-import {assertNoServiceWorkerReported, html, withMcpContext} from '../utils.js';
+import {
+  assertNoServiceWorkerReported,
+  html,
+  stabilizeStructuredContent,
+  withMcpContext,
+} from '../utils.js';
 
 const EXTENSION_SW_PATH = path.join(
   import.meta.dirname,
@@ -61,6 +66,46 @@ describe('pages', () => {
         // list_pages should still work even though the selected page is gone.
         await listPages().handler({params: {}}, response, context);
         assert.ok(response.includePages);
+      });
+    });
+    it('includes the CDP targetId for each listed page', async () => {
+      await withMcpContext(async (response, context) => {
+        // A second page, so targetIds must be present and distinct per page.
+        await context.newPage();
+
+        const listPageDef = listPages();
+        await listPageDef.handler({params: {}}, response, context);
+        const result = await response.handle(listPageDef.name, context);
+
+        const pages = (
+          result.structuredContent as {
+            pages: Array<{id: number; targetId: string}>;
+          }
+        ).pages;
+        assert.ok(pages.length >= 2);
+
+        // Every page carries a non-empty, distinct targetId.
+        for (const page of pages) {
+          assert.strictEqual(typeof page.targetId, 'string');
+          assert.ok(page.targetId.length > 0);
+        }
+        assert.strictEqual(
+          new Set(pages.map(p => p.targetId)).size,
+          pages.length,
+        );
+
+        // Each reported targetId resolves to a real CDP page target, checked via
+        // a separate path than the one that produced the output.
+        const pageTargetIds = new Set(
+          context.browser
+            .targets()
+            .filter(t => t.type() === 'page')
+            // @ts-expect-error use internal Puppeteer API to get target ID
+            .map(t => t._targetId as string),
+        );
+        for (const page of pages) {
+          assert.ok(pageTargetIds.has(page.targetId));
+        }
       });
     });
     it(`list pages for extension pages with --category-extensions`, async t => {
@@ -224,7 +269,7 @@ describe('pages', () => {
         await listPages().handler({params: {}}, response, context);
 
         const result = await response.handle('list_pages', context);
-        t.assert.snapshot(JSON.stringify(result));
+        t.assert.snapshot(JSON.stringify(stabilizeStructuredContent(result)));
         await dialog.dismiss();
         await evalPromise;
       });
@@ -405,7 +450,7 @@ describe('pages', () => {
         );
 
         const result = await response.handle('new_page', context);
-        t.assert.snapshot(JSON.stringify(result));
+        t.assert.snapshot(JSON.stringify(stabilizeStructuredContent(result)));
         await dialog.dismiss();
         await evalPromise;
       });
@@ -508,7 +553,7 @@ describe('pages', () => {
         await closePage.handler({params: {pageId: 2}}, response, context);
 
         const result = await response.handle('close_page', context);
-        t.assert.snapshot(JSON.stringify(result));
+        t.assert.snapshot(JSON.stringify(stabilizeStructuredContent(result)));
       });
     });
   });
@@ -618,7 +663,7 @@ describe('pages', () => {
         await selectPage.handler({params: {pageId: 1}}, response, context);
 
         const result = await response.handle('select_page', context);
-        t.assert.snapshot(JSON.stringify(result));
+        t.assert.snapshot(JSON.stringify(stabilizeStructuredContent(result)));
         await dialog.dismiss();
         await evalPromise;
       });
@@ -898,7 +943,7 @@ describe('pages', () => {
         );
 
         const result = await response.handle('navigate_page', context);
-        t.assert.snapshot(JSON.stringify(result));
+        t.assert.snapshot(JSON.stringify(stabilizeStructuredContent(result)));
       });
     });
   });
@@ -1090,7 +1135,7 @@ describe('pages', () => {
         );
 
         const result = await response.handle('resize_page', context);
-        t.assert.snapshot(JSON.stringify(result));
+        t.assert.snapshot(JSON.stringify(stabilizeStructuredContent(result)));
         await dialog.dismiss();
         await evalPromise;
       });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -265,6 +265,8 @@ export function stabilizeStructuredContent(content: unknown): unknown {
     for (const [key, value] of Object.entries(content)) {
       if (key === 'snapshotFilePath' && typeof value === 'string') {
         result[key] = '<file>';
+      } else if (key === 'targetId' && typeof value === 'string') {
+        result[key] = '<targetId>';
       } else {
         result[key] = stabilizeStructuredContent(value);
       }


### PR DESCRIPTION
Closes #2366

Adds each page's CDP `targetId` to `list_pages` output, on the `structuredContent.pages[]` entries. `createStructuredPage()` reads it via the same internal-Puppeteer accessor `PageCollector` already uses (`page.target()._targetId`), so it's additive – `id`/`url`/`title`/`selected` are untouched.

The use case is in #2366 – correlating an MCP page to its CDP target without the fragile `GET /json` + title/url matching a client has to do today. With the id present it's a direct `entry.targetId` lookup.

The test lists pages and checks each `targetId` is distinct, non-empty, and among the real page targets from `browser.targets()` – a separate path than the code under test, so it fails if the value is wrong, not just if the field went missing. `stabilizeStructuredContent` normalizes the non-deterministic id so snapshots stay stable, and the affected snapshots are updated.
