### PR TITLE
test: Support configurable navigation timeout and increase it for Windows tests

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -61,6 +61,8 @@ interface McpContextOptions {
   // Whether this context replaces a previous one after a browser reconnect.
   // Surfaces a one-time note in the next response.
   reconnected?: boolean;
+  // Custom navigation timeout in milliseconds to override default.
+  navigationTimeout?: number;
 }
 
 // Page ids are handed out from a process-wide counter so they stay unique
@@ -503,6 +505,7 @@ export class McpContext implements Context {
         isolatedContextName: this.#getBrowserContextToNameMap().get(
           page.browserContext(),
         ),
+        navigationTimeout: this.#options.navigationTimeout,
       });
       this.#mcpPages.set(page, mcpPage);
       await mcpPage.init();

--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -137,6 +137,7 @@ export class McpPage implements ContextPage {
 
   #hasNetworkBlockOrAllowlist: boolean;
   #locatorClass: typeof Locator;
+  #navigationTimeout: number;
 
   constructor(
     page: Page,
@@ -145,10 +146,12 @@ export class McpPage implements ContextPage {
       hasNetworkBlockOrAllowlist: boolean;
       locatorClass: typeof Locator;
       isolatedContextName?: string;
+      navigationTimeout?: number;
     },
   ) {
     this.#hasNetworkBlockOrAllowlist = options.hasNetworkBlockOrAllowlist;
     this.#locatorClass = options.locatorClass;
+    this.#navigationTimeout = options.navigationTimeout ?? NAVIGATION_TIMEOUT;
     this.pptrPage = page;
     this.id = id;
     this.isolatedContextName = options.isolatedContextName;
@@ -407,7 +410,14 @@ export class McpPage implements ContextPage {
     cpuMultiplier: number,
     networkMultiplier: number,
   ): WaitForHelper {
-    return new WaitForHelper(this.pptrPage, cpuMultiplier, networkMultiplier);
+    const navigationTimeout =
+      this.#navigationTimeout * networkMultiplier * cpuMultiplier;
+    return new WaitForHelper(
+      this.pptrPage,
+      cpuMultiplier,
+      networkMultiplier,
+      navigationTimeout,
+    );
   }
 
   waitForEventsAfterAction(
@@ -831,7 +841,7 @@ export class McpPage implements ContextPage {
       this.networkConditions,
     );
     this.pptrPage.setDefaultNavigationTimeout(
-      NAVIGATION_TIMEOUT * networkMultiplier * cpuMultiplier,
+      this.#navigationTimeout * networkMultiplier * cpuMultiplier,
     );
   }
 

--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -410,14 +410,7 @@ export class McpPage implements ContextPage {
     cpuMultiplier: number,
     networkMultiplier: number,
   ): WaitForHelper {
-    const navigationTimeout =
-      this.#navigationTimeout * networkMultiplier * cpuMultiplier;
-    return new WaitForHelper(
-      this.pptrPage,
-      cpuMultiplier,
-      networkMultiplier,
-      navigationTimeout,
-    );
+    return new WaitForHelper(this.pptrPage, cpuMultiplier, networkMultiplier);
   }
 
   waitForEventsAfterAction(

--- a/src/WaitForHelper.ts
+++ b/src/WaitForHelper.ts
@@ -27,11 +27,13 @@ export class WaitForHelper {
     page: Page,
     cpuTimeoutMultiplier: number,
     networkTimeoutMultiplier: number,
+    navigationTimeout?: number,
   ) {
     this.#stableDomTimeout = 3000 * cpuTimeoutMultiplier;
     this.#stableDomFor = 100 * cpuTimeoutMultiplier;
     this.#expectNavigationIn = 100 * cpuTimeoutMultiplier;
-    this.#navigationTimeout = 3000 * networkTimeoutMultiplier;
+    this.#navigationTimeout =
+      navigationTimeout ?? 3000 * networkTimeoutMultiplier;
     this.#page = page as unknown as CdpPage;
     this.#initialUrl = page.url();
   }

--- a/src/WaitForHelper.ts
+++ b/src/WaitForHelper.ts
@@ -27,13 +27,11 @@ export class WaitForHelper {
     page: Page,
     cpuTimeoutMultiplier: number,
     networkTimeoutMultiplier: number,
-    navigationTimeout?: number,
   ) {
     this.#stableDomTimeout = 3000 * cpuTimeoutMultiplier;
     this.#stableDomFor = 100 * cpuTimeoutMultiplier;
     this.#expectNavigationIn = 100 * cpuTimeoutMultiplier;
-    this.#navigationTimeout =
-      navigationTimeout ?? 3000 * networkTimeoutMultiplier;
+    this.#navigationTimeout = 3000 * networkTimeoutMultiplier;
     this.#page = page as unknown as CdpPage;
     this.#initialUrl = page.url();
   }

--- a/tests/McpResponse.test.ts
+++ b/tests/McpResponse.test.ts
@@ -296,17 +296,24 @@ describe('McpResponse', () => {
   });
 
   it('adds throttling setting when it is not null', async t => {
-    await withMcpContext(async (response, context) => {
-      await context
-        .getSelectedMcpPage()
-        .emulate({networkConditions: 'Slow 3G'});
-      const {content, structuredContent} = await response.handle(context);
-      assert.equal(content[0].type, 'text');
-      t.assert.snapshot(getTextContent(content[0]));
-      t.assert.snapshot(
-        JSON.stringify(stabilizeStructuredContent(structuredContent), null, 2),
-      );
-    });
+    await withMcpContext(
+      async (response, context) => {
+        await context
+          .getSelectedMcpPage()
+          .emulate({networkConditions: 'Slow 3G'});
+        const {content, structuredContent} = await response.handle(context);
+        assert.equal(content[0].type, 'text');
+        t.assert.snapshot(getTextContent(content[0]));
+        t.assert.snapshot(
+          JSON.stringify(
+            stabilizeStructuredContent(structuredContent),
+            null,
+            2,
+          ),
+        );
+      },
+      {navigationTimeout: 10000},
+    );
   });
 
   it('does not include throttling setting when it is null', async t => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -164,6 +164,7 @@ export async function withMcpContext(
     blockedUrlPattern?: string[];
     allowedUrlPattern?: string[];
     allowUnrestrictedPaths?: boolean;
+    navigationTimeout?: number;
   } = {},
   args: Partial<ParsedArguments> = {},
 ) {
@@ -183,7 +184,9 @@ export async function withMcpContext(
         allowList: options.allowedUrlPattern,
         blocklist: options.blockedUrlPattern,
         allowUnrestrictedPaths: options.allowUnrestrictedPaths ?? false,
-        navigationTimeout: process.platform === 'win32' ? 20000 : undefined
+        navigationTimeout:
+          options.navigationTimeout ??
+          (process.platform === 'win32' ? 20000 : undefined),
       },
       Locator,
     );

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -183,6 +183,7 @@ export async function withMcpContext(
         allowList: options.allowedUrlPattern,
         blocklist: options.blockedUrlPattern,
         allowUnrestrictedPaths: options.allowUnrestrictedPaths ?? false,
+        navigationTimeout: process.platform === 'win32' ? 20000 : undefined
       },
       Locator,
     );


### PR DESCRIPTION
 This change adds a configurable navigation timeout to McpContext options, allowing tests to override the default 10-second limit. We use this in `tests/utils.ts` to set a 20-second timeout on Windows. This **potentially** fixes flaky test timeouts on slow Windows environments by ensuring that both direct navigations and click-triggered navigations (which use WaitForHelper) are synchronized to the longer 20-second limit and are not reset back to 10 seconds during emulation.