### PR TITLE
chore: change dependabot cooldown default days to 0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,5 +58,3 @@ updates:
       timezone: 'Europe/Berlin'
     cooldown:
       default-days: 0
-      exclude:
-        - 'devtools-frontend'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,6 @@ updates:
       time: '06:00'
       timezone: 'Europe/Berlin'
     cooldown:
-      default-days: 7
+      default-days: 0
       exclude:
         - 'devtools-frontend'


### PR DESCRIPTION
it looks like exclude does not work and we only roll devtools-frontend as submodule