### PR TITLE
fix(input): select empty-value options by text

### DIFF
--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -221,8 +221,8 @@ async function selectOption(
         using childValueHandle = await childHandle.getProperty('value');
 
         const childValue = await childValueHandle.jsonValue();
-        if (childValue) {
-          await handle.asLocator().fill(childValue.toString());
+        if (typeof childValue === 'string') {
+          await handle.asLocator().fill(childValue);
         }
 
         break;

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -590,6 +590,44 @@ describe('input', () => {
       });
     });
 
+    it('fills out a select option with an empty value by text', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(
+          html`<select
+            ><option value="">none</option
+            ><option
+              value="v2"
+              selected
+              >two</option
+            ></select
+          >`,
+        );
+        context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
+          context.getSelectedMcpPage(),
+        );
+        await fill.handler(
+          {
+            params: {
+              uid: '1_1',
+              value: 'none',
+            },
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+        assert.strictEqual(
+          response.responseLines[0],
+          'Successfully filled out the element',
+        );
+        const selectedValue = await page.evaluate(
+          () => document.querySelector('select')!.value,
+        );
+        assert.strictEqual(selectedValue, '');
+      });
+    });
+
     it('fills out a textarea marked as combobox', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedMcpPage().pptrPage;


### PR DESCRIPTION
## Summary

- Fixes: When fill targets a native select option whose visible text matches the requested value but whose DOM value is the empty string, the tool reports success while the previously selected option remains selected.
- Root cause: selectOption tests the option's DOM value for truthiness before calling Locator.fill. An empty string is a valid option value, but the truthiness check skips the fill while optionFound remains true, so the handler returns a false success.

## Regression evidence

- Before: `npx --yes -p node@24 -c 'node --version && npm run test tests/tools/input.test.ts -- --test-name-pattern=empty.value.by.text'` exited `1`

- After: `npx --yes -p node@24 -c 'node --version && npm run test tests/tools/input.test.ts -- --test-name-pattern=empty.value.by.text'` exited `0`

## Verification

- `npx --yes -p node@24 -c 'node --version && npm run test tests/tools/input.test.ts'`
- `npx --yes -p node@24 -c 'node --version && npm run build'`
- `npx --yes -p node@24 -c 'node --version && npm run check-format'`
- `npx --yes -p node@24 -c 'node --version && npm run gen'`

The full `npm run test` was also attempted. On this machine it reaches an
unrelated Chrome 151 `Page.captureScreenshot: Page is too large` failure; the
same screenshot test fails identically on the exact unmodified base SHA under
Node 24. The complete affected input test suite passes.

## Scope

- 2 files changed, +40 / -2 lines
