### PR TITLE
feat: add optional stack traces to list_console_messages

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -391,6 +391,7 @@
 **Parameters:**
 
 - **includePreservedMessages** (boolean) _(optional)_: Set to true to return the preserved messages over the last 3 navigations.
+- **includeStackTraces** (boolean) _(optional)_: Set to true to include the stack trace for each message when available. Increases the response size.
 - **pageIdx** (integer) _(optional)_: Page number to return (0-based). When omitted, returns the first page.
 - **pageSize** (integer) _(optional)_: Maximum number of messages to return. When omitted, returns all messages.
 - **serviceWorkerId** (string) _(optional)_: Filter messages to only return messages of the specified service worker.

--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -106,6 +106,7 @@ export class McpResponse implements Response {
     pagination?: PaginationOptions;
     types?: string[];
     includePreservedMessages?: boolean;
+    includeStackTraces?: boolean;
     serviceWorkerId?: string;
   };
   #listExtensions?: boolean;
@@ -212,6 +213,7 @@ export class McpResponse implements Response {
     options?: PaginationOptions & {
       types?: string[];
       includePreservedMessages?: boolean;
+      includeStackTraces?: boolean;
       serviceWorkerId?: string;
     },
   ): void {
@@ -231,6 +233,7 @@ export class McpResponse implements Response {
           : undefined,
       types: options?.types,
       includePreservedMessages: options?.includePreservedMessages,
+      includeStackTraces: options?.includeStackTraces,
       serviceWorkerId: options?.serviceWorkerId,
     };
   }
@@ -598,6 +601,7 @@ export class McpResponse implements Response {
               return await ConsoleFormatter.from(consoleMessage, {
                 id: consoleMessageStableId,
                 fetchDetailedData: false,
+                fetchStackTrace: this.#consoleDataOptions?.includeStackTraces,
                 devTools: page ? page.devtoolsUniverse : undefined,
               });
             }
@@ -1344,6 +1348,15 @@ Call ${handleDialog.name} to handle it before continuing.`);
           response.push(compactEncode(structuredContent.consoleMessages));
         } else {
           response.push(...paginationData.items.map(item => item.toString()));
+        }
+        if (
+          structuredContent.consoleMessages.some(
+            message => 'stackTrace' in message,
+          )
+        ) {
+          response.push(
+            'Note: stack trace line and column numbers use 1-based indexing',
+          );
         }
       } else {
         response.push('<no console messages found>');

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -758,6 +758,14 @@ export const commands: Commands = {
         required: false,
         default: false,
       },
+      includeStackTraces: {
+        name: 'includeStackTraces',
+        type: 'boolean',
+        description:
+          'Set to true to include the stack trace for each message when available. Increases the response size.',
+        required: false,
+        default: false,
+      },
       serviceWorkerId: {
         name: 'serviceWorkerId',
         type: 'string',

--- a/src/formatters/ConsoleFormatter.ts
+++ b/src/formatters/ConsoleFormatter.ts
@@ -17,6 +17,8 @@ import type {IssueFormatter} from './IssueFormatter.js';
 
 export interface ConsoleFormatterOptions {
   fetchDetailedData?: boolean;
+  // Fetches the stack trace and includes it in the concise output.
+  fetchStackTrace?: boolean;
   id: number;
   devTools?: TargetUniverse;
   resolvedArgsForTesting?: unknown[];
@@ -35,6 +37,8 @@ interface ConsoleMessageConcise {
   argsCount: number;
   id: number;
   count?: number;
+  // pre-formatted stacktrace.
+  stackTrace?: string;
 }
 
 interface ConsoleMessageDetailed extends ConsoleMessageConcise {
@@ -54,6 +58,7 @@ export class ConsoleFormatter {
 
   readonly #stack?: DevTools.DevTools.StackTrace.StackTrace.StackTrace;
   readonly #cause?: SymbolizedError;
+  readonly #includeStackInConcise: boolean;
 
   readonly isIgnored: IgnoreCheck;
 
@@ -65,6 +70,7 @@ export class ConsoleFormatter {
     resolvedArgs?: unknown[];
     stack?: DevTools.DevTools.StackTrace.StackTrace.StackTrace;
     cause?: SymbolizedError;
+    includeStackInConcise?: boolean;
     isIgnored: IgnoreCheck;
   }) {
     this.#id = params.id;
@@ -74,6 +80,7 @@ export class ConsoleFormatter {
     this.#resolvedArgs = params.resolvedArgs ?? [];
     this.#stack = params.stack;
     this.#cause = params.cause;
+    this.#includeStackInConcise = params.includeStackInConcise ?? false;
     this.isIgnored = params.isIgnored;
   }
 
@@ -110,7 +117,8 @@ export class ConsoleFormatter {
         devTools: options?.devTools,
         details: msg.details,
         targetId: msg.targetId,
-        includeStackAndCause: options?.fetchDetailedData,
+        includeStackAndCause:
+          options?.fetchDetailedData || options?.fetchStackTrace,
         resolvedStackTraceForTesting: options?.resolvedStackTraceForTesting,
         resolvedCauseForTesting: options?.resolvedCauseForTesting,
       });
@@ -120,6 +128,7 @@ export class ConsoleFormatter {
         text: error.message,
         stack: error.stackTrace,
         cause: error.cause,
+        includeStackInConcise: options.fetchStackTrace,
         isIgnored,
       });
     }
@@ -154,7 +163,10 @@ export class ConsoleFormatter {
     let stack: DevTools.DevTools.StackTrace.StackTrace.StackTrace | undefined;
     if (options.resolvedStackTraceForTesting) {
       stack = options.resolvedStackTraceForTesting;
-    } else if (options.fetchDetailedData && options.devTools) {
+    } else if (
+      (options.fetchDetailedData || options.fetchStackTrace) &&
+      options.devTools
+    ) {
       try {
         stack = await createStackTraceForConsoleMessage(options.devTools, msg);
       } catch {
@@ -169,6 +181,7 @@ export class ConsoleFormatter {
       argCount: resolvedArgs.length || msg.args().length,
       resolvedArgs,
       stack,
+      includeStackInConcise: options.fetchStackTrace,
       isIgnored,
     });
   }
@@ -196,12 +209,18 @@ export class ConsoleFormatter {
   }
 
   toJSON(): ConsoleMessageConcise {
-    return {
+    const json: ConsoleMessageConcise = {
       type: this.#type,
       text: this.#text,
       argsCount: this.#argCount,
       id: this.#id,
     };
+    if (this.#includeStackInConcise && this.#stack) {
+      json.stackTrace = formatStackTrace(this.#stack, this.#cause, this, {
+        includeNote: false,
+      });
+    }
+    return json;
   }
 
   /**
@@ -238,6 +257,9 @@ export class ConsoleFormatter {
               type: message.#type,
               text: message.#text,
               argCount: message.#argCount,
+              stack: message.#stack,
+              cause: message.#cause,
+              includeStackInConcise: message.#includeStackInConcise,
               isIgnored: message.isIgnored,
             },
             count,
@@ -269,6 +291,9 @@ export class GroupedConsoleFormatter extends ConsoleFormatter {
       type: string;
       text: string;
       argCount: number;
+      stack?: DevTools.DevTools.StackTrace.StackTrace.StackTrace;
+      cause?: SymbolizedError;
+      includeStackInConcise?: boolean;
       isIgnored: IgnoreCheck;
     },
     count: number,
@@ -290,7 +315,15 @@ export class GroupedConsoleFormatter extends ConsoleFormatter {
 
 function convertConsoleMessageConciseToString(msg: ConsoleMessageConcise) {
   const countSuffix = msg.count && msg.count > 1 ? ` [${msg.count} times]` : '';
-  return `msgid=${msg.id} [${msg.type}] ${msg.text} (${msg.argsCount} args)${countSuffix}`;
+  const messageLine = `msgid=${msg.id} [${msg.type}] ${msg.text} (${msg.argsCount} args)${countSuffix}`;
+  if (!msg.stackTrace) {
+    return messageLine;
+  }
+  const indentedStackTrace = msg.stackTrace
+    .split('\n')
+    .map(line => `  ${line}`)
+    .join('\n');
+  return `${messageLine}\n${indentedStackTrace}`;
 }
 
 function convertConsoleMessageConciseDetailedToString(
@@ -341,6 +374,7 @@ function formatStackTrace(
   stackTrace: DevTools.DevTools.StackTrace.StackTrace.StackTrace,
   cause: SymbolizedError | undefined,
   formatter: {isIgnored: IgnoreCheck},
+  options?: {includeNote?: boolean},
 ): string {
   const lines = formatStackTraceInner(stackTrace, cause, formatter);
   const includedLines = lines.slice(0, STACK_TRACE_MAX_LINES);
@@ -349,7 +383,9 @@ function formatStackTrace(
   return [
     ...includedLines,
     reminderCount > 0 ? `... and ${reminderCount} more frames` : '',
-    'Note: line and column numbers use 1-based indexing',
+    options?.includeNote === false
+      ? ''
+      : 'Note: line and column numbers use 1-based indexing',
   ]
     .filter(line => !!line)
     .join('\n');

--- a/src/telemetry/tool_call_metrics.json
+++ b/src/telemetry/tool_call_metrics.json
@@ -258,6 +258,10 @@
       {
         "name": "service_worker_id_length",
         "argType": "number"
+      },
+      {
+        "name": "include_stack_traces",
+        "argType": "boolean"
       }
     ]
   },

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -151,6 +151,7 @@ export interface Response {
     options?: PaginationOptions & {
       types?: string[];
       includePreservedMessages?: boolean;
+      includeStackTraces?: boolean;
       serviceWorkerId?: string;
     },
   ): void;

--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -77,6 +77,13 @@ export const listConsoleMessages = definePageTool(cliArgs => {
         .describe(
           'Set to true to return the preserved messages over the last 3 navigations.',
         ),
+      includeStackTraces: zod
+        .boolean()
+        .default(false)
+        .optional()
+        .describe(
+          'Set to true to include the stack trace for each message when available. Increases the response size.',
+        ),
       serviceWorkerId: zod
         .string()
         .optional()
@@ -92,6 +99,7 @@ export const listConsoleMessages = definePageTool(cliArgs => {
         pageIdx: request.params.pageIdx,
         types: request.params.types,
         includePreservedMessages: request.params.includePreservedMessages,
+        includeStackTraces: request.params.includeStackTraces,
         serviceWorkerId: request.params.serviceWorkerId,
       });
     },

--- a/tests/formatters/ConsoleFormatter.test.js.snapshot
+++ b/tests/formatters/ConsoleFormatter.test.js.snapshot
@@ -1,3 +1,21 @@
+exports[`ConsoleFormatter > toString/toJSON > formats a console message with a stack trace when fetchStackTrace is set toJSON 1`] = `
+{
+  "type": "log",
+  "text": "Hello stack trace!",
+  "argsCount": 0,
+  "id": 1,
+  "stackTrace": "at foo (foo.ts:10:2)\\nat bar (foo.ts:20:2)\\n--- setTimeout -------------------------\\nat schedule (util.ts:5:2)"
+}
+`;
+
+exports[`ConsoleFormatter > toString/toJSON > formats a console message with a stack trace when fetchStackTrace is set toString 1`] = `
+msgid=1 [log] Hello stack trace! (0 args)
+  at foo (foo.ts:10:2)
+  at bar (foo.ts:20:2)
+  --- setTimeout -------------------------
+  at schedule (util.ts:5:2)
+`;
+
 exports[`ConsoleFormatter > toString/toJSON > formats a console.log message toJSON 1`] = `
 {
   "type": "log",
@@ -48,6 +66,34 @@ exports[`ConsoleFormatter > toString/toJSON > formats an UncaughtError toJSON 1`
 
 exports[`ConsoleFormatter > toString/toJSON > formats an UncaughtError toString 1`] = `
 msgid=1 [error] Uncaught TypeError: Cannot read properties of undefined (0 args)
+`;
+
+exports[`ConsoleFormatter > toString/toJSON > formats an UncaughtError with a stack trace when fetchStackTrace is set toJSON 1`] = `
+{
+  "type": "error",
+  "text": "Uncaught TypeError: Cannot read properties of undefined",
+  "argsCount": 0,
+  "id": 2,
+  "stackTrace": "at foo (foo.ts:10:2)"
+}
+`;
+
+exports[`ConsoleFormatter > toString/toJSON > formats an UncaughtError with a stack trace when fetchStackTrace is set toString 1`] = `
+msgid=2 [error] Uncaught TypeError: Cannot read properties of undefined (0 args)
+  at foo (foo.ts:10:2)
+`;
+
+exports[`ConsoleFormatter > toString/toJSON > omits the stack trace when fetchStackTrace is not set toJSON 1`] = `
+{
+  "type": "log",
+  "text": "Hello stack trace!",
+  "argsCount": 0,
+  "id": 1
+}
+`;
+
+exports[`ConsoleFormatter > toString/toJSON > omits the stack trace when fetchStackTrace is not set toString 1`] = `
+msgid=1 [log] Hello stack trace! (0 args)
 `;
 
 exports[`ConsoleFormatter > toStringDetailed/toJSONDetailed > does not show call frames with ignore listed scripts toJSONDetailed 1`] = `

--- a/tests/formatters/ConsoleFormatter.test.ts
+++ b/tests/formatters/ConsoleFormatter.test.ts
@@ -125,6 +125,118 @@ describe('ConsoleFormatter', () => {
       );
       return await ConsoleFormatter.from(error, {id: 1});
     });
+
+    formatterTestConcise(
+      'omits the stack trace when fetchStackTrace is not set',
+      async () => {
+        const message = createMockMessage({
+          type: () => 'log',
+          text: () => 'Hello stack trace!',
+        });
+        const stackTrace = {
+          syncFragment: {
+            frames: [
+              {
+                line: 10,
+                column: 2,
+                url: 'foo.ts',
+                name: 'foo',
+              },
+            ],
+          },
+          asyncFragments: [],
+        } as unknown as DevTools.StackTrace.StackTrace.StackTrace;
+
+        return await ConsoleFormatter.from(message, {
+          id: 1,
+          resolvedStackTraceForTesting: stackTrace,
+        });
+      },
+    );
+
+    formatterTestConcise(
+      'formats a console message with a stack trace when fetchStackTrace is set',
+      async () => {
+        const message = createMockMessage({
+          type: () => 'log',
+          text: () => 'Hello stack trace!',
+        });
+        const stackTrace = {
+          syncFragment: {
+            frames: [
+              {
+                line: 10,
+                column: 2,
+                url: 'foo.ts',
+                name: 'foo',
+              },
+              {
+                line: 20,
+                column: 2,
+                url: 'foo.ts',
+                name: 'bar',
+              },
+            ],
+          },
+          asyncFragments: [
+            {
+              description: 'setTimeout',
+              frames: [
+                {
+                  line: 5,
+                  column: 2,
+                  url: 'util.ts',
+                  name: 'schedule',
+                },
+              ],
+            },
+          ],
+        } as unknown as DevTools.StackTrace.StackTrace.StackTrace;
+
+        return await ConsoleFormatter.from(message, {
+          id: 1,
+          fetchStackTrace: true,
+          resolvedStackTraceForTesting: stackTrace,
+        });
+      },
+    );
+
+    formatterTestConcise(
+      'formats an UncaughtError with a stack trace when fetchStackTrace is set',
+      async () => {
+        const stackTrace = {
+          syncFragment: {
+            frames: [
+              {
+                line: 10,
+                column: 2,
+                url: 'foo.ts',
+                name: 'foo',
+              },
+            ],
+          },
+          asyncFragments: [],
+        } as unknown as DevTools.StackTrace.StackTrace.StackTrace;
+        const error = new UncaughtError(
+          {
+            exceptionId: 1,
+            lineNumber: 0,
+            columnNumber: 5,
+            exception: {
+              type: 'object',
+              description: 'TypeError: Cannot read properties of undefined',
+            },
+            text: 'Uncaught',
+          },
+          '<mock target ID>',
+        );
+        return await ConsoleFormatter.from(error, {
+          id: 2,
+          fetchStackTrace: true,
+          resolvedStackTraceForTesting: stackTrace,
+        });
+      },
+    );
   });
 
   describe('toStringDetailed/toJSONDetailed', () => {

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -188,6 +188,59 @@ describe('console', () => {
       });
     });
 
+    it('includes stack traces when includeStackTraces is set', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedMcpPage();
+        await page.pptrPage.setContent(
+          '<script>function failingFn() { console.error("This is an error"); } failingFn();</script>',
+        );
+        await listConsoleMessages().handler(
+          {
+            params: {includeStackTraces: true},
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+        const formattedResponse = await response.handle(context);
+        const textContent = getTextContent(formattedResponse.content[0]);
+        assert.ok(textContent.includes('msgid=1 [error] This is an error'));
+        assert.match(textContent, /at failingFn/);
+        const structuredContent = formattedResponse.structuredContent as {
+          consoleMessages: Array<{stackTrace?: string}>;
+        };
+        assert.match(
+          structuredContent.consoleMessages[0].stackTrace ?? '',
+          /at failingFn/,
+        );
+      });
+    });
+
+    it('omits stack traces by default', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedMcpPage();
+        await page.pptrPage.setContent(
+          '<script>function failingFn() { console.error("This is an error"); } failingFn();</script>',
+        );
+        await listConsoleMessages().handler(
+          {params: {}, page: context.getSelectedMcpPage()},
+          response,
+          context,
+        );
+        const formattedResponse = await response.handle(context);
+        const textContent = getTextContent(formattedResponse.content[0]);
+        assert.ok(textContent.includes('msgid=1 [error] This is an error'));
+        assert.ok(!textContent.includes('at failingFn'));
+        const structuredContent = formattedResponse.structuredContent as {
+          consoleMessages: Array<{stackTrace?: string}>;
+        };
+        assert.strictEqual(
+          structuredContent.consoleMessages[0].stackTrace,
+          undefined,
+        );
+      });
+    });
+
     it('work with primitive unhandled errors', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedMcpPage();


### PR DESCRIPTION
## What

Adds an opt-in `includeStackTraces` parameter to `list_console_messages`. When set, each listed message includes its resolved (source-mapped, ignore-list-filtered) stack trace — in the text output as indented frames under the message line, and in `structuredContent` as a pre-formatted `stackTrace` string, matching the format `get_console_message` already uses.

## Why

Fixes the workflow described in #383: today the list output only contains plain message text, so an LLM debugging a page has to call `get_console_message` once per message to learn which file/function/line failed. With `includeStackTraces: true` the model can map every error to its source in a single call.

Design notes:

- **Opt-in, default off** — the default output is byte-for-byte unchanged, keeping the token cost of the common path identical.
- Reuses the existing DevTools stack resolution (`createStackTraceForConsoleMessage` / `SymbolizedError`) and the existing `formatStackTrace` formatting, so frames are source-mapped and ignore-listed exactly like in `get_console_message`.
- The per-message "1-based indexing" note is emitted once for the whole list instead of once per message to keep the output compact.
- Works for console API messages, uncaught errors (including `Caused by:` chains), and grouped repeated messages (`[N times]`).

## Before / after

Default (unchanged):

```
## Console messages
Showing 1-1 of 1 (Page 1 of 1).
msgid=1 [log] Hello stack trace! (0 args)
```

With `includeStackTraces: true`:

```
## Console messages
Showing 1-1 of 1 (Page 1 of 1).
msgid=1 [log] Hello stack trace! (0 args)
  at foo (foo.ts:10:2)
  at bar (foo.ts:20:2)
  --- setTimeout -------------------------
  at schedule (util.ts:5:2)
Note: stack trace line and column numbers use 1-based indexing
```

`structuredContent.consoleMessages[i]` gains an optional `"stackTrace": "at foo (foo.ts:10:2)\nat bar (foo.ts:20:2)\n..."` field.

## Relationship to #2060

Complements #2060 (source location for `list_console_messages`, issue #903): that PR surfaces the top-frame *location* for every message by default, while this one exposes the *full stack trace* behind an explicit opt-in. The features are independent and the changes are designed to coexist with minimal conflict.

## Testing

- `npm run build` — passes
- `npm run test:no-build` — full suite passes (exit 0)
- `npm run check-format` — passes
- `npm run gen` — regenerated `docs/tool-reference.md`, CLI options, and tool-call metrics (included)

New coverage:

- `tests/formatters/ConsoleFormatter.test.ts` — snapshot tests for concise `toString`/`toJSON` with `fetchStackTrace` set (console message + uncaught error) and for the unchanged default.
- `tests/tools/console.test.ts` — integration tests asserting frames (`at failingFn`) appear in text and `structuredContent` when `includeStackTraces: true`, and are absent by default.

Fixes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
