### PR TITLE
test: add targeted unit tests for core utilities and transforms

### DIFF
--- a/tests/tools/ToolDefinitionTransforms.test.ts
+++ b/tests/tools/ToolDefinitionTransforms.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {describe, it} from 'node:test';
+
+import {
+  viewportTransform,
+  geolocationTransform,
+} from '../../src/tools/ToolDefinition.js';
+
+describe('viewportTransform', () => {
+  it('returns undefined for empty input', () => {
+    assert.strictEqual(viewportTransform(undefined), undefined);
+  });
+
+  it('parses simple widthxheight', () => {
+    const v = viewportTransform('800x600');
+    assert.strictEqual(v?.width, 800);
+    assert.strictEqual(v?.height, 600);
+    assert.strictEqual(v?.isMobile, false);
+    assert.strictEqual(v?.hasTouch, false);
+    assert.strictEqual(v?.isLandscape, false);
+  });
+
+  it('parses tags like mobile, touch and landscape', () => {
+    const v = viewportTransform('375x812,mobile,touch,landscape');
+    assert.strictEqual(v?.width, 375);
+    assert.strictEqual(v?.height, 812);
+    assert.strictEqual(v?.isMobile, true);
+    assert.strictEqual(v?.hasTouch, true);
+    assert.strictEqual(v?.isLandscape, true);
+  });
+});
+
+describe('geolocationTransform', () => {
+  it('returns undefined for empty input', () => {
+    assert.strictEqual(geolocationTransform(undefined), undefined);
+  });
+
+  it('parses latitude and longitude', () => {
+    const g = geolocationTransform('59.3293,18.0686');
+    assert.ok(g);
+    assert.strictEqual(Number(g.latitude.toFixed(4)), 59.3293);
+    assert.strictEqual(Number(g.longitude.toFixed(4)), 18.0686);
+  });
+});

--- a/tests/utils/id.test.ts
+++ b/tests/utils/id.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {describe, it} from 'node:test';
+
+import {createIdGenerator, stableIdSymbol} from '../../src/utils/id.js';
+
+describe('createIdGenerator', () => {
+  it('produces sequential integers starting at 1', () => {
+    const gen = createIdGenerator();
+    assert.strictEqual(gen(), 1);
+    assert.strictEqual(gen(), 2);
+    assert.strictEqual(gen(), 3);
+  });
+});
+
+describe('stableIdSymbol', () => {
+  it('is a symbol and can be used as a property key', () => {
+    const obj: Record<symbol, number> = {} as Record<symbol, number>;
+    obj[stableIdSymbol] = 42;
+    assert.strictEqual(obj[stableIdSymbol], 42);
+  });
+});

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {describe, it} from 'node:test';
+
+import {saveLogsToFile, flushLogs} from '../../src/utils/logger.js';
+
+describe('logger utilities', () => {
+  it('writes and flushes to file', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'logger-test-'));
+    try {
+      const logPath = path.join(tmpDir, 'out.log');
+      const stream = saveLogsToFile(logPath);
+
+      // Write directly to stream; saveLogsToFile also patches debug.log but
+      // writing here verifies flush behavior.
+      stream.write('hello-logger\n');
+
+      await flushLogs(stream, 2000);
+
+      const content = await fs.readFile(logPath, 'utf8');
+      assert.match(content, /hello-logger/);
+    } finally {
+      await fs.rm(tmpDir, {recursive: true, force: true});
+    }
+  });
+});

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import {describe, it} from 'node:test';
+
+import {VERSION} from '../src/version.js';
+
+describe('VERSION constant', () => {
+  it('matches package.json version', async () => {
+    const pkgJson = JSON.parse(
+      await fs.readFile(new URL('../../package.json', import.meta.url), 'utf8'),
+    );
+    assert.strictEqual(VERSION, pkgJson.version);
+  });
+});


### PR DESCRIPTION
Why

Add small, high-value unit tests to cover critical, previously-untested utility code paths so reviewers can gain confidence and catch regressions quickly.

What

- Adds focused unit tests for the following areas:
  - utils/id: createIdGenerator and stableIdSymbol
  - utils/logger: saveLogsToFile and flushLogs
  - tools/ToolDefinition: viewportTransform and geolocationTransform
  - version: ensures the exported VERSION constant matches package.json

Approach

Small, isolated tests were chosen to be easy to run locally and to provide immediate coverage for logic that is often relied on by higher-level code. Tests use the Node built-in test runner to avoid adding new testing frameworks.

Notes and review guidance

- Ran a targeted build + the new tests locally; they pass.
- No changes to production code, only new test files.
- A dev dependency install was performed in the session to run tests; package.json was not modified.

Next steps

- Optionally expand coverage for daemon, HeapSnapshotManager, and SnapshotFormatter (these need harnesses/mocks).

N/A