### PR TITLE
test: unskip webmcp test now that Chrome 149 is stable

### DIFF
--- a/tests/tools/webmcp.test.ts
+++ b/tests/tools/webmcp.test.ts
@@ -65,10 +65,13 @@ describe('webmcp', () => {
       await withMcpContext(
         async (response, context) => {
           const page = context.getSelectedMcpPage();
+          const toolsAddedPromise = new Promise(resolve => {
+            page.pptrPage.webmcp.once('toolsadded', resolve);
+          });
           await setupWebMcpTool(page);
 
           // Wait for WebMCP tools to be registered and detected by Puppeteer
-          await new Promise(r => setTimeout(r, 100));
+          await toolsAddedPromise;
 
           await executeWebMcpTool.handler(
             {params: {toolName: 'test_tool', input: JSON.stringify({})}, page},

--- a/tests/tools/webmcp.test.ts
+++ b/tests/tools/webmcp.test.ts
@@ -61,12 +61,14 @@ describe('webmcp', () => {
       );
     }
 
-    // TODO: Remove `.skip` once Chrome 149 reaches stable channel.
-    it.skip('executes a tool successfully', async () => {
+    it('executes a tool successfully', async () => {
       await withMcpContext(
         async (response, context) => {
           const page = context.getSelectedMcpPage();
           await setupWebMcpTool(page);
+
+          // Wait for WebMCP tools to be registered and detected by Puppeteer
+          await new Promise(r => setTimeout(r, 100));
 
           await executeWebMcpTool.handler(
             {params: {toolName: 'test_tool', input: JSON.stringify({})}, page},


### PR DESCRIPTION
Unskips the `execute_webmcp_tool` test in `tests/tools/webmcp.test.ts` as requested since Chrome 149 features are available. Included a small sleep in the test to make it reliable by waiting for WebMCP tools to be successfully registered with Puppeteer before trying to execute them.

---
*PR created automatically by Jules for task [15184110676727103525](https://jules.google.com/task/15184110676727103525) started by @OrKoN*