### PR TITLE
fix: resolve dangling symlinks to their target in resolveCanonicalPath

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -15,18 +15,52 @@ export async function getTempFilePath(filename: string) {
   return filepath;
 }
 
-export async function resolveCanonicalPath(filePath: string): Promise<string> {
+function isENOENT(err: unknown): boolean {
+  return (
+    !!err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT'
+  );
+}
+
+// Matches the conventional SYMLOOP_MAX so a cycle of dangling links cannot
+// recurse without bound.
+const MAX_SYMLINK_DEPTH = 40;
+
+export async function resolveCanonicalPath(
+  filePath: string,
+  depth = 0,
+): Promise<string> {
   const absolutePath = path.resolve(filePath);
   try {
     // Get the true canonical path, resolving all symlinks.
     return await fs.realpath(absolutePath);
   } catch (err) {
-    if (
-      err &&
-      typeof err === 'object' &&
-      'code' in err &&
-      err.code === 'ENOENT'
-    ) {
+    if (isENOENT(err)) {
+      // realpath() also reports ENOENT for a symlink whose target does not
+      // exist. Treating that as a missing path would fall through to the
+      // ancestor walk below and return the link's own location, which hides
+      // the fact that writing to it lands wherever the link points. Follow the
+      // link explicitly instead, so the caller sees the real destination.
+      let linkStat;
+      try {
+        linkStat = await fs.lstat(absolutePath);
+      } catch {
+        linkStat = undefined;
+      }
+      if (linkStat?.isSymbolicLink()) {
+        if (depth >= MAX_SYMLINK_DEPTH) {
+          throw err;
+        }
+        const target = await fs.readlink(absolutePath);
+        const resolvedTarget = path.resolve(
+          path.dirname(absolutePath),
+          target,
+        );
+        if (resolvedTarget === absolutePath) {
+          throw err;
+        }
+        return await resolveCanonicalPath(resolvedTarget, depth + 1);
+      }
+
       // Find the nearest existing ancestor directory on the filesystem.
       let current = absolutePath;
       const missingSegments: string[] = [];
@@ -37,19 +71,17 @@ export async function resolveCanonicalPath(filePath: string): Promise<string> {
           throw err;
         }
         try {
-          const canonicalParent = await fs.realpath(parent);
+          // Resolve the parent through this function rather than realpath() so
+          // that a dangling symlink used as an intermediate directory is
+          // followed to its destination as well.
+          const canonicalParent = await resolveCanonicalPath(parent, depth + 1);
           return path.join(
             canonicalParent,
             path.basename(current),
             ...missingSegments,
           );
         } catch (parentErr) {
-          if (
-            parentErr &&
-            typeof parentErr === 'object' &&
-            'code' in parentErr &&
-            parentErr.code === 'ENOENT'
-          ) {
+          if (isENOENT(parentErr)) {
             missingSegments.unshift(path.basename(current));
             current = parent;
           } else {

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -51,10 +51,7 @@ export async function resolveCanonicalPath(
           throw err;
         }
         const target = await fs.readlink(absolutePath);
-        const resolvedTarget = path.resolve(
-          path.dirname(absolutePath),
-          target,
-        );
+        const resolvedTarget = path.resolve(path.dirname(absolutePath), target);
         if (resolvedTarget === absolutePath) {
           throw err;
         }

--- a/tests/utils/files.test.ts
+++ b/tests/utils/files.test.ts
@@ -92,4 +92,76 @@ describe('resolveCanonicalPath', () => {
       await fs.rm(tmpDir, {recursive: true, force: true});
     }
   });
+
+  it('should resolve a dangling symlink to its target, not to the link', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'resolve-canonical-test-'),
+    );
+    try {
+      const inside = path.join(tmpDir, 'inside');
+      const outside = path.join(tmpDir, 'outside');
+      await fs.mkdir(inside);
+      await fs.mkdir(outside);
+
+      // The target does not exist, so realpath() reports ENOENT for the link
+      // just as it would for a missing file.
+      const target = path.join(outside, 'not-created-yet.txt');
+      const link = path.join(inside, 'link.txt');
+      await fs.symlink(target, link);
+
+      const resolved = await resolveCanonicalPath(link);
+      const canonicalOutside = await fs.realpath(outside);
+      assert.strictEqual(
+        resolved,
+        path.join(canonicalOutside, 'not-created-yet.txt'),
+      );
+    } finally {
+      await fs.rm(tmpDir, {recursive: true, force: true});
+    }
+  });
+
+  it('should resolve through a dangling symlink used as a parent directory', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'resolve-canonical-test-'),
+    );
+    try {
+      const inside = path.join(tmpDir, 'inside');
+      const outside = path.join(tmpDir, 'outside');
+      await fs.mkdir(inside);
+      await fs.mkdir(outside);
+
+      const targetDir = path.join(outside, 'not-created-yet');
+      const linkDir = path.join(inside, 'link_dir');
+      await fs.symlink(targetDir, linkDir, 'dir');
+
+      const resolved = await resolveCanonicalPath(
+        path.join(linkDir, 'file.txt'),
+      );
+      const canonicalOutside = await fs.realpath(outside);
+      assert.strictEqual(
+        resolved,
+        path.join(canonicalOutside, 'not-created-yet', 'file.txt'),
+      );
+    } finally {
+      await fs.rm(tmpDir, {recursive: true, force: true});
+    }
+  });
+
+  it('should not loop forever on a self-referential dangling symlink', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'resolve-canonical-test-'),
+    );
+    try {
+      const a = path.join(tmpDir, 'a');
+      const b = path.join(tmpDir, 'b');
+      await fs.symlink(b, a);
+      await fs.symlink(a, b);
+
+      await assert.rejects(async () => {
+        await resolveCanonicalPath(a);
+      });
+    } finally {
+      await fs.rm(tmpDir, {recursive: true, force: true});
+    }
+  });
 });


### PR DESCRIPTION
### Problem

`fs.realpath()` reports `ENOENT` in two different situations: the path does not exist, and the path is a symlink whose target does not exist. `resolveCanonicalPath` treats both the same way, so for a dangling symlink it falls through to the nearest existing ancestor walk and returns

```
path.join(canonicalParent, path.basename(current), ...missingSegments)
```

which is the link's own location, not where the link points.

`McpContext.validatePath` uses that value to decide whether a client supplied path lies inside a configured workspace root:

```ts
canonicalPath === canonicalRoot ||
canonicalPath.startsWith(canonicalRoot + path.sep)
```

So a dangling symlink sitting inside a root resolves to a path inside the root and passes containment, even though a write to it lands at the link target. A live symlink pointing outside the root is handled correctly today, because `realpath()` succeeds and containment then fails. Only the dangling case slips through. The same applies when the dangling symlink is an intermediate directory component.

Measured against the current resolver, using the containment expression above:

| Input | resolved to | passes containment |
| :-- | :-- | :-- |
| new file in root | inside root | yes, correct |
| symlink to an existing file outside root | the outside target | no, correct |
| symlink to a non-existent file outside root | the link itself, inside root | **yes, incorrect** |
| dangling symlink as a parent directory | the link path, inside root | **yes, incorrect** |

Most write paths are not affected in practice, because `McpContext.#writeFile` passes `O_NOFOLLOW` and fails with `ELOOP` on a symlink. The gap matters for writers that do not, for example `page.screencast()`, which hands the path to ffmpeg.

### Change

When `realpath()` fails with `ENOENT`, `lstat` the path first. If it is a symlink, read the link and resolve the target instead of treating the path as missing. The ancestor walk now resolves the parent through `resolveCanonicalPath` as well, so a dangling symlink used as an intermediate directory is followed too.

Recursion is bounded by `MAX_SYMLINK_DEPTH`, set to the conventional `SYMLOOP_MAX` of 40, and a self referential link still rejects rather than looping.

### Tests

Three cases added to `tests/utils/files.test.ts`:

* a dangling symlink resolves to its target rather than to the link
* a dangling symlink used as a parent directory resolves through to the target
* a pair of self referential dangling links rejects instead of looping

The first two fail on the current resolver and pass with this change. The four existing `resolveCanonicalPath` tests continue to pass, so behaviour for existing files, missing files with existing parents, deeply nested missing paths, and live symlinks is unchanged.
