### PR TITLE
test: relaunch a disconnected cached browser in tests

### DIFF
--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {describe, it} from 'node:test';
+
+import type {Browser} from 'puppeteer';
+
+import {withBrowser} from './utils.js';
+
+describe('withBrowser', () => {
+  it('relaunches a cached browser that has disconnected', async () => {
+    let firstBrowser: Browser | undefined;
+    await withBrowser(async browser => {
+      firstBrowser = browser;
+    });
+    assert.ok(firstBrowser);
+
+    // Simulate a browser that died mid-run – the cache still holds the dead handle.
+    await firstBrowser.close();
+    assert.ok(!firstBrowser.connected);
+
+    // The next call with the same options must not reuse the dead browser.
+    let secondBrowser: Browser | undefined;
+    await withBrowser(async browser => {
+      secondBrowser = browser;
+      assert.ok(browser.connected);
+    });
+    assert.notStrictEqual(secondBrowser, firstBrowser);
+  });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -94,6 +94,13 @@ export async function withBrowser(
   const key = JSON.stringify(launchOptions);
 
   let browser = browsers.get(key);
+  // A cached browser can die mid-run (crash, pipe drop, teardown race). Reusing the
+  // dead handle makes every later same-key test fail with `Target closed`, so drop a
+  // disconnected one and let the miss path relaunch it.
+  if (browser && !browser.connected) {
+    browsers.delete(key);
+    browser = undefined;
+  }
   if (!browser) {
     browser = await puppeteer.launch(launchOptions);
     browsers.set(key, browser);


### PR DESCRIPTION
The Windows screenshot flakes in #2137 are `TargetCloseError`s (`Target closed`), which is what you get from reusing a browser that already died.

`withBrowser` (`tests/utils.ts`) caches one browser per `launchOptions` key, but the cache-hit path only checks that an entry exists, not that it's still connected – and nothing evicts a dead one. So a single browser death mid-run (a pipe drop, an OOM, a teardown race) leaves every later same-key test reusing the dead handle, turning one failure into a run of them.

#2205's concurrency limit lowers how often a browser dies; a liveness check on cache hit bounds the blast radius when one still does – a disconnected browser is dropped and relaunched, so a death fails only its own test. Inert on a healthy run, since `connected` only goes false once the connection is actually gone.

The test closes a cached browser and asserts the next `withBrowser` call gets a fresh, connected one – it fails on `main` and passes with the check.
