### PR TITLE
fix: preserve path prefix in --browserUrl discovery (#2394)

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -75,7 +75,34 @@ export async function ensureBrowserConnected(options: {
       connectOptions.headers = options.wsHeaders;
     }
   } else if (options.browserURL) {
-    connectOptions.browserURL = options.browserURL;
+    // Puppeteer's getWSEndpoint() uses `new URL('/json/version', browserURL)`
+    // which replaces the entire pathname when the second argument is an
+    // absolute path. For a browserURL with a path prefix (e.g. behind a
+    // reverse proxy like `http://host/t/abc123`), this drops the prefix and
+    // discovery fails (issue #2394). Resolve the WebSocket endpoint ourselves
+    // and pass it as `browserWSEndpoint` so Puppeteer skips getWSEndpoint().
+    const parsedBrowserURL = new URL(options.browserURL);
+    const discoveryURL = new URL(
+      parsedBrowserURL.pathname.replace(/\/?$/, '/') + 'json/version',
+      parsedBrowserURL.origin,
+    );
+    // Preserve any search params from the original URL.
+    parsedBrowserURL.searchParams.forEach((value, key) => {
+      discoveryURL.searchParams.set(key, value);
+    });
+    const response = await fetch(discoveryURL);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch browser webSocket URL from ${discoveryURL.href} (status ${response.status})`,
+      );
+    }
+    const data = (await response.json()) as {webSocketDebuggerUrl?: string};
+    if (!data.webSocketDebuggerUrl) {
+      throw new Error(
+        `Browser at ${discoveryURL.href} did not return a webSocketDebuggerUrl`,
+      );
+    }
+    connectOptions.browserWSEndpoint = data.webSocketDebuggerUrl;
   } else if (channel || options.userDataDir) {
     const userDataDir = options.userDataDir;
     if (userDataDir) {


### PR DESCRIPTION
## Summary

Fixes #2394.

When `--browserUrl` includes a path prefix (e.g. Chrome DevTools behind a reverse proxy or gateway like `http://127.0.0.1:54704/t/abc123`), Puppeteer's `getWSEndpoint()` uses `new URL('/json/version', browserURL)` which replaces the entire pathname. The path prefix is dropped, discovery fails, and the user sees:

```
Failed to fetch browser webSocket URL from http://127.0.0.1:54704/json/version
```

## Root Cause

```js
// Puppeteer's bundled getWSEndpoint()
const endpointURL = new URL('/json/version', browserURL);
// http://127.0.0.1:54704/t/abc123 + /json/version → http://127.0.0.1:54704/json/version (prefix lost)
```

The JS `URL` constructor with an absolute path (`/json/version`) replaces the base URL's entire pathname.

## Fix

Resolve the WebSocket endpoint ourselves in `src/browser.ts` before passing it to `puppeteer.connect()`:

1. Parse `browserURL` and append `json/version` to the **existing** pathname (rather than replacing it).
2. Fetch the discovery response (`{ webSocketDebuggerUrl }`).
3. Pass `data.webSocketDebuggerUrl` as `browserWSEndpoint` so Puppeteer skips its own `getWSEndpoint()` entirely.

```ts
const parsedBrowserURL = new URL(options.browserURL);
const discoveryURL = new URL(
  parsedBrowserURL.pathname.replace(/\/?$/, '/') + 'json/version',
  parsedBrowserURL.origin,
);
// Preserve any search params from the original URL.
parsedBrowserURL.searchParams.forEach((value, key) => {
  discoveryURL.searchParams.set(key, value);
});
const response = await fetch(discoveryURL);
const data = await response.json();
connectOptions.browserWSEndpoint = data.webSocketDebuggerUrl;
```

## Testing

URL construction verified against 5 cases:

| Input | Discovery URL |
|---|---|
| `http://127.0.0.1:54704/t/abc123` | `http://127.0.0.1:54704/t/abc123/json/version` ✅ |
| `http://127.0.0.1:9222` | `http://127.0.0.1:9222/json/version` ✅ |
| `http://127.0.0.1:9222/` | `http://127.0.0.1:9222/json/version` ✅ |
| `http://host:8080/prefix/` | `http://host:8080/prefix/json/version` ✅ |
| `https://proxy.example.com/cdp/t/token` | `https://proxy.example.com/cdp/t/token/json/version` ✅ |

The previous PR #2403 was closed without a fix; this implements the suggested fix from the issue report.