### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Chrome DevTools for agents
 
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.ChromeDevTools%2Fchrome-devtools-mcp.svg)](https://mcptoplist.com/server/io.github.ChromeDevTools%2Fchrome-devtools-mcp)
+
 [![npm chrome-devtools-mcp package](https://img.shields.io/npm/v/chrome-devtools-mcp.svg)](https://npmjs.org/package/chrome-devtools-mcp)
 
 Chrome DevTools for agents (`chrome-devtools-mcp`) lets your coding agent (such as Antigravity, Claude, Cursor or Copilot)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 77,122 MCP servers across the major
registries, and **Chrome DevTools MCP** is currently ranked **#2**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/io.github.ChromeDevTools%2Fchrome-devtools-mcp.svg)](https://mcptoplist.com/server/io.github.ChromeDevTools%2Fchrome-devtools-mcp)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Chrome DevTools MCP!
