### PR TITLE
fix: preserve browserUrl path prefix

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -44,6 +44,40 @@ function makeTargetFilter(enableExtensions = false) {
   };
 }
 
+function browserJsonVersionEndpoint(browserURL: string): string {
+  const endpointURL = new URL(browserURL);
+  const pathname = endpointURL.pathname.endsWith('/')
+    ? endpointURL.pathname
+    : `${endpointURL.pathname}/`;
+  endpointURL.pathname = `${pathname}json/version`;
+  endpointURL.search = '';
+  endpointURL.hash = '';
+  return endpointURL.toString();
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export async function resolveBrowserWSEndpoint(
+  browserURL: string,
+): Promise<string> {
+  const endpointURL = browserJsonVersionEndpoint(browserURL);
+  const response = await fetch(endpointURL);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch browser webSocket URL from ${endpointURL}: HTTP ${response.status}`,
+    );
+  }
+
+  const payload: unknown = await response.json();
+  if (!isObject(payload) || typeof payload.webSocketDebuggerUrl !== 'string') {
+    throw new Error(`No webSocketDebuggerUrl found at ${endpointURL}`);
+  }
+
+  return payload.webSocketDebuggerUrl;
+}
+
 export async function ensureBrowserConnected(options: {
   browserURL?: string;
   wsEndpoint?: string;
@@ -75,7 +109,9 @@ export async function ensureBrowserConnected(options: {
       connectOptions.headers = options.wsHeaders;
     }
   } else if (options.browserURL) {
-    connectOptions.browserURL = options.browserURL;
+    connectOptions.browserWSEndpoint = await resolveBrowserWSEndpoint(
+      options.browserURL,
+    );
   } else if (channel || options.userDataDir) {
     const userDataDir = options.userDataDir;
     if (userDataDir) {

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -11,7 +11,12 @@ import {describe, it} from 'node:test';
 
 import {executablePath} from 'puppeteer';
 
-import {detectDisplay, ensureBrowserConnected, launch} from '../src/browser.js';
+import {
+  detectDisplay,
+  ensureBrowserConnected,
+  launch,
+  resolveBrowserWSEndpoint,
+} from '../src/browser.js';
 import type {Browser} from '../src/third_party/index.js';
 
 import {serverHooks} from './server.js';
@@ -52,8 +57,127 @@ async function runWithRetry(fn: () => Promise<void>) {
 }
 
 describe('browser', () => {
+  const server = serverHooks();
+
   it('detects display does not crash', () => {
     detectDisplay();
+  });
+
+  it('discovers an existing browser behind a path prefix', async () => {
+    const wsEndpoint = 'ws://localhost:9222/devtools/browser/abc123';
+    server.addRoute('/t/abc123/json/version', (_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({webSocketDebuggerUrl: wsEndpoint}));
+    });
+
+    assert.strictEqual(
+      await resolveBrowserWSEndpoint(`${server.baseUrl}/t/abc123`),
+      wsEndpoint,
+    );
+  });
+
+  it('discovers an existing browser at the root discovery URL', async () => {
+    const wsEndpoint = 'ws://localhost:9222/devtools/browser/root';
+    server.addRoute('/json/version', (_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({webSocketDebuggerUrl: wsEndpoint}));
+    });
+
+    assert.strictEqual(
+      await resolveBrowserWSEndpoint(server.baseUrl),
+      wsEndpoint,
+    );
+  });
+
+  it('drops browserURL query strings before discovery', async () => {
+    const wsEndpoint = 'ws://localhost:9222/devtools/browser/query';
+    server.addRoute('/t/query/json/version', (_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({webSocketDebuggerUrl: wsEndpoint}));
+    });
+
+    assert.strictEqual(
+      await resolveBrowserWSEndpoint(`${server.baseUrl}/t/query?token=secret`),
+      wsEndpoint,
+    );
+  });
+
+  it('discovers an existing browser behind a trailing-slash path prefix', async () => {
+    const wsEndpoint = 'ws://localhost:9222/devtools/browser/slash';
+    server.addRoute('/t/slash/json/version', (_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({webSocketDebuggerUrl: wsEndpoint}));
+    });
+
+    assert.strictEqual(
+      await resolveBrowserWSEndpoint(`${server.baseUrl}/t/slash/`),
+      wsEndpoint,
+    );
+  });
+
+  it('does not include URL fragments in discovery errors', async () => {
+    server.addRoute('/fragment/json/version', (_req, res) => {
+      res.statusCode = 500;
+      res.end();
+    });
+
+    await assert.rejects(
+      resolveBrowserWSEndpoint(`${server.baseUrl}/fragment#debugger`),
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.includes('/fragment/json/version') &&
+        !error.message.includes('#debugger'),
+    );
+  });
+
+  it('uses the prefixed discovery URL when connecting by browserURL', async () => {
+    let discoveryRequests = 0;
+    server.addRoute('/t/abc123/json/version', (_req, res) => {
+      discoveryRequests++;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          webSocketDebuggerUrl: 'ws://127.0.0.1:9/devtools/browser/abc123',
+        }),
+      );
+    });
+
+    await assert.rejects(
+      ensureBrowserConnected({
+        browserURL: `${server.baseUrl}/t/abc123`,
+        devtools: false,
+      }),
+      /Could not connect to Chrome/,
+    );
+    assert.strictEqual(discoveryRequests, 1);
+  });
+
+  it('rejects invalid browser discovery responses', async () => {
+    server.addRoute('/missing/json/version', (_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({}));
+    });
+    server.addRoute('/invalid/json/version', (_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(null));
+    });
+    server.addRoute('/failed/json/version', (_req, res) => {
+      res.statusCode = 500;
+      res.end();
+    });
+
+    await assert.rejects(
+      resolveBrowserWSEndpoint(`${server.baseUrl}/missing`),
+      /No webSocketDebuggerUrl found/,
+    );
+    await assert.rejects(
+      resolveBrowserWSEndpoint(`${server.baseUrl}/invalid`),
+      /No webSocketDebuggerUrl found/,
+    );
+    await assert.rejects(
+      resolveBrowserWSEndpoint(`${server.baseUrl}/failed`),
+      /HTTP 500/,
+    );
   });
 
   it('cannot launch multiple times with the same profile', async () => {


### PR DESCRIPTION
## Summary

- Resolve `--browserUrl` through its `/json/version` discovery endpoint before connecting
- Preserve path prefixes when constructing the discovery URL and strip query strings/fragments
- Validate discovery payloads before using the WebSocket endpoint

## Tests

- `npm run test tests/browser.test.ts`
- `npm run check-format`
- `npm run test`
- `git diff --check`

Fixes #2394
