### PR TITLE
feat: add --visual-cursor to show an animated cursor during input automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,16 @@ The Chrome DevTools MCP server supports the following configuration option:
   - **Type:** string
   - **Default:** `false`
 
+- **`--visualCursor`/ `--visual-cursor`**
+  If specified, shows an animated ghost cursor on the page before mouse actions (click, double click, click at coordinates, drag) so a human observer can follow where the agent is interacting. Defaults to false.
+  - **Type:** boolean
+  - **Default:** `false`
+
+- **`--visualCursorDuration`/ `--visual-cursor-duration`**
+  Duration in milliseconds of the ghost cursor slide animation shown with --visual-cursor. Defaults to 800.
+  - **Type:** number
+  - **Default:** `800`
+
 - **`--proxyServer`/ `--proxy-server`**
   Proxy server configuration for Chrome passed as --proxy-server when launching the browser. See https://www.chromium.org/developers/design-documents/network-settings/ for details.
   - **Type:** string

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -139,6 +139,12 @@ export const cliOptions = {
       };
     },
   },
+  visualCursor: {
+    type: 'boolean',
+    description:
+      'If specified, shows an animated ghost cursor on the page before mouse actions (click, double click, click at coordinates, drag) so a human observer can follow where the agent is interacting. Defaults to false.',
+    default: false,
+  },
   proxyServer: {
     type: 'string',
     description: `Proxy server configuration for Chrome passed as --proxy-server when launching the browser. See https://www.chromium.org/developers/design-documents/network-settings/ for details.`,

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -145,6 +145,23 @@ export const cliOptions = {
       'If specified, shows an animated ghost cursor on the page before mouse actions (click, double click, click at coordinates, drag) so a human observer can follow where the agent is interacting. Defaults to false.',
     default: false,
   },
+  visualCursorDuration: {
+    type: 'number',
+    description:
+      'Duration in milliseconds of the ghost cursor slide animation shown with --visual-cursor. Defaults to 800.',
+    default: 800,
+    coerce: (value: number | undefined) => {
+      if (value === undefined) {
+        return;
+      }
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error(
+          `Invalid visualCursorDuration ${value}. Expected a positive integer.`,
+        );
+      }
+      return value;
+    },
+  },
   proxyServer: {
     type: 'string',
     description: `Proxy server configuration for Chrome passed as --proxy-server when launching the browser. See https://www.chromium.org/developers/design-documents/network-settings/ for details.`,

--- a/src/telemetry/flag_usage_metrics.json
+++ b/src/telemetry/flag_usage_metrics.json
@@ -371,5 +371,17 @@
   {
     "name": "allow_unrestricted_paths",
     "flagType": "boolean"
+  },
+  {
+    "name": "visual_cursor_present",
+    "flagType": "boolean"
+  },
+  {
+    "name": "visual_cursor",
+    "flagType": "boolean"
+  },
+  {
+    "name": "visual_cursor_duration_present",
+    "flagType": "boolean"
   }
 ]

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -134,7 +134,12 @@ export const click = definePageTool(cliArgs => ({
       if (cliArgs?.visualCursor && !shouldSelectNativeOption) {
         const point = await getElementCenterPoint(handle);
         if (point) {
-          await animateCursorTo(request.page.pptrPage, point.x, point.y);
+          await animateCursorTo(
+            request.page.pptrPage,
+            point.x,
+            point.y,
+            cliArgs.visualCursorDuration,
+          );
         }
       }
       const result = await request.page.waitForEventsAfterAction(async () => {
@@ -185,7 +190,12 @@ export const clickAt = definePageTool(cliArgs => ({
   handler: async (request, response) => {
     const page = request.page;
     if (cliArgs?.visualCursor) {
-      await animateCursorTo(page.pptrPage, request.params.x, request.params.y);
+      await animateCursorTo(
+        page.pptrPage,
+        request.params.x,
+        request.params.y,
+        cliArgs.visualCursorDuration,
+      );
     }
     const result = await page.waitForEventsAfterAction(async () => {
       await page.pptrPage.mouse.click(request.params.x, request.params.y, {
@@ -420,7 +430,12 @@ export const drag = definePageTool(cliArgs => ({
       if (cliArgs?.visualCursor) {
         const point = await getElementCenterPoint(fromHandle);
         if (point) {
-          await animateCursorTo(request.page.pptrPage, point.x, point.y);
+          await animateCursorTo(
+            request.page.pptrPage,
+            point.x,
+            point.y,
+            cliArgs.visualCursorDuration,
+          );
         }
       }
       const result = await request.page.waitForEventsAfterAction(async () => {

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -10,6 +10,7 @@ import type {ElementHandle, KeyInput} from '../third_party/index.js';
 import type {TextSnapshotNode} from '../types.js';
 import {parseKey} from '../utils/keyboard.js';
 import {logger} from '../utils/logger.js';
+import {animateCursorTo} from '../visualCursor.js';
 import type {WaitForEventsResult} from '../WaitForHelper.js';
 
 import {ToolCategory} from './categories.js';
@@ -41,6 +42,25 @@ function handleActionError(error: unknown, uid: string) {
       cause: error,
     },
   );
+}
+
+/**
+ * Best-effort center point of an element used to position the visual cursor
+ * before a mouse action. Returns undefined when the element has no layout
+ * box (e.g. it is not visible).
+ */
+async function getElementCenterPoint(
+  handle: ElementHandle<Element>,
+): Promise<{x: number; y: number} | undefined> {
+  try {
+    return await handle.clickablePoint();
+  } catch {
+    const box = await handle.boundingBox();
+    if (!box) {
+      return undefined;
+    }
+    return {x: box.x + box.width / 2, y: box.y + box.height / 2};
+  }
 }
 
 async function selectNativeSelectOption(handle: ElementHandle<Element>) {
@@ -86,7 +106,7 @@ async function selectNativeSelectOption(handle: ElementHandle<Element>) {
   }
 }
 
-export const click = definePageTool({
+export const click = definePageTool(cliArgs => ({
   name: 'click',
   description: `Clicks on the provided element`,
   annotations: {
@@ -111,6 +131,12 @@ export const click = definePageTool({
     const shouldSelectNativeOption =
       !request.params.dblClick && aXNode?.role === 'option';
     try {
+      if (cliArgs?.visualCursor && !shouldSelectNativeOption) {
+        const point = await getElementCenterPoint(handle);
+        if (point) {
+          await animateCursorTo(request.page.pptrPage, point.x, point.y);
+        }
+      }
       const result = await request.page.waitForEventsAfterAction(async () => {
         if (
           shouldSelectNativeOption &&
@@ -138,9 +164,9 @@ export const click = definePageTool({
       void handle.dispose();
     }
   },
-});
+}));
 
-export const clickAt = definePageTool({
+export const clickAt = definePageTool(cliArgs => ({
   name: 'click_at',
   description: `Clicks at the provided coordinates`,
   annotations: {
@@ -158,6 +184,9 @@ export const clickAt = definePageTool({
   verifyFilesSchema: [],
   handler: async (request, response) => {
     const page = request.page;
+    if (cliArgs?.visualCursor) {
+      await animateCursorTo(page.pptrPage, request.params.x, request.params.y);
+    }
     const result = await page.waitForEventsAfterAction(async () => {
       await page.pptrPage.mouse.click(request.params.x, request.params.y, {
         count: request.params.dblClick ? 2 : 1,
@@ -173,7 +202,7 @@ export const clickAt = definePageTool({
       response.includeSnapshot();
     }
   },
-});
+}));
 
 export const hover = definePageTool({
   name: 'hover',
@@ -368,7 +397,7 @@ export const typeText = definePageTool({
   },
 });
 
-export const drag = definePageTool({
+export const drag = definePageTool(cliArgs => ({
   name: 'drag',
   description: `Drag an element onto another element`,
   annotations: {
@@ -388,6 +417,12 @@ export const drag = definePageTool({
     );
     const toHandle = await request.page.getElementByUid(request.params.to_uid);
     try {
+      if (cliArgs?.visualCursor) {
+        const point = await getElementCenterPoint(fromHandle);
+        if (point) {
+          await animateCursorTo(request.page.pptrPage, point.x, point.y);
+        }
+      }
       const result = await request.page.waitForEventsAfterAction(async () => {
         await fromHandle.drag(toHandle);
         await new Promise(resolve => setTimeout(resolve, 50));
@@ -403,7 +438,7 @@ export const drag = definePageTool({
       void toHandle.dispose();
     }
   },
-});
+}));
 
 export const fillForm = definePageTool({
   name: 'fill_form',

--- a/src/visualCursor.ts
+++ b/src/visualCursor.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {Page} from './third_party/index.js';
+import {logger} from './utils/logger.js';
+
+/**
+ * Blue arrow cursor shown on the page when the --visual-cursor flag is
+ * enabled, so a human observer can follow where the agent interacts.
+ */
+export const CURSOR_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24"><path d="M5 3l14 9-6.5 1.2L9 19.5z" fill="#1f6feb" stroke="#ffffff" stroke-width="1.5" stroke-linejoin="round"/></svg>';
+
+// Duration of the cursor slide animation in milliseconds. Kept in sync with
+// the CSS transition inside VISUAL_CURSOR_INJECTION_SCRIPT.
+export const CURSOR_MOVE_DURATION_MS = 350;
+
+/**
+ * Idempotent script injected into pages. It creates a fixed-position ghost
+ * cursor element and exposes two helpers on `window`:
+ * - `__ghostCursorMove(x, y)`: smoothly slides the cursor to the given
+ *   viewport coordinates and resolves once the transition finished.
+ * - `__ghostCursorRipple()`: shows an expanding ripple at the current cursor
+ *   position to highlight the click point.
+ */
+export const VISUAL_CURSOR_INJECTION_SCRIPT = `(() => {
+  if (window.__ghostCursorInstalled) {
+    return;
+  }
+  window.__ghostCursorInstalled = true;
+
+  const cursor = document.createElement('div');
+  cursor.id = '__ghost-cursor';
+  cursor.innerHTML = ${JSON.stringify(CURSOR_SVG)};
+  Object.assign(cursor.style, {
+    position: 'fixed',
+    left: '80px',
+    top: '200px',
+    zIndex: '2147483647',
+    pointerEvents: 'none',
+    filter: 'drop-shadow(0 2px 6px rgba(0,0,0,.5))',
+    transition:
+      'left ${CURSOR_MOVE_DURATION_MS}ms cubic-bezier(.33,.9,.25,1), top ${CURSOR_MOVE_DURATION_MS}ms cubic-bezier(.33,.9,.25,1)',
+  });
+  // At document-start the DOM may not exist yet, so defer mounting until the
+  // root element is available.
+  const mountCursor = () => {
+    if (!cursor.isConnected) {
+      (document.body || document.documentElement).appendChild(cursor);
+    }
+  };
+  if (document.documentElement) {
+    mountCursor();
+  } else {
+    document.addEventListener('DOMContentLoaded', mountCursor, {once: true});
+  }
+
+  window.__ghostCursorPos = {x: 80, y: 200};
+
+  window.__ghostCursorMove = (x, y) => {
+    return new Promise(resolve => {
+      window.__ghostCursorPos = {x, y};
+      let settled = false;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cursor.removeEventListener('transitionend', onTransitionEnd);
+        resolve();
+      };
+      const onTransitionEnd = () => {
+        finish();
+      };
+      cursor.addEventListener('transitionend', onTransitionEnd);
+      // Fallback in case the transition event never fires (e.g. the page is
+      // hidden and transitions are throttled).
+      setTimeout(finish, ${CURSOR_MOVE_DURATION_MS} + 50);
+      cursor.style.left = x + 'px';
+      cursor.style.top = y + 'px';
+    });
+  };
+
+  window.__ghostCursorRipple = () => {
+    const pos = window.__ghostCursorPos;
+    const ripple = document.createElement('div');
+    Object.assign(ripple.style, {
+      position: 'fixed',
+      left: pos.x - 16 + 'px',
+      top: pos.y - 16 + 'px',
+      width: '32px',
+      height: '32px',
+      borderRadius: '50%',
+      border: '4px solid #1f6feb',
+      background: 'rgba(31,111,235,.18)',
+      zIndex: '2147483647',
+      pointerEvents: 'none',
+      transform: 'scale(1)',
+      opacity: '1',
+      transition: 'transform 500ms ease-out, opacity 500ms ease-out',
+    });
+    (document.body || document.documentElement).appendChild(ripple);
+    requestAnimationFrame(() => {
+      ripple.style.transform = 'scale(2.2)';
+      ripple.style.opacity = '0';
+    });
+    setTimeout(() => {
+      ripple.remove();
+    }, 500);
+  };
+})();`;
+
+interface GhostCursorWindow {
+  __ghostCursorMove?: (x: number, y: number) => Promise<void>;
+  __ghostCursorRipple?: () => void;
+}
+
+// Tracks pages that already have the injection script registered via
+// evaluateOnNewDocument, so it is only registered once per page.
+const registeredPages = new WeakSet<Page>();
+
+/**
+ * Registers the ghost cursor injection script on the page so it is
+ * re-installed after every navigation, and injects it into the current
+ * document right away. Safe to call multiple times for the same page.
+ */
+export async function ensureVisualCursor(page: Page): Promise<void> {
+  if (!registeredPages.has(page)) {
+    await page.evaluateOnNewDocument(VISUAL_CURSOR_INJECTION_SCRIPT);
+    registeredPages.add(page);
+  }
+  // The in-page script itself is idempotent, so re-evaluating it for the
+  // current document is safe.
+  await page.evaluate(VISUAL_CURSOR_INJECTION_SCRIPT);
+}
+
+/**
+ * Slides the ghost cursor to the target coordinates, waits for the move to
+ * finish and then shows a click ripple. Any failure (e.g. CSP restrictions,
+ * a navigation in flight, a closed page) is swallowed so that the actual
+ * input action is never affected.
+ */
+export async function animateCursorTo(
+  page: Page,
+  x: number,
+  y: number,
+): Promise<void> {
+  try {
+    await ensureVisualCursor(page);
+    await page.evaluate(
+      (targetX, targetY) => {
+        return (window as unknown as GhostCursorWindow).__ghostCursorMove?.(
+          targetX,
+          targetY,
+        );
+      },
+      x,
+      y,
+    );
+    await page.evaluate(() => {
+      (window as unknown as GhostCursorWindow).__ghostCursorRipple?.();
+    });
+  } catch (error) {
+    logger?.('visual cursor animation failed', error);
+  }
+}

--- a/src/visualCursor.ts
+++ b/src/visualCursor.ts
@@ -14,19 +14,27 @@ import {logger} from './utils/logger.js';
 export const CURSOR_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24"><path d="M5 3l14 9-6.5 1.2L9 19.5z" fill="#1f6feb" stroke="#ffffff" stroke-width="1.5" stroke-linejoin="round"/></svg>';
 
-// Duration of the cursor slide animation in milliseconds. Kept in sync with
-// the CSS transition inside VISUAL_CURSOR_INJECTION_SCRIPT.
-export const CURSOR_MOVE_DURATION_MS = 350;
+/**
+ * Default duration of the cursor slide animation in milliseconds. Can be
+ * overridden with the --visual-cursor-duration CLI flag.
+ */
+export const DEFAULT_VISUAL_CURSOR_DURATION_MS = 800;
 
 /**
- * Idempotent script injected into pages. It creates a fixed-position ghost
- * cursor element and exposes two helpers on `window`:
+ * Builds the idempotent script injected into pages. It creates a
+ * fixed-position ghost cursor element and exposes two helpers on `window`:
  * - `__ghostCursorMove(x, y)`: smoothly slides the cursor to the given
  *   viewport coordinates and resolves once the transition finished.
  * - `__ghostCursorRipple()`: shows an expanding ripple at the current cursor
  *   position to highlight the click point.
+ *
+ * @param durationMs Duration of the slide animation (and the upper bound of
+ * the wait in `__ghostCursorMove`).
  */
-export const VISUAL_CURSOR_INJECTION_SCRIPT = `(() => {
+export function buildVisualCursorInjectionScript(
+  durationMs: number = DEFAULT_VISUAL_CURSOR_DURATION_MS,
+): string {
+  return `(() => {
   if (window.__ghostCursorInstalled) {
     return;
   }
@@ -43,7 +51,7 @@ export const VISUAL_CURSOR_INJECTION_SCRIPT = `(() => {
     pointerEvents: 'none',
     filter: 'drop-shadow(0 2px 6px rgba(0,0,0,.5))',
     transition:
-      'left ${CURSOR_MOVE_DURATION_MS}ms cubic-bezier(.33,.9,.25,1), top ${CURSOR_MOVE_DURATION_MS}ms cubic-bezier(.33,.9,.25,1)',
+      'left ${durationMs}ms cubic-bezier(.33,.9,.25,1), top ${durationMs}ms cubic-bezier(.33,.9,.25,1)',
   });
   // At document-start the DOM may not exist yet, so defer mounting until the
   // root element is available.
@@ -78,7 +86,7 @@ export const VISUAL_CURSOR_INJECTION_SCRIPT = `(() => {
       cursor.addEventListener('transitionend', onTransitionEnd);
       // Fallback in case the transition event never fires (e.g. the page is
       // hidden and transitions are throttled).
-      setTimeout(finish, ${CURSOR_MOVE_DURATION_MS} + 50);
+      setTimeout(finish, ${durationMs} + 50);
       cursor.style.left = x + 'px';
       cursor.style.top = y + 'px';
     });
@@ -112,6 +120,7 @@ export const VISUAL_CURSOR_INJECTION_SCRIPT = `(() => {
     }, 500);
   };
 })();`;
+}
 
 interface GhostCursorWindow {
   __ghostCursorMove?: (x: number, y: number) => Promise<void>;
@@ -127,29 +136,36 @@ const registeredPages = new WeakSet<Page>();
  * re-installed after every navigation, and injects it into the current
  * document right away. Safe to call multiple times for the same page.
  */
-export async function ensureVisualCursor(page: Page): Promise<void> {
+export async function ensureVisualCursor(
+  page: Page,
+  durationMs: number = DEFAULT_VISUAL_CURSOR_DURATION_MS,
+): Promise<void> {
   if (!registeredPages.has(page)) {
-    await page.evaluateOnNewDocument(VISUAL_CURSOR_INJECTION_SCRIPT);
+    await page.evaluateOnNewDocument(
+      buildVisualCursorInjectionScript(durationMs),
+    );
     registeredPages.add(page);
   }
   // The in-page script itself is idempotent, so re-evaluating it for the
   // current document is safe.
-  await page.evaluate(VISUAL_CURSOR_INJECTION_SCRIPT);
+  await page.evaluate(buildVisualCursorInjectionScript(durationMs));
 }
 
 /**
  * Slides the ghost cursor to the target coordinates, waits for the move to
- * finish and then shows a click ripple. Any failure (e.g. CSP restrictions,
- * a navigation in flight, a closed page) is swallowed so that the actual
- * input action is never affected.
+ * finish and then shows a click ripple. The ripple is fire-and-forget, so the
+ * only added latency is the slide animation itself. Any failure (e.g. CSP
+ * restrictions, a navigation in flight, a closed page) is swallowed so that
+ * the actual input action is never affected.
  */
 export async function animateCursorTo(
   page: Page,
   x: number,
   y: number,
+  durationMs: number = DEFAULT_VISUAL_CURSOR_DURATION_MS,
 ): Promise<void> {
   try {
-    await ensureVisualCursor(page);
+    await ensureVisualCursor(page, durationMs);
     await page.evaluate(
       (targetX, targetY) => {
         return (window as unknown as GhostCursorWindow).__ghostCursorMove?.(

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -31,6 +31,8 @@ describe('cli args parsing', () => {
     redactNetworkHeaders: false,
     'allow-unrestricted-paths': false,
     allowUnrestrictedPaths: false,
+    'visual-cursor': false,
+    visualCursor: false,
   };
 
   it('parses with default args', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -33,6 +33,8 @@ describe('cli args parsing', () => {
     allowUnrestrictedPaths: false,
     'visual-cursor': false,
     visualCursor: false,
+    'visual-cursor-duration': 800,
+    visualCursorDuration: 800,
   };
 
   it('parses with default args', async () => {

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -15,19 +15,23 @@ import type {ParsedArguments} from '../../src/bin/chrome-devtools-mcp-cli-option
 import {McpResponse} from '../../src/McpResponse.js';
 import {TextSnapshot} from '../../src/TextSnapshot.js';
 import {
-  click,
+  click as clickFactory,
   hover,
   fill,
-  drag,
+  drag as dragFactory,
   fillForm,
   uploadFile,
   pressKey,
-  clickAt,
+  clickAt as clickAtFactory,
   typeText,
 } from '../../src/tools/input.js';
 import {parseKey} from '../../src/utils/keyboard.js';
 import {serverHooks} from '../server.js';
 import {html, withMcpContext, getTextContent} from '../utils.js';
+
+const click = clickFactory({} as ParsedArguments);
+const clickAt = clickAtFactory({} as ParsedArguments);
+const drag = dragFactory({} as ParsedArguments);
 
 describe('input', () => {
   const server = serverHooks();

--- a/tests/visualCursor.test.ts
+++ b/tests/visualCursor.test.ts
@@ -1,0 +1,246 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {describe, it} from 'node:test';
+
+import {
+  parseArguments,
+  type ParsedArguments,
+} from '../src/bin/chrome-devtools-mcp-cli-options.js';
+import {TextSnapshot} from '../src/TextSnapshot.js';
+import {click, clickAt} from '../src/tools/input.js';
+import {
+  animateCursorTo,
+  CURSOR_MOVE_DURATION_MS,
+  ensureVisualCursor,
+  VISUAL_CURSOR_INJECTION_SCRIPT,
+} from '../src/visualCursor.js';
+
+import {html, withMcpContext} from './utils.js';
+
+interface GhostCursorTestWindow {
+  __ghostCursorInstalled?: boolean;
+  __ghostCursorMove?: (x: number, y: number) => Promise<void>;
+  __ghostCursorRipple?: () => void;
+}
+
+describe('visualCursor', () => {
+  describe('--visual-cursor CLI flag', () => {
+    it('defaults to false', () => {
+      const args = parseArguments('1.0.0', ['node', 'main.js'], {});
+      assert.strictEqual(args.visualCursor, false);
+    });
+
+    it('parses --visual-cursor', () => {
+      const args = parseArguments(
+        '1.0.0',
+        ['node', 'main.js', '--visual-cursor'],
+        {},
+      );
+      assert.strictEqual(args.visualCursor, true);
+    });
+  });
+
+  describe('injection script', () => {
+    it('exposes the ghost cursor helpers on window', () => {
+      assert.ok(
+        VISUAL_CURSOR_INJECTION_SCRIPT.includes('__ghostCursorInstalled'),
+      );
+      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('__ghostCursorMove'));
+      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('__ghostCursorRipple'));
+    });
+
+    it('renders a non-interactive cursor on top of the page', () => {
+      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('2147483647'));
+      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('pointerEvents'));
+      assert.ok(
+        VISUAL_CURSOR_INJECTION_SCRIPT.includes(
+          `${CURSOR_MOVE_DURATION_MS}ms cubic-bezier(.33,.9,.25,1)`,
+        ),
+      );
+    });
+
+    it('embeds the blue cursor svg and ripple styles', () => {
+      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('1f6feb'));
+      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('scale(2.2)'));
+    });
+  });
+
+  describe('ensureVisualCursor', () => {
+    it('installs the cursor and is idempotent', async () => {
+      await withMcpContext(async (_response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(html`<button>test</button>`);
+        await ensureVisualCursor(page);
+        await ensureVisualCursor(page);
+        const state = await page.evaluate(() => {
+          const win = window as unknown as GhostCursorTestWindow;
+          return {
+            installed: win.__ghostCursorInstalled === true,
+            moveType: typeof win.__ghostCursorMove,
+            rippleType: typeof win.__ghostCursorRipple,
+            cursorCount: document.querySelectorAll('#__ghost-cursor').length,
+          };
+        });
+        assert.deepStrictEqual(state, {
+          installed: true,
+          moveType: 'function',
+          rippleType: 'function',
+          cursorCount: 1,
+        });
+      });
+    });
+
+    it('re-installs the cursor after a navigation', async () => {
+      await withMcpContext(async (_response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(html`<button>test</button>`);
+        await ensureVisualCursor(page);
+        // A real navigation creates a new document which re-runs the
+        // injection script registered via evaluateOnNewDocument.
+        await page.reload();
+        const cursorCount = await page.evaluate(() => {
+          return document.querySelectorAll('#__ghost-cursor').length;
+        });
+        assert.strictEqual(cursorCount, 1);
+      });
+    });
+  });
+
+  describe('animateCursorTo', () => {
+    it('moves the cursor to the target coordinates and shows a ripple', async () => {
+      await withMcpContext(async (_response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(html`<button>test</button>`);
+        await animateCursorTo(page, 120, 130);
+        const state = await page.evaluate(() => {
+          const cursor = document.getElementById('__ghost-cursor');
+          const ripples = [...document.querySelectorAll('div')].filter(el => {
+            return el.style.borderRadius === '50%';
+          });
+          return {
+            left: cursor?.style.left,
+            top: cursor?.style.top,
+            rippleCount: ripples.length,
+          };
+        });
+        assert.deepStrictEqual(state, {
+          left: '120px',
+          top: '130px',
+          rippleCount: 1,
+        });
+      });
+    });
+
+    it('silently degrades when the page is gone', async () => {
+      await withMcpContext(async (_response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.close();
+        // Must not throw even though the page is closed.
+        await animateCursorTo(page, 10, 10);
+      });
+    });
+  });
+
+  describe('input tools integration', () => {
+    it('click shows the cursor before clicking when the flag is on', async () => {
+      const clickWithCursor = click({visualCursor: true} as ParsedArguments);
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(
+          html`<button onclick="this.innerText = 'clicked';">test</button>`,
+        );
+        context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
+          context.getSelectedMcpPage(),
+        );
+        await clickWithCursor.handler(
+          {
+            params: {
+              uid: '1_1',
+            },
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+        assert.strictEqual(
+          response.responseLines[0],
+          'Successfully clicked on the element',
+        );
+        assert.ok(await page.$('text/clicked'));
+        assert.ok(await page.$('#__ghost-cursor'));
+      });
+    });
+
+    it('click does not show the cursor when the flag is off', async () => {
+      const clickWithoutCursor = click({} as ParsedArguments);
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(
+          html`<button onclick="this.innerText = 'clicked';">test</button>`,
+        );
+        context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
+          context.getSelectedMcpPage(),
+        );
+        await clickWithoutCursor.handler(
+          {
+            params: {
+              uid: '1_1',
+            },
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+        assert.strictEqual(
+          response.responseLines[0],
+          'Successfully clicked on the element',
+        );
+        assert.ok(await page.$('text/clicked'));
+        assert.strictEqual(await page.$('#__ghost-cursor'), null);
+      });
+    });
+
+    it('click_at shows the cursor at the target coordinates', async () => {
+      const clickAtWithCursor = clickAt({
+        visualCursor: true,
+      } as ParsedArguments);
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(
+          html`<button
+            style="position: fixed; left: 100px; top: 100px; width: 50px; height: 50px;"
+            onclick="this.innerText = 'clicked';"
+          >
+            test
+          </button>`,
+        );
+        await clickAtWithCursor.handler(
+          {
+            params: {
+              x: 110,
+              y: 110,
+            },
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+        assert.strictEqual(
+          response.responseLines[0],
+          'Successfully clicked at the coordinates',
+        );
+        assert.ok(await page.$('text/clicked'));
+        const position = await page.evaluate(() => {
+          const cursor = document.getElementById('__ghost-cursor');
+          return {left: cursor?.style.left, top: cursor?.style.top};
+        });
+        assert.deepStrictEqual(position, {left: '110px', top: '110px'});
+      });
+    });
+  });
+});

--- a/tests/visualCursor.test.ts
+++ b/tests/visualCursor.test.ts
@@ -15,9 +15,9 @@ import {TextSnapshot} from '../src/TextSnapshot.js';
 import {click, clickAt} from '../src/tools/input.js';
 import {
   animateCursorTo,
-  CURSOR_MOVE_DURATION_MS,
+  buildVisualCursorInjectionScript,
+  DEFAULT_VISUAL_CURSOR_DURATION_MS,
   ensureVisualCursor,
-  VISUAL_CURSOR_INJECTION_SCRIPT,
 } from '../src/visualCursor.js';
 
 import {html, withMcpContext} from './utils.js';
@@ -45,28 +45,56 @@ describe('visualCursor', () => {
     });
   });
 
+  describe('--visual-cursor-duration CLI flag', () => {
+    it('defaults to 800', () => {
+      const args = parseArguments('1.0.0', ['node', 'main.js'], {});
+      assert.strictEqual(args.visualCursorDuration, 800);
+    });
+
+    it('parses --visual-cursor-duration', () => {
+      const args = parseArguments(
+        '1.0.0',
+        ['node', 'main.js', '--visual-cursor-duration', '500'],
+        {},
+      );
+      assert.strictEqual(args.visualCursorDuration, 500);
+    });
+  });
+
   describe('injection script', () => {
     it('exposes the ghost cursor helpers on window', () => {
-      assert.ok(
-        VISUAL_CURSOR_INJECTION_SCRIPT.includes('__ghostCursorInstalled'),
-      );
-      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('__ghostCursorMove'));
-      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('__ghostCursorRipple'));
+      const script = buildVisualCursorInjectionScript();
+      assert.ok(script.includes('__ghostCursorInstalled'));
+      assert.ok(script.includes('__ghostCursorMove'));
+      assert.ok(script.includes('__ghostCursorRipple'));
     });
 
     it('renders a non-interactive cursor on top of the page', () => {
-      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('2147483647'));
-      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('pointerEvents'));
-      assert.ok(
-        VISUAL_CURSOR_INJECTION_SCRIPT.includes(
-          `${CURSOR_MOVE_DURATION_MS}ms cubic-bezier(.33,.9,.25,1)`,
-        ),
-      );
+      const script = buildVisualCursorInjectionScript();
+      assert.ok(script.includes('2147483647'));
+      assert.ok(script.includes('pointerEvents'));
+    });
+
+    it('uses the default duration of 800ms', () => {
+      assert.strictEqual(DEFAULT_VISUAL_CURSOR_DURATION_MS, 800);
+      const script = buildVisualCursorInjectionScript();
+      assert.ok(script.includes('800ms cubic-bezier(.33,.9,.25,1)'));
+      // The fallback timeout in __ghostCursorMove is the duration plus a
+      // small buffer.
+      assert.ok(script.includes('setTimeout(finish, 800 + 50)'));
+    });
+
+    it('embeds a custom duration', () => {
+      const script = buildVisualCursorInjectionScript(1200);
+      assert.ok(script.includes('1200ms cubic-bezier(.33,.9,.25,1)'));
+      assert.ok(script.includes('setTimeout(finish, 1200 + 50)'));
+      assert.ok(!script.includes('800ms'));
     });
 
     it('embeds the blue cursor svg and ripple styles', () => {
-      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('1f6feb'));
-      assert.ok(VISUAL_CURSOR_INJECTION_SCRIPT.includes('scale(2.2)'));
+      const script = buildVisualCursorInjectionScript();
+      assert.ok(script.includes('1f6feb'));
+      assert.ok(script.includes('scale(2.2)'));
     });
   });
 
@@ -133,6 +161,20 @@ describe('visualCursor', () => {
           top: '130px',
           rippleCount: 1,
         });
+      });
+    });
+
+    it('applies a custom duration to the cursor transition', async () => {
+      await withMcpContext(async (_response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(html`<button>test</button>`);
+        await animateCursorTo(page, 50, 60, 100);
+        const transition = await page.evaluate(() => {
+          return document.getElementById('__ghost-cursor')?.style.transition;
+        });
+        // The browser normalizes the transition shorthand (e.g. adds leading
+        // zeros), so only assert on the duration itself.
+        assert.ok(transition?.includes('100ms'));
       });
     });
 


### PR DESCRIPTION
## Motivation

When an agent drives a real (headed) Chrome instance, all input is injected at the protocol level, so the OS cursor never moves and a human watching the browser cannot tell where the agent is clicking. Other agent harnesses solve this with a visible cursor overlay; chrome-devtools-mcp currently has nothing similar. This makes supervised/demo sessions hard to follow.

## What this PR does

Adds an opt-in `--visual-cursor` flag. When enabled, mouse-based input tools (`click`, `dblClick`, `click_at`, `drag`) animate a ghost cursor on the page before acting:

- The cursor smoothly slides from its current position to the target point (default 800 ms, configurable via `--visual-cursor-duration <ms>`).
- An expanding ripple marks the click point.
- The cursor is injected with `Page.addScriptToEvaluateOnNewDocument`, so it survives navigations.
- Everything is wrapped in silent fallbacks: if injection or animation fails (CSP, navigation in flight, closed page), the real input action is unaffected.
- Flag off (default): zero behavioral or latency change.

## Implementation

- `src/visualCursor.ts`: injection script builder (parameterized by duration), idempotent `ensureVisualCursor()`, and `animateCursorTo()`.
- `src/tools/input.ts`: `click`/`clickAt`/`drag` resolve the target point (`clickablePoint()` with a `boundingBox()` center fallback) and call `animateCursorTo()` before the real action when the flag is on. Keyboard-only tools (`fill`, `press_key`, `type_text`) are untouched, as is the native `<select>` option path.
- Docs regenerated with `npm run gen`.

## Testing

- New `tests/visualCursor.test.ts` (12+ tests): flag parsing, injection script content (default and custom duration), idempotent ensure, re-injection after navigation, move + ripple behavior, silent degradation on closed pages, end-to-end click behavior with the flag on/off.
- `npm run build`, `npm run typecheck`, `npm run format` and `npm test` pass (one pre-existing environment-dependent failure in `tests/tools/screenshot.test.ts` "Page is too large" also fails on a clean `main`).
- Manually verified on headed Chrome 150 (`--autoConnect --visual-cursor`): cursor glides to targets across clicks and persists through navigations.