### PR TITLE
feat: report newly opened pages in the action response

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -36,7 +36,7 @@ import type {
   Extension,
   HTTPRequest,
 } from './third_party/index.js';
-import {handleDialog, listPages} from './tools/pages.js';
+import {handleDialog, listPages, selectPage} from './tools/pages.js';
 import type {ToolGroups} from './tools/thirdPartyDeveloper.js';
 import type {
   DevToolsData,
@@ -317,6 +317,12 @@ export class McpResponse implements Response {
 
   attachWaitForResult(result: WaitForEventsResult): void {
     this.#attachedWaitForResult = result;
+    if (result.newPagesOpened) {
+      // The action opened a new page (e.g., a click on a link with
+      // target=_blank). Include the page list so that the client can
+      // perceive the new page without calling list_pages.
+      this.setIncludePages(true);
+    }
   }
 
   setHeapSnapshotAggregates(
@@ -792,6 +798,7 @@ export class McpResponse implements Response {
       extensionPages?: object[];
       errorMessage?: string;
       navigatedToUrl?: string;
+      newPagesOpened?: boolean;
       geolocation?: {latitude: number; longitude: number};
     } = {};
 
@@ -840,6 +847,12 @@ export class McpResponse implements Response {
         );
         structuredContent.navigatedToUrl =
           this.#attachedWaitForResult.navigatedToUrl;
+      }
+      if (this.#attachedWaitForResult.newPagesOpened) {
+        response.push(
+          `The action opened a new page. See the list of pages below and call ${selectPage.name} to switch to a page.`,
+        );
+        structuredContent.newPagesOpened = true;
       }
     }
 

--- a/src/WaitForHelper.ts
+++ b/src/WaitForHelper.ts
@@ -21,6 +21,8 @@ export class WaitForHelper {
   #dialogHandled = false;
   /** Track all dialogs as they pause the renderer. */
   #dialogDetected = false;
+  /** Whether the action opened one or more new pages. */
+  #newPagesOpened = false;
   #initialUrl: string;
 
   constructor(
@@ -185,6 +187,16 @@ export class WaitForHelper {
       this.#page.off('dialog', dialogHandler);
     });
 
+    // Detect pages opened by the action (e.g., a click on a link with
+    // target=_blank or a window.open() call) so the response can report them.
+    const popupHandler = () => {
+      this.#newPagesOpened = true;
+    };
+    this.#page.on('popup', popupHandler);
+    this.#abortController.signal.addEventListener('abort', () => {
+      this.#page.off('popup', popupHandler);
+    });
+
     const navigationFinished = this.waitForNavigationStarted()
       .then(navigationStated => {
         if (navigationStated) {
@@ -230,6 +242,7 @@ export class WaitForHelper {
       ...(urlAfterAction !== this.#initialUrl
         ? {navigatedToUrl: urlAfterAction}
         : {}),
+      ...(this.#newPagesOpened ? {newPagesOpened: true} : {}),
       dialogHandled: this.#dialogHandled,
     };
   }
@@ -241,6 +254,11 @@ export interface WaitForEventsResult {
    * occurred.
    */
   navigatedToUrl?: string;
+  /**
+   * Whether the action opened one or more new pages (e.g., a click on a
+   * link with target=_blank or a window.open() call).
+   */
+  newPagesOpened?: boolean;
   /**
    * Whether a dialog was automatically handled during the action.
    */

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -90,6 +90,36 @@ describe('input', () => {
         assert.ok(await page.$('text/dblclicked'));
       });
     });
+    it('reports newly opened pages', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(
+          html`<button onclick="window.open('about:blank');">open</button>`,
+        );
+        context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
+          context.getSelectedMcpPage(),
+        );
+        await click.handler(
+          {
+            params: {
+              uid: '1_1',
+            },
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+        assert.strictEqual(
+          response.responseLines[0],
+          'Successfully clicked on the element',
+        );
+        assert.ok(response.includePages);
+        const result = await response.handle(context);
+        const text = getTextContent(result.content[0]);
+        assert.ok(text.includes('The action opened a new page'));
+        assert.ok(text.includes('## Pages'));
+      });
+    });
     it('waits for navigation', async () => {
       const resolveNavigation = Promise.withResolvers<void>();
       server.addHtmlRoute(


### PR DESCRIPTION
## What

When a click opens a new page (link with `target=_blank`, `window.open()`), the tool response now says so and includes the list of open pages. Previously the response only said "Successfully clicked on the element", so clients could not perceive that a new tab/window had opened and assumed the click had no effect.

## How

- `WaitForHelper` now listens for the page's `popup` event while the action runs and reports `newPagesOpened` in `WaitForEventsResult` (alongside the existing `navigatedToUrl`). This automatically covers every input tool that uses `waitForEventsAfterAction` (`click`, `click_at`, `fill`, `press_key`, etc.).
- `McpResponse.attachWaitForResult()` calls the existing `setIncludePages(true)` when a new page was opened, reusing the exact same page-list formatting as `list_pages` — no new format is introduced.
- A note line and `structuredContent.newPagesOpened` are emitted next to the existing `Page navigated to …` handling.

Token-conscious per the discussion in #367: the page list is only attached when a new page actually opened during the action; responses for ordinary clicks are unchanged, and no snapshot/tree is included.

## Before

```
Successfully clicked on the element
```

## After

```
Successfully clicked on the element
The action opened a new page. See the list of pages below and call select_page to switch to a page.
## Pages
1: My test page (about:blank) [selected]
2: about:blank
```

(sample captured from the new test run)

## Testing

- `npm run build` — pass
- `npm run test:no-build` — full suite pass (exit 0)
- new test: `input > click > reports newly opened pages` proves a `window.open` click surfaces the note and the `## Pages` list
- `npm run check-format` — pass
- `node scripts/generate-docs.ts` — no doc changes (no tool descriptions/schemas touched)

Fixes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)