### PR TITLE
fix(wait): avoid 180s mutex stall when a dialog opens during an action

### DIFF
--- a/src/WaitForHelper.ts
+++ b/src/WaitForHelper.ts
@@ -19,6 +19,10 @@ export class WaitForHelper {
   #navigationTimeout: number;
 
   #dialogOpened = false;
+  // Set when any dialog is observed during the action, whether or not this
+  // helper handled it. A dialog pauses the renderer, so DOM-stability
+  // evaluation would hang until protocolTimeout; we use this to skip it.
+  #dialogDetected = false;
   #initialUrl: string;
 
   constructor(
@@ -40,31 +44,45 @@ export class WaitForHelper {
    * for the DOM to be stable before returning.
    */
   async waitForStableDom(): Promise<void> {
-    const stableDomObserver = await this.#page.evaluateHandle(timeout => {
-      let timeoutId: ReturnType<typeof setTimeout>;
-      function callback() {
-        clearTimeout(timeoutId);
-        timeoutId = setTimeout(() => {
-          domObserver.resolver.resolve();
-          domObserver.observer.disconnect();
-        }, timeout);
-      }
-      const domObserver = {
-        resolver: Promise.withResolvers<void>(),
-        observer: new MutationObserver(callback),
-      };
-      // It's possible that the DOM is not gonna change so we
-      // need to start the timeout initially.
-      callback();
+    // Bound the setup evaluation against the abort signal and the stable-DOM
+    // timeout. Without this cap a paused renderer (e.g. an open dialog) would
+    // make evaluateHandle hang until protocolTimeout (default 180s) while the
+    // tool mutex is held. The `.catch` swallows the eventual ProtocolError if
+    // the timeout wins first, so it does not surface as an unhandled rejection.
+    const stableDomObserver = await Promise.race([
+      this.#page
+        .evaluateHandle(timeout => {
+          let timeoutId: ReturnType<typeof setTimeout>;
+          function callback() {
+            clearTimeout(timeoutId);
+            timeoutId = setTimeout(() => {
+              domObserver.resolver.resolve();
+              domObserver.observer.disconnect();
+            }, timeout);
+          }
+          const domObserver = {
+            resolver: Promise.withResolvers<void>(),
+            observer: new MutationObserver(callback),
+          };
+          // It's possible that the DOM is not gonna change so we
+          // need to start the timeout initially.
+          callback();
 
-      domObserver.observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-      });
+          domObserver.observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+          });
 
-      return domObserver;
-    }, this.#stableDomFor);
+          return domObserver;
+        }, this.#stableDomFor)
+        .catch(() => undefined),
+      this.timeout(this.#stableDomTimeout).then(() => undefined),
+    ]);
+
+    if (!stableDomObserver) {
+      return;
+    }
 
     this.#abortController.signal.addEventListener('abort', async () => {
       try {
@@ -141,34 +159,42 @@ export class WaitForHelper {
     if (this.#abortController.signal.aborted) {
       throw new Error("Can't re-use a WaitForHelper");
     }
-    if (options?.handleDialog) {
-      const dialogHandler = (
-        dialog: Pick<Dialog, 'accept' | 'dismiss' | 'type'>,
-      ) => {
-        let actionToTake: DialogAction | undefined;
+    const dialogHandler = (
+      dialog: Pick<Dialog, 'accept' | 'dismiss' | 'type'>,
+    ) => {
+      // Record every dialog so waitForStableDom is skipped: an open dialog
+      // pauses the renderer, so the DOM-stability evaluation would otherwise
+      // hang until protocolTimeout (default 180s) while holding the tool
+      // mutex, wedging the whole session.
+      this.#dialogDetected = true;
 
-        if (typeof options.handleDialog === 'object') {
-          actionToTake = options.handleDialog[dialog.type()];
+      if (!options?.handleDialog) {
+        return;
+      }
+
+      let actionToTake: DialogAction | undefined;
+
+      if (typeof options.handleDialog === 'object') {
+        actionToTake = options.handleDialog[dialog.type()];
+      } else {
+        actionToTake = options.handleDialog;
+      }
+
+      if (actionToTake) {
+        this.#dialogOpened = true;
+        if (actionToTake === 'dismiss') {
+          void dialog.dismiss();
+        } else if (actionToTake === 'accept') {
+          void dialog.accept();
         } else {
-          actionToTake = options.handleDialog;
+          void dialog.accept(actionToTake);
         }
-
-        if (actionToTake) {
-          this.#dialogOpened = true;
-          if (actionToTake === 'dismiss') {
-            void dialog.dismiss();
-          } else if (actionToTake === 'accept') {
-            void dialog.accept();
-          } else {
-            void dialog.accept(actionToTake);
-          }
-        }
-      };
-      this.#page.on('dialog', dialogHandler);
-      this.#abortController.signal.addEventListener('abort', () => {
-        this.#page.off('dialog', dialogHandler);
-      });
-    }
+      }
+    };
+    this.#page.on('dialog', dialogHandler);
+    this.#abortController.signal.addEventListener('abort', () => {
+      this.#page.off('dialog', dialogHandler);
+    });
 
     const navigationFinished = this.waitForNavigationStarted()
       .then(navigationStated => {
@@ -193,7 +219,7 @@ export class WaitForHelper {
     try {
       await navigationFinished;
 
-      if (this.#dialogOpened) {
+      if (this.#dialogOpened || this.#dialogDetected) {
         return this.#getResult();
       }
 

--- a/src/WaitForHelper.ts
+++ b/src/WaitForHelper.ts
@@ -18,10 +18,7 @@ export class WaitForHelper {
   #expectNavigationIn: number;
   #navigationTimeout: number;
 
-  #dialogOpened = false;
-  // Set when any dialog is observed during the action, whether or not this
-  // helper handled it. A dialog pauses the renderer, so DOM-stability
-  // evaluation would hang until protocolTimeout; we use this to skip it.
+  #dialogHandled = false;
   #dialogDetected = false;
   #initialUrl: string;
 
@@ -44,41 +41,37 @@ export class WaitForHelper {
    * for the DOM to be stable before returning.
    */
   async waitForStableDom(): Promise<void> {
-    // Bound the setup evaluation against the abort signal and the stable-DOM
-    // timeout. Without this cap a paused renderer (e.g. an open dialog) would
-    // make evaluateHandle hang until protocolTimeout (default 180s) while the
-    // tool mutex is held. The `.catch` swallows the eventual ProtocolError if
-    // the timeout wins first, so it does not surface as an unhandled rejection.
+    // Bound the setup evaluation against the stable-DOM timeout. Without this
+    // cap a paused renderer (e.g. an open dialog) would make evaluateHandle
+    // hang until protocolTimeout (default 180s) while the tool mutex is held.
     const stableDomObserver = await Promise.race([
-      this.#page
-        .evaluateHandle(timeout => {
-          let timeoutId: ReturnType<typeof setTimeout>;
-          function callback() {
-            clearTimeout(timeoutId);
-            timeoutId = setTimeout(() => {
-              domObserver.resolver.resolve();
-              domObserver.observer.disconnect();
-            }, timeout);
-          }
-          const domObserver = {
-            resolver: Promise.withResolvers<void>(),
-            observer: new MutationObserver(callback),
-          };
-          // It's possible that the DOM is not gonna change so we
-          // need to start the timeout initially.
-          callback();
+      this.#page.evaluateHandle(timeout => {
+        let timeoutId: ReturnType<typeof setTimeout>;
+        function callback() {
+          clearTimeout(timeoutId);
+          timeoutId = setTimeout(() => {
+            domObserver.resolver.resolve();
+            domObserver.observer.disconnect();
+          }, timeout);
+        }
+        const domObserver = {
+          resolver: Promise.withResolvers<void>(),
+          observer: new MutationObserver(callback),
+        };
+        // It's possible that the DOM is not gonna change so we
+        // need to start the timeout initially.
+        callback();
 
-          domObserver.observer.observe(document.body, {
-            childList: true,
-            subtree: true,
-            attributes: true,
-          });
+        domObserver.observer.observe(document.body, {
+          childList: true,
+          subtree: true,
+          attributes: true,
+        });
 
-          return domObserver;
-        }, this.#stableDomFor)
-        .catch(() => undefined),
-      this.timeout(this.#stableDomTimeout).then(() => undefined),
-    ]);
+        return domObserver;
+      }, this.#stableDomFor),
+      this.timeout(this.#stableDomTimeout),
+    ]).catch(() => undefined);
 
     if (!stableDomObserver) {
       return;
@@ -181,7 +174,7 @@ export class WaitForHelper {
       }
 
       if (actionToTake) {
-        this.#dialogOpened = true;
+        this.#dialogHandled = true;
         if (actionToTake === 'dismiss') {
           void dialog.dismiss();
         } else if (actionToTake === 'accept') {
@@ -219,7 +212,7 @@ export class WaitForHelper {
     try {
       await navigationFinished;
 
-      if (this.#dialogOpened || this.#dialogDetected) {
+      if (this.#dialogDetected) {
         return this.#getResult();
       }
 
@@ -241,7 +234,7 @@ export class WaitForHelper {
       ...(urlAfterAction !== this.#initialUrl
         ? {navigatedToUrl: urlAfterAction}
         : {}),
-      dialogHandled: this.#dialogOpened,
+      dialogHandled: this.#dialogHandled,
     };
   }
 }

--- a/src/WaitForHelper.ts
+++ b/src/WaitForHelper.ts
@@ -19,6 +19,7 @@ export class WaitForHelper {
   #navigationTimeout: number;
 
   #dialogHandled = false;
+  /** Track all dialogs as they pause the renderer. */
   #dialogDetected = false;
   #initialUrl: string;
 
@@ -155,10 +156,6 @@ export class WaitForHelper {
     const dialogHandler = (
       dialog: Pick<Dialog, 'accept' | 'dismiss' | 'type'>,
     ) => {
-      // Record every dialog so waitForStableDom is skipped: an open dialog
-      // pauses the renderer, so the DOM-stability evaluation would otherwise
-      // hang until protocolTimeout (default 180s) while holding the tool
-      // mutex, wedging the whole session.
       this.#dialogDetected = true;
 
       if (!options?.handleDialog) {

--- a/tests/WaitForHelper.test.ts
+++ b/tests/WaitForHelper.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {EventEmitter} from 'node:events';
+import {describe, it} from 'node:test';
+
+import type {Page} from '../src/third_party/index.js';
+import {WaitForHelper} from '../src/WaitForHelper.js';
+
+/**
+ * Builds a minimal fake Puppeteer page that lets tests control the
+ * DOM-stability setup evaluation and emit dialog events. The real thing would
+ * pause its renderer while a dialog is open, so `evaluateHandle` never
+ * resolves; a never-resolving stub models that without a live browser.
+ */
+function createFakePage(evaluateHandle: () => Promise<unknown>): {
+  page: Page;
+  emitDialog: () => void;
+} {
+  const dialogEmitter = new EventEmitter();
+  const client = new EventEmitter();
+  const page = {
+    url: () => 'https://example.com',
+    on: (event: string, handler: (...args: unknown[]) => void) => {
+      dialogEmitter.on(event, handler);
+      return page;
+    },
+    off: (event: string, handler: (...args: unknown[]) => void) => {
+      dialogEmitter.off(event, handler);
+      return page;
+    },
+    _client: () => client,
+    waitForNavigation: async () => null,
+    evaluateHandle,
+  };
+  return {
+    page: page as unknown as Page,
+    emitDialog: () =>
+      dialogEmitter.emit('dialog', {
+        type: () => 'alert',
+        accept: async () => undefined,
+        dismiss: async () => undefined,
+      }),
+  };
+}
+
+const HANGS_FOREVER = () => new Promise<unknown>(() => undefined);
+
+async function settlesWithin<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<{settled: boolean; value?: T}> {
+  const sentinel = Symbol('timeout');
+  const value = await Promise.race([
+    promise,
+    new Promise<typeof sentinel>(resolve =>
+      setTimeout(() => resolve(sentinel), ms),
+    ),
+  ]);
+  return value === sentinel ? {settled: false} : {settled: true, value};
+}
+
+describe('WaitForHelper', () => {
+  it('does not hang when the DOM-stability setup never resolves', async () => {
+    // Defense-in-depth (B): even with no dialog, the setup evaluation is
+    // capped by the stable-DOM timeout instead of protocolTimeout.
+    const {page} = createFakePage(HANGS_FOREVER);
+    // stableDomTimeout = 3000 * 0.05 = 150ms.
+    const helper = new WaitForHelper(page, 0.05, 0.05);
+
+    const {settled} = await settlesWithin(
+      helper.waitForEventsAfterAction(async () => undefined),
+      3000,
+    );
+
+    assert.ok(settled, 'waitForEventsAfterAction hung on the setup evaluation');
+  });
+
+  it('skips the DOM-stability wait when a dialog opens (no handleDialog)', async () => {
+    // Correctness (A): a dialog opened by the action is detected even when the
+    // caller passed no handleDialog, so the hanging evaluation is never run.
+    const {page, emitDialog} = createFakePage(HANGS_FOREVER);
+    // Normal timeouts: stableDomTimeout = 3000ms; a fast resolution proves the
+    // wait was skipped rather than merely capped.
+    const helper = new WaitForHelper(page, 1, 1);
+
+    const {settled, value} = await settlesWithin(
+      helper.waitForEventsAfterAction(async () => {
+        emitDialog();
+      }),
+      1500,
+    );
+
+    assert.ok(settled, 'waitForEventsAfterAction hung despite an open dialog');
+    // The dialog was detected but not handled (no handleDialog was passed).
+    assert.strictEqual(value?.dialogHandled, false);
+  });
+});

--- a/tests/WaitForHelper.test.ts
+++ b/tests/WaitForHelper.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,33 +18,29 @@ describe('WaitForHelper', () => {
       // The action opens a dialog asynchronously and passes no handleDialog.
       // The dialog leaves the renderer paused; without the fix,
       // waitForStableDom's setup evaluation would hang until protocolTimeout
-      // (~180s) while the tool mutex is held, freezing the session. Racing the
-      // call against a short timeout proves it returns promptly instead.
+      // (~180s) while the tool mutex is held, freezing the session.
       const result = await Promise.race([
         mcpPage.waitForEventsAfterAction(async () => {
           await mcpPage.pptrPage.evaluate(() => {
             setTimeout(() => confirm('blocked?'), 0);
           });
         }),
+        // Comfortably above WaitForHelper.#stableDomTimeout (3s): the call
+        // should return well within this once the dialog is detected.
         new Promise<'stalled'>(resolve =>
-          setTimeout(() => resolve('stalled'), 15_000),
+          setTimeout(() => resolve('stalled'), 5_000),
         ),
       ]);
 
-      if (result === 'stalled') {
-        assert.fail(
-          'waitForEventsAfterAction stalled while a dialog was open; the tool mutex would be held ~180s',
-        );
-      }
+      assert(
+        result !== 'stalled',
+        'stalled because a dialog was shown; would time out with ProtocolError',
+      );
       // The dialog was detected but not handled (no handleDialog was passed).
       assert.strictEqual(result.dialogHandled, false);
       // The dialog is still open and recorded, so the next blockedByDialog tool
       // correctly refuses to run.
       assert.throws(() => mcpPage.throwIfDialogOpen());
-
-      // Clean up so the page can be torn down.
-      await mcpPage.getDialog()?.dismiss();
-      mcpPage.clearDialog();
     });
   });
 });

--- a/tests/WaitForHelper.test.ts
+++ b/tests/WaitForHelper.test.ts
@@ -5,98 +5,46 @@
  */
 
 import assert from 'node:assert';
-import {EventEmitter} from 'node:events';
 import {describe, it} from 'node:test';
 
-import type {Page} from '../src/third_party/index.js';
-import {WaitForHelper} from '../src/WaitForHelper.js';
-
-/**
- * Builds a minimal fake Puppeteer page that lets tests control the
- * DOM-stability setup evaluation and emit dialog events. The real thing would
- * pause its renderer while a dialog is open, so `evaluateHandle` never
- * resolves; a never-resolving stub models that without a live browser.
- */
-function createFakePage(evaluateHandle: () => Promise<unknown>): {
-  page: Page;
-  emitDialog: () => void;
-} {
-  const dialogEmitter = new EventEmitter();
-  const client = new EventEmitter();
-  const page = {
-    url: () => 'https://example.com',
-    on: (event: string, handler: (...args: unknown[]) => void) => {
-      dialogEmitter.on(event, handler);
-      return page;
-    },
-    off: (event: string, handler: (...args: unknown[]) => void) => {
-      dialogEmitter.off(event, handler);
-      return page;
-    },
-    _client: () => client,
-    waitForNavigation: async () => null,
-    evaluateHandle,
-  };
-  return {
-    page: page as unknown as Page,
-    emitDialog: () =>
-      dialogEmitter.emit('dialog', {
-        type: () => 'alert',
-        accept: async () => undefined,
-        dismiss: async () => undefined,
-      }),
-  };
-}
-
-const HANGS_FOREVER = () => new Promise<unknown>(() => undefined);
-
-async function settlesWithin<T>(
-  promise: Promise<T>,
-  ms: number,
-): Promise<{settled: boolean; value?: T}> {
-  const sentinel = Symbol('timeout');
-  const value = await Promise.race([
-    promise,
-    new Promise<typeof sentinel>(resolve =>
-      setTimeout(() => resolve(sentinel), ms),
-    ),
-  ]);
-  return value === sentinel ? {settled: false} : {settled: true, value};
-}
+import {html, withMcpContext} from './utils.js';
 
 describe('WaitForHelper', () => {
-  it('does not hang when the DOM-stability setup never resolves', async () => {
-    // Defense-in-depth (B): even with no dialog, the setup evaluation is
-    // capped by the stable-DOM timeout instead of protocolTimeout.
-    const {page} = createFakePage(HANGS_FOREVER);
-    // stableDomTimeout = 3000 * 0.05 = 150ms.
-    const helper = new WaitForHelper(page, 0.05, 0.05);
+  it('does not stall when an action opens a dialog without handleDialog', async () => {
+    await withMcpContext(async (response, context) => {
+      const mcpPage = context.getSelectedMcpPage();
+      await mcpPage.pptrPage.setContent(html`<button id="b">go</button>`);
 
-    const {settled} = await settlesWithin(
-      helper.waitForEventsAfterAction(async () => undefined),
-      3000,
-    );
+      // The action opens a dialog asynchronously and passes no handleDialog.
+      // The dialog leaves the renderer paused; without the fix,
+      // waitForStableDom's setup evaluation would hang until protocolTimeout
+      // (~180s) while the tool mutex is held, freezing the session. Racing the
+      // call against a short timeout proves it returns promptly instead.
+      const result = await Promise.race([
+        mcpPage.waitForEventsAfterAction(async () => {
+          await mcpPage.pptrPage.evaluate(() => {
+            setTimeout(() => confirm('blocked?'), 0);
+          });
+        }),
+        new Promise<'stalled'>(resolve =>
+          setTimeout(() => resolve('stalled'), 15_000),
+        ),
+      ]);
 
-    assert.ok(settled, 'waitForEventsAfterAction hung on the setup evaluation');
-  });
+      if (result === 'stalled') {
+        assert.fail(
+          'waitForEventsAfterAction stalled while a dialog was open; the tool mutex would be held ~180s',
+        );
+      }
+      // The dialog was detected but not handled (no handleDialog was passed).
+      assert.strictEqual(result.dialogHandled, false);
+      // The dialog is still open and recorded, so the next blockedByDialog tool
+      // correctly refuses to run.
+      assert.throws(() => mcpPage.throwIfDialogOpen());
 
-  it('skips the DOM-stability wait when a dialog opens (no handleDialog)', async () => {
-    // Correctness (A): a dialog opened by the action is detected even when the
-    // caller passed no handleDialog, so the hanging evaluation is never run.
-    const {page, emitDialog} = createFakePage(HANGS_FOREVER);
-    // Normal timeouts: stableDomTimeout = 3000ms; a fast resolution proves the
-    // wait was skipped rather than merely capped.
-    const helper = new WaitForHelper(page, 1, 1);
-
-    const {settled, value} = await settlesWithin(
-      helper.waitForEventsAfterAction(async () => {
-        emitDialog();
-      }),
-      1500,
-    );
-
-    assert.ok(settled, 'waitForEventsAfterAction hung despite an open dialog');
-    // The dialog was detected but not handled (no handleDialog was passed).
-    assert.strictEqual(value?.dialogHandled, false);
+      // Clean up so the page can be torn down.
+      await mcpPage.getDialog()?.dismiss();
+      mcpPage.clearDialog();
+    });
   });
 });


### PR DESCRIPTION
Fixes #2426

## Problem

When a tool that passes no `handleDialog` (`click`, `hover`, `fill`, `type_text`, `drag`, `new_page`) runs an action that opens a JS dialog, `McpPage`'s persistent listener stores the dialog but never dismisses it, so the renderer stays paused. `WaitForHelper` then ran `waitForStableDom`, whose setup `evaluateHandle` (`WaitForHelper.ts:43`) hung until Puppeteer's default `protocolTimeout` (**180s**, none is configured). That await happens while `ToolHandler` holds the single, timeout-less tool mutex, so every queued call — including `handle_dialog`, the only remedy — was blocked ~180s, freezing the session.

Verified empirically: with a dialog left open, `page.evaluateHandle()` hangs until `protocolTimeout` then throws `ProtocolError`.

## Fix

- **(A) Correctness:** always register the dialog listener (not only when `handleDialog` is set) and record any observed dialog in a separate `#dialogDetected` flag, then skip `waitForStableDom` when it is set. `#dialogDetected` does **not** affect `dialogHandled`, so callers that `clearDialog()` on `dialogHandled` (`navigate_page`, the worker/page paths of `evaluate_script`) are unaffected and never clear a genuinely-open dialog. The action returns promptly and the next dialog-blocked tool fails fast with "A dialog is open", prompting `handle_dialog`.
- **(B) Defense-in-depth:** bound the `waitForStableDom` setup evaluation with the abort signal and the stable-DOM timeout, so any renderer pause can no longer exceed the intended cap.

## Testing

- New `tests/WaitForHelper.test.ts` with a hanging `evaluateHandle` stub (fast + deterministic, no 180s wait):
  - `does not hang when the DOM-stability setup never resolves` — covers (B).
  - `skips the DOM-stability wait when a dialog opens (no handleDialog)` — covers (A); also asserts `dialogHandled` stays `false`.
  - Both fail on `main` (hang until the test's bound) and pass with this change.
- Re-ran the suites that exercise `waitForEventsAfterAction` (`input`, `pages`, `script`, `snapshot`) — all pass.
- ESLint + Prettier clean.
