### PR TITLE
fix(script): clear dialog state after evaluate_script auto-handles a dialog

### DIFF
--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -129,6 +129,9 @@ Example with arguments: \`(el) => el.innerText\`
           },
           {handleDialog: dialogAction ?? 'accept'},
         );
+        if (result.dialogHandled) {
+          mcpPage.clearDialog();
+        }
         response.attachWaitForResult(result);
       } finally {
         void Promise.allSettled(args.map(arg => arg.dispose()));

--- a/tests/tools/script.test.ts
+++ b/tests/tools/script.test.ts
@@ -150,6 +150,34 @@ describe('script', () => {
       });
     });
 
+    it('clears the dialog state after auto-handling a dialog', async () => {
+      await withMcpContext(async (response, context) => {
+        const mcpPage = context.getSelectedMcpPage();
+        await mcpPage.pptrPage.setContent(
+          html`<button id="test">test</button>`,
+        );
+
+        await evaluateScript().handler(
+          {
+            params: {
+              function: String(() => {
+                confirm('hello');
+                return 'done';
+              }),
+            },
+          },
+          response,
+          context,
+        );
+
+        // After the dialog is auto-accepted, the stored dialog reference must
+        // be cleared. Otherwise throwIfDialogOpen() wedges every subsequent
+        // blockedByDialog tool with a false "A dialog is open" error.
+        assert.strictEqual(mcpPage.getDialog(), undefined);
+        assert.doesNotThrow(() => mcpPage.throwIfDialogOpen());
+      });
+    });
+
     it('work for scripts that trigger prompts and fill them', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedMcpPage().pptrPage;


### PR DESCRIPTION
Fixes #2424

## Problem

After `evaluate_script` runs a script that opens a JS dialog (`alert`/`confirm`/`prompt`), every subsequent dialog-blocked tool fails with a misleading `A dialog is open (...)` error — even though the dialog was already auto-handled and is gone. The session stays wedged until `handle_dialog` is called or the page is navigated/closed.

`McpPage` stores every dialog in `#dialog` via a persistent `'dialog'` listener. The page-evaluation path of `evaluate_script` passes `handleDialog` (default `'accept'`) so the dialog is auto-accepted, but — unlike the sibling service-worker path (`script.ts:100-102`) and `navigate_page` (`pages.ts:274-278`) — it never clears `#dialog`. Since `evaluate_script` and most tools are `blockedByDialog: true`, the next one throws on `throwIfDialogOpen()`.

## Fix

On the page path, clear the dialog state when a dialog was handled, mirroring the worker path:

```ts
if (result.dialogHandled) {
  mcpPage.clearDialog();
}
```

## Testing

- Added `clears the dialog state after auto-handling a dialog`: evaluates `() => { confirm('hello'); return 'done'; }` and asserts `getDialog()` is `undefined` and `throwIfDialogOpen()` doesn't throw. Fails on `main` (`getDialog()` returns the already-accepted dialog) and passes with this change.
- `npm run test tests/tools/script.test.ts` — all tests pass.
- ESLint + Prettier clean on both changed files.
