### PR TITLE
fix(input): dispose the drag source handle when the target lookup fails

### DIFF
--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -386,21 +386,26 @@ export const drag = definePageTool({
     const fromHandle = await request.page.getElementByUid(
       request.params.from_uid,
     );
-    const toHandle = await request.page.getElementByUid(request.params.to_uid);
     try {
-      const result = await request.page.waitForEventsAfterAction(async () => {
-        await fromHandle.drag(toHandle);
-        await new Promise(resolve => setTimeout(resolve, 50));
-        await toHandle.drop(fromHandle);
-      });
-      response.appendResponseLine(`Successfully dragged an element`);
-      response.attachWaitForResult(result);
-      if (request.params.includeSnapshot) {
-        response.includeSnapshot();
+      const toHandle = await request.page.getElementByUid(
+        request.params.to_uid,
+      );
+      try {
+        const result = await request.page.waitForEventsAfterAction(async () => {
+          await fromHandle.drag(toHandle);
+          await new Promise(resolve => setTimeout(resolve, 50));
+          await toHandle.drop(fromHandle);
+        });
+        response.appendResponseLine(`Successfully dragged an element`);
+        response.attachWaitForResult(result);
+        if (request.params.includeSnapshot) {
+          response.includeSnapshot();
+        }
+      } finally {
+        void toHandle.dispose();
       }
     } finally {
       void fromHandle.dispose();
-      void toHandle.dispose();
     }
   },
 });

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -1055,6 +1055,43 @@ describe('input', () => {
         assert.ok(await page.$('text/dropped'));
       });
     });
+
+    it('disposes the source handle when the target lookup fails', async () => {
+      await withMcpContext(async (response, context) => {
+        const mcpPage = context.getSelectedMcpPage();
+        await mcpPage.pptrPage.setContent(html`<div id="drag">drag me</div>`);
+        mcpPage.textSnapshot = await TextSnapshot.create(mcpPage);
+        const fromHandle = await mcpPage.getElementByUid('1_1');
+        const disposeSpy = sinon.spy(fromHandle, 'dispose');
+        // First lookup (from_uid) succeeds, second (to_uid) throws as it would
+        // for a stale/invalid uid.
+        const stub = sinon.stub(mcpPage, 'getElementByUid');
+        stub.onFirstCall().resolves(fromHandle);
+        stub
+          .onSecondCall()
+          .rejects(
+            new Error('Element uid "bad" no longer exists on the page.'),
+          );
+
+        try {
+          await assert.rejects(
+            drag.handler(
+              {
+                params: {from_uid: '1_1', to_uid: 'bad'},
+                page: mcpPage,
+              },
+              response,
+              context,
+            ),
+            /no longer exists/,
+          );
+
+          sinon.assert.calledOnce(disposeSpy);
+        } finally {
+          sinon.restore();
+        }
+      });
+    });
   });
 
   describe('fill form', () => {


### PR DESCRIPTION
Fixes #2440

## Problem

The `drag` handler resolved both element handles before its `try/finally`:

```ts
const fromHandle = await request.page.getElementByUid(request.params.from_uid);
const toHandle   = await request.page.getElementByUid(request.params.to_uid); // can throw
try { ...drag... } finally { void fromHandle.dispose(); void toHandle.dispose(); }
```

If `getElementByUid(to_uid)` throws — which it does for a stale/invalid `to_uid` — the `try` is never entered and `fromHandle` (a fresh remote object) is never disposed, leaking it for the life of the page's execution context. Same class as the merged #2422; `fill_form` already handles this correctly, so `drag` was the only affected input tool.

## Fix

Acquire `toHandle` inside a nested `try` so `fromHandle` is disposed on every path:

```ts
const fromHandle = await request.page.getElementByUid(request.params.from_uid);
try {
  const toHandle = await request.page.getElementByUid(request.params.to_uid);
  try { ...drag... } finally { void toHandle.dispose(); }
} finally { void fromHandle.dispose(); }
```

## Testing

- Added `disposes the source handle when the target lookup fails`: stubs `getElementByUid` so the target lookup rejects, and asserts the source handle's `dispose` was still called. Fails on `main` (`dispose` called 0 times) and passes with this change.
- `npm run test tests/tools/input.test.ts` — all pass.
- ESLint + Prettier clean.
