### PR TITLE
feat: persist CLI startup defaults

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,21 @@ chrome-devtools take_screenshot --filePath screenshot.png
 chrome-devtools stop
 ```
 
+## Startup defaults
+
+You can persist options used to start the daemon in an XDG-compatible configuration file at `$XDG_CONFIG_HOME/chrome-devtools/config.json`, or `~/.config/chrome-devtools/config.json` when `XDG_CONFIG_HOME` is not set
+
+The file contains a JSON object whose keys match the options accepted by `chrome-devtools start`
+
+```json
+{
+  "executablePath": "/usr/bin/chromium",
+  "headless": false
+}
+```
+
+These defaults apply both when a tool command automatically starts the daemon and when `chrome-devtools start` is invoked explicitly. Command-line options override configuration values, which override the built-in defaults
+
 ## Command Usage
 
 The CLI only supports tools available in the MCP server without additional arguments (see [Tool reference](./tool-reference.md)).

--- a/src/bin/chrome-devtools-cli-config.ts
+++ b/src/bin/chrome-devtools-cli-config.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+export function getCliConfigPath(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDirectory = os.homedir(),
+): string {
+  const configHome =
+    env['XDG_CONFIG_HOME'] || path.join(homeDirectory, '.config');
+  return path.join(configHome, 'chrome-devtools', 'config.json');
+}
+
+export function readCliConfig(
+  configPath = getCliConfigPath(),
+): Record<string, unknown> {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(configPath, 'utf8');
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return {};
+    }
+    throw new Error(
+      `Failed to read Chrome DevTools CLI config at ${configPath}: ${getErrorMessage(error)}`,
+      {cause: error},
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse Chrome DevTools CLI config at ${configPath}: ${getErrorMessage(error)}`,
+      {cause: error},
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(
+      `Chrome DevTools CLI config at ${configPath} must contain a JSON object`,
+    );
+  }
+  return parsed;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -24,6 +24,7 @@ import {hideBin, yargs, type CallToolResult} from '../third_party/index.js';
 import {checkForUpdates} from '../utils/check-for-updates.js';
 import {VERSION} from '../version.js';
 
+import {readCliConfig} from './chrome-devtools-cli-config.js';
 import {commands} from './chrome-devtools-cli-options.js';
 import {cliOptions, parseArguments} from './chrome-devtools-mcp-cli-options.js';
 
@@ -60,6 +61,21 @@ startCliOptions.headless!.default = true;
 startCliOptions.isolated!.description =
   'If specified, creates a temporary user-data-dir that is automatically cleaned up after the browser is closed. Defaults to true unless userDataDir is provided.';
 startCliOptions.categoryExtensions!.default = true;
+
+function getConfiguredStartArgs(): string[] {
+  const config = readCliConfig();
+  yargs([])
+    .locale('en')
+    .options(startCliOptions)
+    .config(config)
+    .strict()
+    .exitProcess(false)
+    .fail((message, error) => {
+      throw error ?? new Error(message);
+    })
+    .parseSync();
+  return serializeArgs(cliOptions, config);
+}
 
 const y = yargs(hideBin(process.argv))
   .locale('en') // Force English to ensure error string matching works in .fail, all custom messages we output are in English anyways
@@ -123,6 +139,7 @@ y.command(
   y =>
     y
       .options(startCliOptions)
+      .config(readCliConfig())
       .example(
         '$0 start --browserUrl http://localhost:9222',
         'Start the server connecting to an existing browser',
@@ -263,7 +280,7 @@ for (const [commandName, commandDef] of Object.entries(commands)) {
       const sessionId = argv.sessionId as string;
       try {
         if (!isDaemonRunning(sessionId)) {
-          await start([], sessionId);
+          await start(getConfiguredStartArgs(), sessionId);
         }
 
         const commandArgs: Record<string, unknown> = {};

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -30,6 +30,7 @@ import {hideBin, yargs, type CallToolResult} from '../third_party/index.js';
 import {checkForUpdates} from '../utils/check-for-updates.js';
 import {VERSION} from '../version.js';
 
+import {readCliConfig} from './chrome-devtools-cli-config.js';
 import {commands} from './chrome-devtools-cli-options.js';
 import {cliOptions, parseArguments} from './chrome-devtools-mcp-cli-options.js';
 
@@ -66,6 +67,21 @@ startCliOptions.headless!.default = true;
 startCliOptions.isolated!.description =
   'If specified, creates a temporary user-data-dir that is automatically cleaned up after the browser is closed. Defaults to true unless userDataDir is provided.';
 startCliOptions.categoryExtensions!.default = true;
+
+function getConfiguredStartArgs(argv: Record<string, unknown>): string[] {
+  const config = readCliConfig();
+  yargs([])
+    .locale('en')
+    .options(startCliOptions)
+    .config(config)
+    .strict()
+    .exitProcess(false)
+    .fail((message, error) => {
+      throw error ?? new Error(message);
+    })
+    .parseSync();
+  return serializeArgs(cliOptions, {...config, ...argv});
+}
 
 const y = yargs(hideBin(process.argv))
   .locale('en') // Force English to ensure error string matching works in .fail, all custom messages we output are in English anyways
@@ -133,6 +149,7 @@ y.command(
   y =>
     y
       .options(startCliOptions)
+      .config(readCliConfig())
       .example(
         '$0 start --browserUrl http://localhost:9222',
         'Start the server connecting to an existing browser',
@@ -276,7 +293,7 @@ for (const [commandName, commandDef] of Object.entries(commands)) {
           : Promise.resolve(undefined);
 
         if (!isDaemonRunning(sessionId)) {
-          await start(serializeArgs(cliOptions, argv), sessionId);
+          await start(getConfiguredStartArgs(argv), sessionId);
         }
 
         const commandArgs: Record<string, unknown> = {};

--- a/tests/cli-config.test.ts
+++ b/tests/cli-config.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, describe, it} from 'node:test';
+
+import {
+  getCliConfigPath,
+  readCliConfig,
+} from '../src/bin/chrome-devtools-cli-config.js';
+
+describe('Chrome DevTools CLI config', () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories) {
+      fs.rmSync(directory, {recursive: true, force: true});
+    }
+    temporaryDirectories.length = 0;
+  });
+
+  function createTemporaryDirectory(): string {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chrome-devtools-cli-config-test-'),
+    );
+    temporaryDirectories.push(directory);
+    return directory;
+  }
+
+  it('uses XDG_CONFIG_HOME when set', () => {
+    assert.strictEqual(
+      getCliConfigPath(
+        {XDG_CONFIG_HOME: '/tmp/xdg-config'},
+        '/tmp/home-directory',
+      ),
+      path.join('/tmp/xdg-config', 'chrome-devtools', 'config.json'),
+    );
+  });
+
+  it('falls back to the home config directory', () => {
+    assert.strictEqual(
+      getCliConfigPath({}, '/tmp/home-directory'),
+      path.join(
+        '/tmp/home-directory',
+        '.config',
+        'chrome-devtools',
+        'config.json',
+      ),
+    );
+  });
+
+  it('returns an empty config when the file does not exist', () => {
+    const configPath = path.join(createTemporaryDirectory(), 'config.json');
+    assert.deepStrictEqual(readCliConfig(configPath), {});
+  });
+
+  it('reads a JSON config object', () => {
+    const configPath = path.join(createTemporaryDirectory(), 'config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({executablePath: '/usr/bin/chromium', headless: false}),
+    );
+
+    assert.deepStrictEqual(readCliConfig(configPath), {
+      executablePath: '/usr/bin/chromium',
+      headless: false,
+    });
+  });
+
+  it('rejects invalid JSON', () => {
+    const configPath = path.join(createTemporaryDirectory(), 'config.json');
+    fs.writeFileSync(configPath, '{');
+
+    assert.throws(
+      () => readCliConfig(configPath),
+      /Failed to parse Chrome DevTools CLI config/,
+    );
+  });
+
+  it('rejects a non-object config', () => {
+    const configPath = path.join(createTemporaryDirectory(), 'config.json');
+    fs.writeFileSync(configPath, '[]');
+
+    assert.throws(
+      () => readCliConfig(configPath),
+      /must contain a JSON object/,
+    );
+  });
+});

--- a/tests/e2e/chrome-devtools-commands.test.ts
+++ b/tests/e2e/chrome-devtools-commands.test.ts
@@ -6,6 +6,10 @@
 
 import assert from 'node:assert';
 import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
 import {describe, it, afterEach, beforeEach} from 'node:test';
 
 import {
@@ -50,6 +54,37 @@ describe('chrome-devtools', () => {
     );
 
     await assertDaemonIsRunning(sessionId);
+  });
+
+  it('uses config defaults when automatically starting the daemon', async () => {
+    const configHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chrome-devtools-cli-config-test-'),
+    );
+    const configDirectory = path.join(configHome, 'chrome-devtools');
+    const executablePath = path.join(configHome, 'chromium');
+    fs.mkdirSync(configDirectory);
+    fs.writeFileSync(
+      path.join(configDirectory, 'config.json'),
+      JSON.stringify({executablePath, headless: false}),
+    );
+    const env = {...process.env, XDG_CONFIG_HOME: configHome};
+
+    try {
+      const listPagesResult = await runCli(['list_pages'], sessionId, env);
+      assert.strictEqual(
+        listPagesResult.status,
+        0,
+        `list_pages command failed: ${listPagesResult.stderr}`,
+      );
+
+      const statusResult = await runCli(['status'], sessionId, env);
+      assert.ok(
+        statusResult.stdout.includes(`"--executable-path","${executablePath}"`),
+      );
+      assert.match(statusResult.stdout, /"--no-headless"/);
+    } finally {
+      fs.rmSync(configHome, {recursive: true, force: true});
+    }
   });
 
   it('can take screenshot', async () => {

--- a/tests/e2e/chrome-devtools-commands.test.ts
+++ b/tests/e2e/chrome-devtools-commands.test.ts
@@ -6,6 +6,10 @@
 
 import assert from 'node:assert';
 import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
 import {describe, it, afterEach, beforeEach} from 'node:test';
 
 import {
@@ -50,6 +54,37 @@ describe('chrome-devtools', () => {
     );
 
     await assertDaemonIsRunning(sessionId);
+  });
+
+  it('uses config defaults when automatically starting the daemon', async () => {
+    const configHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chrome-devtools-cli-config-test-'),
+    );
+    const configDirectory = path.join(configHome, 'chrome-devtools');
+    const executablePath = path.join(configHome, 'chromium');
+    fs.mkdirSync(configDirectory);
+    fs.writeFileSync(
+      path.join(configDirectory, 'config.json'),
+      JSON.stringify({executablePath, headless: false}),
+    );
+    const env = {...process.env, XDG_CONFIG_HOME: configHome};
+
+    try {
+      const listPagesResult = await runCli(['list_pages'], sessionId, env);
+      assert.strictEqual(
+        listPagesResult.status,
+        0,
+        `list_pages command failed: ${listPagesResult.stderr}`,
+      );
+
+      const statusResult = await runCli(['status'], sessionId, env);
+      assert.ok(
+        statusResult.stdout.includes(`"--executable-path=${executablePath}"`),
+      );
+      assert.match(statusResult.stdout, /"--no-headless"/);
+    } finally {
+      fs.rmSync(configHome, {recursive: true, force: true});
+    }
   });
 
   it('can take screenshot', async () => {

--- a/tests/e2e/chrome-devtools-start-stop.test.ts
+++ b/tests/e2e/chrome-devtools-start-stop.test.ts
@@ -9,6 +9,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 import {describe, it, afterEach, beforeEach} from 'node:test';
 
 import {
@@ -77,5 +78,37 @@ describe('chrome-devtools', () => {
     );
 
     await assertDaemonIsRunning(sessionId);
+  });
+
+  it('lets command-line options override config defaults', async () => {
+    const configHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chrome-devtools-cli-config-test-'),
+    );
+    const configDirectory = path.join(configHome, 'chrome-devtools');
+    fs.mkdirSync(configDirectory);
+    fs.writeFileSync(
+      path.join(configDirectory, 'config.json'),
+      JSON.stringify({headless: false}),
+    );
+    const env = {...process.env, XDG_CONFIG_HOME: configHome};
+
+    try {
+      const startResult = await runCli(
+        ['start', '--headless=true'],
+        sessionId,
+        env,
+      );
+      assert.strictEqual(
+        startResult.status,
+        0,
+        `start command failed: ${startResult.stderr}`,
+      );
+
+      const statusResult = await runCli(['status'], sessionId, env);
+      assert.match(statusResult.stdout, /"--headless"/);
+      assert.doesNotMatch(statusResult.stdout, /"--no-headless"/);
+    } finally {
+      fs.rmSync(configHome, {recursive: true, force: true});
+    }
   });
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -373,6 +373,7 @@ export const CLI_PATH = path.resolve('build/src/bin/chrome-devtools.js');
 export async function runCli(
   args: string[],
   sessionId?: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<{status: number | null; stdout: string; stderr: string}> {
   return new Promise((resolve, reject) => {
     const finalArgs = [...args];
@@ -380,7 +381,7 @@ export async function runCli(
       finalArgs.push('--sessionId', sessionId);
     }
     const child = spawn('node', [CLI_PATH, ...finalArgs], {
-      env: process.env,
+      env,
     });
     let stdout = '';
     let stderr = '';

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -435,6 +435,7 @@ export const CLI_PATH = path.resolve('build/src/bin/chrome-devtools.js');
 export async function runCli(
   args: string[],
   sessionId?: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<{status: number | null; stdout: string; stderr: string}> {
   return new Promise((resolve, reject) => {
     const finalArgs = [...args];
@@ -442,7 +443,7 @@ export async function runCli(
       finalArgs.push('--sessionId', sessionId);
     }
     const child = spawn('node', [CLI_PATH, ...finalArgs], {
-      env: process.env,
+      env,
     });
     let stdout = '';
     let stderr = '';


### PR DESCRIPTION
## Summary

- load persistent CLI startup defaults from an XDG-compatible configuration file
- apply configured options to automatic daemon startup and explicit `start` commands
- preserve command-line precedence over configuration values
- document the configuration path and format

## Testing

- `npm run format`
- `npm run build`
- `npm run test tests/cli-config.test.ts`
- `npm run test tests/e2e/chrome-devtools-start-stop.test.ts`
- `npm run test tests/e2e/chrome-devtools-commands.test.ts`
- full test suite with local Chromium, with one unrelated request-header ordering snapshot mismatch

Fixes #2388