### PR TITLE
chore: fix Explicit resource management polyfill

### DIFF
--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -53,6 +53,7 @@ export {Mutex} from 'puppeteer-core/internal/util/Mutex.js';
 export {
   DisposableStack,
   AsyncDisposableStack,
+  SuppressedError,
 } from 'puppeteer-core/internal/util/disposable.js';
 export {
   resolveDefaultUserDataDir,

--- a/src/utils/polyfill.ts
+++ b/src/utils/polyfill.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {DisposableStack, AsyncDisposableStack} from '../third_party/index.js';
+import {
+  DisposableStack,
+  AsyncDisposableStack,
+  SuppressedError,
+} from '../third_party/index.js';
 
 globalThis.DisposableStack ??= DisposableStack;
 globalThis.AsyncDisposableStack ??= AsyncDisposableStack;
+// @ts-expect-error Type mismatch between puppeteer-core and node for SuppressedError.
+globalThis.SuppressedError ??= SuppressedError;


### PR DESCRIPTION
There are no runtime error without this but one can't use `instanceof` and similar methods.