### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-chromedevtools-chrome-devtools-mcp)](https://mcpindex.ai/server/io-github-chromedevtools-chrome-devtools-mcp)
+
 # Chrome DevTools for agents
 
 [![npm chrome-devtools-mcp package](https://img.shields.io/npm/v/chrome-devtools-mcp.svg)](https://npmjs.org/package/chrome-devtools-mcp)


### PR DESCRIPTION
Hey, ran chrome-devtools-mcp through mcpindex's screening (checks the registered tool description for injection/manipulation patterns, nothing deeper). Came back clean, so added the badge to your README. It's an advisory signal, not a security certification. Feel free to close this if it's not something you want on the repo. 