### PR TITLE
fix: report the tab id in the get_tab_id response

### DIFF
--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -408,6 +408,12 @@ export const getTabId = definePageTool({
   handler: async (request, response, context) => {
     const page = context.getPageById(request.params.pageId);
     const tabId = (page.pptrPage as unknown as CdpPage)._tabId;
+    // Puppeteer returns an empty string when the tab id is not known.
+    if (!tabId) {
+      response.appendResponseLine('The tab ID is not available for this page');
+      return;
+    }
     response.setTabId(tabId);
+    response.appendResponseLine(`Tab ID: ${tabId}`);
   },
 });

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -12,8 +12,6 @@ import type {Dialog} from 'puppeteer-core';
 import sinon from 'sinon';
 
 import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
-import {parseArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
-import {ToolHandler} from '../../src/ToolHandler.js';
 import {
   listPages,
   newPage,
@@ -24,8 +22,6 @@ import {
   handleDialog,
   getTabId,
 } from '../../src/tools/pages.js';
-import type {DefinedPageTool} from '../../src/tools/ToolDefinition.js';
-import {Mutex} from '../../src/utils/Mutex.js';
 import {assertNoServiceWorkerReported, html, withMcpContext} from '../utils.js';
 
 const EXTENSION_SW_PATH = path.join(
@@ -1301,35 +1297,29 @@ describe('pages', () => {
     });
 
     it('reports the tab id when structured content is disabled', async () => {
-      await withMcpContext(async (_response, context) => {
-        const page = context.getSelectedMcpPage().pptrPage;
-        // @ts-expect-error _tabId is internal.
-        const tabId = page._tabId as string;
-        assert.ok(tabId);
-        const serverArgs = parseArguments(
-          '1.0.0',
-          ['node', 'script.js', '--experimentalInteropTools'],
-          {CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true'},
-        );
-        const toolHandler = new ToolHandler(
-          getTabId as unknown as DefinedPageTool,
-          serverArgs,
-          async () => context,
-          new Mutex(),
-        );
-
-        const result = await toolHandler.handle({pageId: 1});
-
-        assert.strictEqual(result.isError, undefined);
-        assert.strictEqual(result.structuredContent, undefined);
-        const text = result.content
-          .map(part => (part.type === 'text' ? part.text : ''))
-          .join('\n');
-        assert.ok(
-          text.includes(tabId),
-          `expected the tab id in the response, got: ${text}`,
-        );
-      });
+      await withMcpContext(
+        async (response, context) => {
+          const page = context.getSelectedMcpPage().pptrPage;
+          // @ts-expect-error _tabId is internal.
+          const tabId = page._tabId as string;
+          assert.ok(tabId);
+          await getTabId.handler(
+            {params: {pageId: 1}, page: context.getSelectedMcpPage()},
+            response,
+            context,
+          );
+          const result = await response.handle('get_tab_id', context);
+          const text = result.content
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('\n');
+          assert.ok(
+            text.includes(tabId),
+            `expected the tab id in the response, got: ${text}`,
+          );
+        },
+        {},
+        {experimentalInteropTools: true, experimentalStructuredContent: false},
+      );
     });
 
     it('reports when the tab id is not available', async () => {

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -12,6 +12,8 @@ import type {Dialog} from 'puppeteer-core';
 import sinon from 'sinon';
 
 import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
+import {parseArguments} from '../../src/bin/chrome-devtools-mcp-cli-options.js';
+import {ToolHandler} from '../../src/ToolHandler.js';
 import {
   listPages,
   newPage,
@@ -22,6 +24,8 @@ import {
   handleDialog,
   getTabId,
 } from '../../src/tools/pages.js';
+import type {DefinedPageTool} from '../../src/tools/ToolDefinition.js';
+import {Mutex} from '../../src/utils/Mutex.js';
 import {assertNoServiceWorkerReported, html, withMcpContext} from '../utils.js';
 
 const EXTENSION_SW_PATH = path.join(
@@ -1282,18 +1286,68 @@ describe('pages', () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedMcpPage().pptrPage;
         // @ts-expect-error _tabId is internal.
-        assert.ok(typeof page._tabId === 'string');
-        // @ts-expect-error _tabId is internal.
-        page._tabId = 'test-tab-id';
+        const tabId = page._tabId as string;
+        assert.ok(tabId);
         await getTabId.handler(
           {params: {pageId: 1}, page: context.getSelectedMcpPage()},
           response,
           context,
         );
         const result = await response.handle('get_tab_id', context);
+        // @ts-expect-error structuredContent is not typed.
+        assert.strictEqual(result.structuredContent.tabId, tabId);
+        assert.deepStrictEqual(response.responseLines, [`Tab ID: ${tabId}`]);
+      });
+    });
+
+    it('reports the tab id when structured content is disabled', async () => {
+      await withMcpContext(async (_response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
         // @ts-expect-error _tabId is internal.
-        assert.strictEqual(result.structuredContent.tabId, 'test-tab-id');
-        assert.deepStrictEqual(response.responseLines, []);
+        const tabId = page._tabId as string;
+        assert.ok(tabId);
+        const serverArgs = parseArguments(
+          '1.0.0',
+          ['node', 'script.js', '--experimentalInteropTools'],
+          {CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true'},
+        );
+        const toolHandler = new ToolHandler(
+          getTabId as unknown as DefinedPageTool,
+          serverArgs,
+          async () => context,
+          new Mutex(),
+        );
+
+        const result = await toolHandler.handle({pageId: 1});
+
+        assert.strictEqual(result.isError, undefined);
+        assert.strictEqual(result.structuredContent, undefined);
+        const text = result.content
+          .map(part => (part.type === 'text' ? part.text : ''))
+          .join('\n');
+        assert.ok(
+          text.includes(tabId),
+          `expected the tab id in the response, got: ${text}`,
+        );
+      });
+    });
+
+    it('reports when the tab id is not available', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        // @ts-expect-error _tabId is internal.
+        page._tabId = '';
+        await getTabId.handler(
+          {params: {pageId: 1}, page: context.getSelectedMcpPage()},
+          response,
+          context,
+        );
+        const result = await response.handle('get_tab_id', context);
+        // @ts-expect-error structuredContent is not typed.
+        assert.strictEqual(result.structuredContent.tabId, undefined);
+        assert.deepStrictEqual(response.responseLines, [
+          'The tab ID is not available for this page',
+        ]);
       });
     });
   });


### PR DESCRIPTION
Follow-up to the `get_tab_id` side-thread in #2366. This doesn't look like a Puppeteer regression — I checked `_tabId` against the pinned puppeteer-core 25.3.0 on real Chrome (launch and connect, `browser.pages()`, `pages(true)`, `newPage()`, with `handleDevToolsAsPage: true`) and it came back populated every time.

What actually happens is that the handler only calls `response.setTabId()`, so the id rides in `structuredContent` and nowhere else — and `ToolHandler` attaches `structuredContent` to the result only when `--experimental-structured-content` is set (ToolHandler.ts:287). The tool itself is gated behind `--experimental-interop-tools`, so turning on just the interop tools gives you an empty response for every page. `src/bin/chrome-devtools.ts` puts `--experimentalStructuredContent` in its default args, which is why it looks fine over the CLI but not when the server is driven over MCP.

That's also why it passes in our test: it stubs `_tabId` and calls `response.handle()` directly, skipping the handler where the gate lives, then asserts `responseLines` is empty — which pins the missing output as expected behaviour.

So the id now goes into the response text like every other tool, and `setTabId` stays for structured consumers. Reverting just the handler change fails the new test with `expected the tab id in the response, got:` and an empty string — the reported symptom. I also handled the empty string Puppeteer documents as "unknown" rather than emitting a bare `Tab ID:`.

pages suite is green (50 tests), ToolHandler suite too.