### PR TITLE
fix: include the tab id in `get_tab_id`'s text response

### DIFF
--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -409,5 +409,6 @@ export const getTabId = definePageTool({
     const page = context.getPageById(request.params.pageId);
     const tabId = (page.pptrPage as unknown as CdpPage)._tabId;
     response.setTabId(tabId);
+    response.appendResponseLine(`Tab ID: ${tabId}`);
   },
 });

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -1293,7 +1293,7 @@ describe('pages', () => {
         const result = await response.handle('get_tab_id', context);
         // @ts-expect-error _tabId is internal.
         assert.strictEqual(result.structuredContent.tabId, 'test-tab-id');
-        assert.deepStrictEqual(response.responseLines, []);
+        assert.deepStrictEqual(response.responseLines, ['Tab ID: test-tab-id']);
       });
     });
   });


### PR DESCRIPTION
As discussed in #2366: `get_tab_id` gates on `--experimentalInteropTools`, but its result only went into `structuredContent`, which is dropped unless `--experimentalStructuredContent` is also set – so with interop alone the tool always returned an empty text response.

This appends a `Tab ID: <id>` line to the text response and keeps `structuredContent.tabId` as-is – `key: value` so it stays trivially parseable.

## Testing

The existing `returns the tab id` test asserted empty `responseLines`, which pinned the old behavior – now it asserts the `Tab ID:` line. Verified end-to-end over stdio with `--experimentalInteropTools` alone: the text response is `Tab ID: <id>` where it was `""` before.
