### PR TITLE
fix(daemon): preserve hyphenated --chrome-arg flags in serialization …

### DIFF
--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -263,7 +263,7 @@ for (const [commandName, commandDef] of Object.entries(commands)) {
       const sessionId = argv.sessionId as string;
       try {
         if (!isDaemonRunning(sessionId)) {
-          await start([], sessionId);
+          await start(serializeArgs(cliOptions, argv), sessionId);
         }
 
         const commandArgs: Record<string, unknown> = {};

--- a/src/daemon/utils.ts
+++ b/src/daemon/utils.ts
@@ -128,10 +128,10 @@ export function serializeArgs(
       }
     } else if (Array.isArray(value)) {
       for (const item of value) {
-        args.push(`--${kebabKey}`, String(item));
+        args.push(`--${kebabKey}=${String(item)}`);
       }
     } else {
-      args.push(`--${kebabKey}`, String(value));
+      args.push(`--${kebabKey}=${String(value)}`);
     }
   }
   return args;

--- a/tests/daemon/utils.test.ts
+++ b/tests/daemon/utils.test.ts
@@ -26,7 +26,7 @@ describe('serializeArgs', () => {
       $0: 'test',
     } as unknown as ParsedArguments;
     const result = serializeArgs(options, argv);
-    assert.deepStrictEqual(result, ['--baz', 'value']);
+    assert.deepStrictEqual(result, ['--baz=value']);
   });
 
   it('should handle boolean values', () => {
@@ -41,15 +41,24 @@ describe('serializeArgs', () => {
     assert.deepStrictEqual(result, ['--foo', '--no-bar']);
   });
 
-  it('should handle array values', () => {
-    const options: Record<string, YargsOptions> = {foo: {}};
+  it('should handle array values including hyphenated flags', () => {
+    const options: Record<string, YargsOptions> = {foo: {}, chromeArg: {}};
     const argv = {
       foo: ['val1', 'val2'],
+      chromeArg: [
+        '--use-fake-device-for-media-stream',
+        '--use-file-for-fake-audio-capture=/tmp/test.wav',
+      ],
       _: [],
       $0: 'test',
     } as unknown as ParsedArguments;
     const result = serializeArgs(options, argv);
-    assert.deepStrictEqual(result, ['--foo', 'val1', '--foo', 'val2']);
+    assert.deepStrictEqual(result, [
+      '--foo=val1',
+      '--foo=val2',
+      '--chrome-arg=--use-fake-device-for-media-stream',
+      '--chrome-arg=--use-file-for-fake-audio-capture=/tmp/test.wav',
+    ]);
   });
 
   it('should handle primitive values', () => {
@@ -61,7 +70,7 @@ describe('serializeArgs', () => {
       $0: 'test',
     } as unknown as ParsedArguments;
     const result = serializeArgs(options, argv);
-    assert.deepStrictEqual(result, ['--foo', 'string', '--bar', '42']);
+    assert.deepStrictEqual(result, ['--foo=string', '--bar=42']);
   });
 
   it('should convert camelCase keys to kebab-case', () => {
@@ -77,9 +86,9 @@ describe('serializeArgs', () => {
     } as unknown as ParsedArguments;
     const result = serializeArgs(options, argv);
     assert.deepStrictEqual(result, [
-      '--camel-case-key',
-      'value1',
+      '--camel-case-key=value1',
       '--another-key',
     ]);
   });
 });
+


### PR DESCRIPTION
…and subcommand daemon startup

When passing `--chrome-arg` flags whose values start with hyphens (such as `--use-fake-device-for-media-stream` or `--use-file-for-fake-audio-capture=...`), `serializeArgs` previously emitted array items as separate tokens without an equals sign (`--chrome-arg`, `--flag`). `yargs` in the spawned daemon process interpreted the trailing token as a new flag and dropped the `--chrome-arg` option. Additionally, when subcommands auto-started an inactive daemon, `start([], sessionId)` dropped all daemon flags passed on the command line.

By formatting serialized arguments strictly as `--key=value` in `serializeArgs` and forwarding `serializeArgs(cliOptions, argv)` when subcommands start the daemon, `--chromeArg` options reliably reach `puppeteer.launch`.

Includes unit tests in `tests/daemon/utils.test.ts` verifying `--key=value` formatting for hyphenated array arguments.