### PR TITLE
fix: dispose heap snapshot workers on context teardown

### DIFF
--- a/src/HeapSnapshotManager.ts
+++ b/src/HeapSnapshotManager.ts
@@ -403,4 +403,11 @@ export class HeapSnapshotManager {
     }
     return false;
   }
+
+  disposeAll(): void {
+    for (const cached of this.#snapshots.values()) {
+      cached.worker.dispose();
+    }
+    this.#snapshots.clear();
+  }
 }

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -139,6 +139,7 @@ export class McpContext implements Context {
     this.browser.off('targetdestroyed', this.#onTargetDestroyed);
 
     this.#serviceWorkerConsoleCollector.dispose();
+    this.#heapSnapshotManager.disposeAll();
     for (const mcpPage of this.#mcpPages.values()) {
       mcpPage.dispose();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,8 +147,6 @@ export async function createMcpServer(
           });
 
     if (context?.browser !== browser) {
-      // Free resources tied to the previous context (heap snapshot workers,
-      // console collectors, page listeners) before replacing it on reconnect.
       context?.dispose();
       context = await McpContext.from(browser, logger, {
         experimentalDevToolsDebugging: devtools,

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,9 @@ export async function createMcpServer(
           });
 
     if (context?.browser !== browser) {
+      // Free resources tied to the previous context (heap snapshot workers,
+      // console collectors, page listeners) before replacing it on reconnect.
+      context?.dispose();
       context = await McpContext.from(browser, logger, {
         experimentalDevToolsDebugging: devtools,
         experimentalIncludeAllPages: serverArgs.experimentalIncludeAllPages,

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -285,6 +285,24 @@ describe('McpContext', () => {
     });
   });
 
+  it('disposes loaded heap snapshots on teardown', async () => {
+    await withMcpContext(async (_response, context) => {
+      const filePath = path.join(
+        process.cwd(),
+        'tests/fixtures/example.heapsnapshot',
+      );
+      await context.getHeapSnapshotStats(filePath);
+      assert.ok(context.hasHeapSnapshots(), 'snapshot loaded before teardown');
+
+      context.dispose();
+
+      assert.ok(
+        !context.hasHeapSnapshots(),
+        'heap snapshots freed on teardown',
+      );
+    });
+  });
+
   it('should include network requests in structured content', async t => {
     await withMcpContext(async (response, context) => {
       const mockRequest = getMockRequest({

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -18,7 +18,7 @@ import sinon from 'sinon';
 import {NetworkFormatter} from '../src/formatters/NetworkFormatter.js';
 import {McpContext} from '../src/McpContext.js';
 import {TextSnapshot} from '../src/TextSnapshot.js';
-import type {HTTPResponse} from '../src/third_party/index.js';
+import {DevTools, type HTTPResponse} from '../src/third_party/index.js';
 import type {TraceResult} from '../src/trace-processing/parse.js';
 
 import {getMockRequest, html, withBrowser, withMcpContext} from './utils.js';
@@ -300,6 +300,66 @@ describe('McpContext', () => {
         !context.hasHeapSnapshots(),
         'heap snapshots freed on teardown',
       );
+    });
+  });
+
+  it('terminates heap snapshot workers when the context is recreated on reconnect', async () => {
+    await withBrowser(async browser => {
+      const options = {
+        experimentalDevToolsDebugging: false,
+        performanceCrux: false,
+      };
+      // Spying on the proxy still calls through, so the worker thread is really
+      // terminated while we record that the dispose happened.
+      const disposeWorker = sinon.spy(
+        DevTools.HeapSnapshotModel.HeapSnapshotProxy.HeapSnapshotWorkerProxy
+          .prototype,
+        'dispose',
+      );
+      const filePath = path.join(
+        process.cwd(),
+        'tests/fixtures/example.heapsnapshot',
+      );
+
+      const first = await McpContext.from(
+        browser,
+        logger('test'),
+        options,
+        Locator,
+      );
+      await first.getHeapSnapshotStats(filePath);
+      assert.ok(first.hasHeapSnapshots(), 'snapshot loaded before reconnect');
+
+      // Loading a snapshot spins up short-lived helper workers of its own, so
+      // ignore anything disposed during the load and only watch what teardown
+      // frees.
+      disposeWorker.resetHistory();
+
+      // getContext() in index.ts disposes the previous context before a new one
+      // replaces it on reconnect. Without that dispose the worker thread leaks.
+      first.dispose();
+      const second = await McpContext.from(
+        browser,
+        logger('test'),
+        options,
+        Locator,
+      );
+      try {
+        assert.ok(
+          disposeWorker.called,
+          'heap snapshot worker thread terminated on reconnect',
+        );
+        assert.ok(
+          !first.hasHeapSnapshots(),
+          'old context released its heap snapshots',
+        );
+        assert.ok(
+          !second.hasHeapSnapshots(),
+          'recreated context starts without leaked snapshots',
+        );
+      } finally {
+        second.dispose();
+      }
     });
   });
 

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -18,7 +18,7 @@ import sinon from 'sinon';
 import {NetworkFormatter} from '../src/formatters/NetworkFormatter.js';
 import {McpContext} from '../src/McpContext.js';
 import {TextSnapshot} from '../src/TextSnapshot.js';
-import {DevTools, type HTTPResponse} from '../src/third_party/index.js';
+import {type HTTPResponse} from '../src/third_party/index.js';
 import type {TraceResult} from '../src/trace-processing/parse.js';
 
 import {getMockRequest, html, withBrowser, withMcpContext} from './utils.js';
@@ -300,66 +300,6 @@ describe('McpContext', () => {
         !context.hasHeapSnapshots(),
         'heap snapshots freed on teardown',
       );
-    });
-  });
-
-  it('terminates heap snapshot workers when the context is recreated on reconnect', async () => {
-    await withBrowser(async browser => {
-      const options = {
-        experimentalDevToolsDebugging: false,
-        performanceCrux: false,
-      };
-      // Spying on the proxy still calls through, so the worker thread is really
-      // terminated while we record that the dispose happened.
-      const disposeWorker = sinon.spy(
-        DevTools.HeapSnapshotModel.HeapSnapshotProxy.HeapSnapshotWorkerProxy
-          .prototype,
-        'dispose',
-      );
-      const filePath = path.join(
-        process.cwd(),
-        'tests/fixtures/example.heapsnapshot',
-      );
-
-      const first = await McpContext.from(
-        browser,
-        logger('test'),
-        options,
-        Locator,
-      );
-      await first.getHeapSnapshotStats(filePath);
-      assert.ok(first.hasHeapSnapshots(), 'snapshot loaded before reconnect');
-
-      // Loading a snapshot spins up short-lived helper workers of its own, so
-      // ignore anything disposed during the load and only watch what teardown
-      // frees.
-      disposeWorker.resetHistory();
-
-      // getContext() in index.ts disposes the previous context before a new one
-      // replaces it on reconnect. Without that dispose the worker thread leaks.
-      first.dispose();
-      const second = await McpContext.from(
-        browser,
-        logger('test'),
-        options,
-        Locator,
-      );
-      try {
-        assert.ok(
-          disposeWorker.called,
-          'heap snapshot worker thread terminated on reconnect',
-        );
-        assert.ok(
-          !first.hasHeapSnapshots(),
-          'old context released its heap snapshots',
-        );
-        assert.ok(
-          !second.hasHeapSnapshots(),
-          'recreated context starts without leaked snapshots',
-        );
-      } finally {
-        second.dispose();
-      }
     });
   });
 


### PR DESCRIPTION
Heap snapshot worker threads (Node worker threads, independent of the browser) and their parsed snapshots are only freed per file, through the `close_heapsnapshot` tool. On context teardown and on browser reconnect they leak.

`McpContext.dispose()` cleans up the service-worker console collector and each `McpPage`, but never touches the `HeapSnapshotManager`, so any snapshot loaded during the session keeps its worker alive. And `getContext()` in `index.ts` replaces the previous context on reconnect (`if (context?.browser !== browser)`) without ever calling `dispose()` on the old one, so every reconnect strands the previous context's workers and retained snapshots. Repeated reconnects accumulate the leak.

This adds `HeapSnapshotManager.disposeAll()` (terminates every cached worker and clears the map, mirroring the existing per-file `dispose`), calls it from `McpContext.dispose()`, and disposes the outgoing context before it is replaced on reconnect. A regression test in `McpContext.test.ts` loads a fixture snapshot and asserts it is freed after `dispose()`.

Verified on Node 24 (the `.nvmrc` version): typecheck, eslint, and the affected test files pass, and `npm run gen` leaves the tree clean, so there is no generated-files drift. Reverting the source makes the new test fail.
