### PR TITLE
fix: load source maps on demand instead of for every parsed script

### DIFF
--- a/src/devtools/DevToolsConnectionAdapter.ts
+++ b/src/devtools/DevToolsConnectionAdapter.ts
@@ -8,6 +8,11 @@ import type * as puppeteer from '../third_party/index.js';
 import type {DevTools} from '../third_party/index.js';
 import {CDPSessionEvent} from '../third_party/index.js';
 
+import {
+  isResourceUrlAllowed,
+  recordRefusedResourceUrl,
+} from './sourceMapGate.js';
+
 /**
  * This class makes a puppeteer connection look like DevTools CDPConnection.
  *
@@ -57,6 +62,22 @@ export class PuppeteerDevToolsConnection
     const session = this.#connection.session(sessionId);
     if (!session) {
       throw new Error('Unknown session ' + sessionId);
+    }
+    // The DevTools frontend loads developer resources (in practice: source
+    // maps) for every script it sees. We only want the ones we are about to
+    // use, so refuse the rest before they reach the browser. Answering with a
+    // protocol error is the path `PageResourceLoader` already handles.
+    if (method === 'Network.loadNetworkResource') {
+      const url = (params as {url?: string})?.url;
+      if (url !== undefined && !isResourceUrlAllowed(url)) {
+        recordRefusedResourceUrl(url);
+        return Promise.resolve({
+          error: {
+            code: -32000,
+            message: 'Developer resources are loaded on demand',
+          } as DevTools.CDPConnection.CDPError,
+        });
+      }
     }
     // Rolled protocol version between puppeteer and DevTools doesn't necessarily match
     /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/src/devtools/DevtoolsUtils.ts
+++ b/src/devtools/DevtoolsUtils.ts
@@ -13,6 +13,8 @@ import type {
 
 import {PuppeteerDevToolsConnection} from './DevToolsConnectionAdapter.js';
 import {McpHostBindingAdapter} from './McpHostBindingAdapter.js';
+import {allowResourceUrl} from './sourceMapGate.js';
+import {logger} from '../utils/logger.js';
 
 /**
  * A mock implementation of an issues manager that only implements the methods
@@ -429,9 +431,14 @@ export async function createStackTrace(
   await Promise.all(
     [...scriptIds].map(id =>
       waitForScript(model, id, signal)
+        .then(script => attachSourceMapOnDemand(model, script))
         .then(script =>
           model.sourceMapManager().sourceMapForClientPromise(script),
         )
+        // A map loaded on demand is brand new, so its scope info can still be
+        // pending. Without this the frames resolve to positions but not to
+        // function names.
+        .then(sourceMap => sourceMap?.waitForScopeInfo())
         .catch(),
     ),
   );
@@ -446,6 +453,60 @@ export async function createStackTrace(
     >[0],
     target,
   );
+}
+
+type DevToolsScript = NonNullable<
+  ReturnType<DevTools.DebuggerModel['scriptForId']>
+>;
+
+/**
+ * Loads the source map for a single script, now that we know we need it.
+ *
+ * Every script is attached to the source map manager when it is parsed, but the
+ * download is refused by the gate (see sourceMapGate.ts), so the client sits
+ * there with no source map. Allowing the URL and re-attaching makes the manager
+ * run the load it skipped, for this one script.
+ */
+const attemptedSourceMaps = new WeakSet<object>();
+
+async function attachSourceMapOnDemand(
+  model: DevTools.DebuggerModel,
+  script: DevToolsScript,
+): Promise<DevToolsScript> {
+  const sourceMapManager = model.sourceMapManager();
+  if (!script.sourceMapURL || sourceMapManager.sourceMapForClient(script)) {
+    return script;
+  }
+  // A map that already failed to load stays failed. Without this, every stack
+  // trace naming the script would retry the download.
+  if (attemptedSourceMaps.has(script)) {
+    return script;
+  }
+  attemptedSourceMaps.add(script);
+
+  // Inline source maps never reach the resource loader.
+  if (!script.sourceMapURL.startsWith('data:')) {
+    let resolved = script.sourceMapURL;
+    try {
+      resolved = new URL(script.sourceMapURL, script.sourceURL).href;
+    } catch {
+      // Not resolvable against the script URL; allow the raw value instead.
+    }
+    allowResourceUrl(resolved);
+    allowResourceUrl(script.sourceMapURL);
+  }
+
+  try {
+    sourceMapManager.detachSourceMap(script);
+    sourceMapManager.attachSourceMap(
+      script,
+      script.sourceURL,
+      script.sourceMapURL,
+    );
+  } catch (error) {
+    logger?.('Failed to attach a source map on demand', error);
+  }
+  return script;
 }
 
 // Waits indefinitely for the script so pair it with Promise.race.

--- a/src/devtools/McpHostBindingAdapter.ts
+++ b/src/devtools/McpHostBindingAdapter.ts
@@ -228,6 +228,11 @@ class BaseMcpHostBindingAdapter
   ): void {}
 }
 
+import {
+  isResourceUrlAllowed,
+  recordRefusedResourceUrl,
+} from './sourceMapGate.js';
+
 export class McpHostBindingAdapter extends BaseMcpHostBindingAdapter {
   #loadResource: (path: string) => Promise<string>;
 
@@ -276,6 +281,15 @@ export class McpHostBindingAdapter extends BaseMcpHostBindingAdapter {
         statusCode: 404,
         urlValid: false,
       });
+      return;
+    }
+
+    // Second half of the on-demand gate, see sourceMapGate.ts. This is the
+    // fallback `PageResourceLoader` uses when the CDP loader fails, so leaving
+    // it open would just reroute every source map download through here.
+    if (!isResourceUrlAllowed(urlString)) {
+      recordRefusedResourceUrl(urlString);
+      callback({statusCode: 404});
       return;
     }
 

--- a/src/devtools/sourceMapGate.ts
+++ b/src/devtools/sourceMapGate.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {logger} from '../utils/logger.js';
+
+/**
+ * DevTools attaches a source map to every script a page parses, and keeps the
+ * decoded mappings for the life of the model. On a script-heavy app that is
+ * hundreds of downloads and gigabytes of retained mappings per page, none of
+ * which we asked for: the only thing the MCP does with source maps is
+ * symbolicate the handful of frames in a stack trace it is about to format.
+ *
+ * So resource loads made by the DevTools frontend are refused by default, and
+ * a URL is allowed only for as long as it takes to attach the source map of a
+ * script we actually need. Both load channels have to be gated, because
+ * `PageResourceLoader.dispatchLoad()` falls back from the CDP loader to the
+ * host bindings when the first one fails.
+ */
+const allowedUrls = new Set<string>();
+
+/** Counts refusals per URL, for diagnostics only. */
+const refused = new Map<string, number>();
+
+export function allowResourceUrl(url: string): void {
+  allowedUrls.add(url);
+}
+
+export function disallowResourceUrl(url: string): void {
+  allowedUrls.delete(url);
+}
+
+export function isResourceUrlAllowed(url: string): boolean {
+  return allowedUrls.has(url);
+}
+
+export function recordRefusedResourceUrl(url: string): void {
+  refused.set(url, (refused.get(url) ?? 0) + 1);
+  logger?.('Refused an on-demand DevTools resource load', url);
+}
+
+export function getRefusedResourceUrlsForTesting(): Map<string, number> {
+  return new Map(refused);
+}
+
+export function resetSourceMapGateForTesting(): void {
+  allowedUrls.clear();
+  refused.clear();
+}


### PR DESCRIPTION
Replaces the original contents of this PR. That version made the DevTools universe lazy, which @OrKoN pointed out collides with #1777 and, as it turns out, treated the symptom anyway: the cost is per page whether or not the universe is created eagerly. This version fixes the cost itself and has no bearing on how many pages get a universe.

Root cause and measurements are in https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/2431#issuecomment-5170268714.

### Problem

`DebuggerModel.parsedScriptSource()` calls `attachSourceMap()` for every script that carries a `sourceMapURL`, because `SourceMapManager` defaults to enabled. Each map is downloaded, VLQ decoded, sorted, reverse mapped, and the decoded mappings are retained for as long as the model lives. On one Jira issue page that is 147 maps and 2427 MB retained, measured with a full GC forced every second. `createPagesSnapshot()` builds an `McpPage` for every page in the browser, so this is paid per open tab.

### Change

The universe only needs source maps to symbolicate the frames of a stack trace it is about to format, and `createStackTrace()` already walks exactly those scripts. So:

- Developer resource loads are refused by default. Both channels have to be gated: `PageResourceLoader.dispatchLoad()` falls back from the CDP loader to the host bindings, so gating one alone reroutes the download instead of preventing it. That is `PuppeteerDevToolsConnection.send` and `McpHostBindingAdapter.loadNetworkResource`.
- `createStackTrace()` allows the URL for a script it needs, then does `detachSourceMap()` + `attachSourceMap()` on that one script, which makes the manager run the load it skipped.
- It then awaits `sourceMap.waitForScopeInfo()`. Without that the frames resolve to positions but the function names come back empty, which is easy to miss.
- A map that already failed to load is not retried.

`SourceMapManager.setEnabled(false)` is not usable for this: `setEnabled(true)` re-attaches every registered client at once, so toggling it around a symbolication brings the whole avalanche back.

### Results

Fixture is a rollup bundle with a real source map back to `src/app.js`; the large one has a 2.8 MB map. Memory is measured against a real browser with 18 ordinary tabs open (Teams, Jira, Gmail, a few SPAs), one `list_pages` call and then no tool calls at all.

| | `main` | this branch |
| --- | --- | --- |
| RSS | OOM at 4.9 GB in 65 s | 210.1 -> 210.3 MB over 120 s |
| stack trace | `deliberatelyFail (app.js:2:9)` … | byte-identical |
| `get_console_message`, 2.8 MB map, 3 runs | 1893 / 1882 / 2340 ms | 133 / 139 / 142 ms |
| `npm run test` | baseline | no new failures |

Two things worth calling out. The memory result holds with every one of the 18 pages still getting a universe, so this does not depend on the lazy-universe idea at all. And symbolication came out roughly 14x faster rather than slower, which I did not expect; I have not dug into why the eager path is slow, so treat that number as an observation rather than a claim about the mechanism.

### Notes for review

- The allowlist in `sourceMapGate.ts` is module state. Per-context would be tidier if you would rather have it on `McpContext`, I kept it standalone so the two gate points do not need a context reference.
- I first put the fallback gate in `McpContext.loadResource` and it broke eight tests, correctly: that method is a public API with its own allowlist, blocklist, `file:` and path-validation semantics. It lives in the host binding adapter instead.
- Inline `data:` source maps never reach the loader and are unaffected.
- Separately, and not fixed here: detaching a CDP session while a source map is loading throws an uncaught `Error: Unknown session <id>` out of `PuppeteerDevToolsConnection.send` and kills the process. `send()` is declared to return a promise but throws synchronously, so the generated agent code never catches it. Happy to send that as its own PR.
