### PR TITLE
fix: capture navigation requests for pages opened via window.open

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -18,6 +18,7 @@ import type {
   DuplicateStringGroup,
 } from './HeapSnapshotManager.js';
 import {McpPage} from './McpPage.js';
+import {NetworkEventBuffer} from './NetworkEventBuffer.js';
 import {type UncaughtError} from './PageCollector.js';
 import {ServiceWorkerConsoleCollector} from './ServiceWorkerCollector.js';
 import {
@@ -85,6 +86,7 @@ export class McpContext implements Context {
   #selectedPageFallback?: {wasClosed: boolean};
 
   #serviceWorkerConsoleCollector: ServiceWorkerConsoleCollector;
+  #networkEventBuffer: NetworkEventBuffer;
 
   #isRunningTrace = false;
   #screenRecorderData: {recorder: ScreenRecorder; filePath: string} | null =
@@ -126,6 +128,9 @@ export class McpContext implements Context {
     this.#serviceWorkerConsoleCollector = new ServiceWorkerConsoleCollector(
       this.browser,
     );
+    // Starts capturing network events for new page targets (e.g. tabs opened
+    // via window.open) before their McpPage exists.
+    this.#networkEventBuffer = new NetworkEventBuffer(this.browser);
   }
 
   async #init() {
@@ -142,6 +147,7 @@ export class McpContext implements Context {
     this.browser.off('targetdestroyed', this.#onTargetDestroyed);
 
     this.#serviceWorkerConsoleCollector.dispose();
+    this.#networkEventBuffer.dispose();
     this.#heapSnapshotManager.dispose();
     for (const mcpPage of this.#mcpPages.values()) {
       mcpPage.dispose();
@@ -505,6 +511,9 @@ export class McpContext implements Context {
         ),
       });
       this.#mcpPages.set(page, mcpPage);
+      // Now that the collectors are listening, replay any network events that
+      // were captured before the page was wired up.
+      this.#networkEventBuffer.flush(page);
       await mcpPage.init();
     }
     return mcpPage;

--- a/src/NetworkEventBuffer.ts
+++ b/src/NetworkEventBuffer.ts
@@ -1,0 +1,212 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  Browser,
+  CDPSession,
+  Connection,
+  Handler,
+  Page,
+  Protocol,
+} from './third_party/index.js';
+import {CDPSessionEvent} from './third_party/index.js';
+import {logger} from './utils/logger.js';
+
+/**
+ * The Network domain events consumed by Puppeteer's NetworkManager.
+ */
+const NETWORK_EVENTS = [
+  'Network.requestWillBeSent',
+  'Network.requestWillBeSentExtraInfo',
+  'Network.requestServedFromCache',
+  'Network.responseReceived',
+  'Network.loadingFinished',
+  'Network.loadingFailed',
+  'Network.responseReceivedExtraInfo',
+] as const;
+
+type NetworkEventName = (typeof NETWORK_EVENTS)[number];
+
+interface BufferedTarget {
+  session: CDPSession;
+  events: Array<{name: NetworkEventName; event: unknown}>;
+  listeners: Array<[NetworkEventName, Handler<unknown>]>;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Captures Network events for newly attached page targets before the
+ * Puppeteer Page (and with it the NetworkCollector) exists.
+ *
+ * Pages created by the browser itself (window.open, target=_blank,
+ * chrome.tabs.create, ...) start navigating as soon as Puppeteer's
+ * TargetManager resumes them, long before `targetcreated` handlers get to
+ * create the Puppeteer Page whose NetworkManager sends `Network.enable`.
+ * Chromium does not replay Network events to sessions that enable the domain
+ * late, so the initial navigation request (including its redirect chain) was
+ * never recorded.
+ *
+ * This class enables the Network domain the moment the new target's session
+ * attaches: the connection emits `SessionAttached` before the
+ * `Target.attachedToTarget` event reaches Puppeteer's TargetManager, so the
+ * `Network.enable` command is dispatched on the session before the
+ * `Runtime.runIfWaitingForDebugger` command with which the TargetManager
+ * resumes the target, and CDP processes commands of a session in order.
+ * Events arriving while nothing else listens are buffered and replayed into
+ * the session once the McpPage's collectors are wired up, at which point
+ * Puppeteer's NetworkManager turns them into regular HTTPRequests.
+ */
+export class NetworkEventBuffer {
+  static readonly MAX_EVENTS_PER_TARGET = 1_000;
+  static readonly BUFFER_TIMEOUT = 30_000;
+
+  #connection?: Connection;
+  #buffers = new Map<string, BufferedTarget>();
+  #hookedSessions = new Set<CDPSession>();
+  #disposed = false;
+
+  constructor(browser: Browser) {
+    // @ts-expect-error use the CDP connection (internal Puppeteer API).
+    this.#connection = browser._connection as Connection | undefined;
+    this.#connection?.on(
+      CDPSessionEvent.SessionAttached,
+      this.#onSessionAttached,
+    );
+    this.#connection?.on(
+      CDPSessionEvent.SessionDetached,
+      this.#onSessionDetached,
+    );
+  }
+
+  dispose(): void {
+    this.#disposed = true;
+    this.#connection?.off(
+      CDPSessionEvent.SessionAttached,
+      this.#onSessionAttached,
+    );
+    this.#connection?.off(
+      CDPSessionEvent.SessionDetached,
+      this.#onSessionDetached,
+    );
+    for (const session of this.#hookedSessions) {
+      session.off('Target.attachedToTarget', this.#onAttachedToTarget);
+    }
+    this.#hookedSessions.clear();
+    for (const targetId of [...this.#buffers.keys()]) {
+      this.#dropBuffer(targetId);
+    }
+  }
+
+  /**
+   * The connection emits SessionAttached for a new session before it routes
+   * the Target.attachedToTarget event to the parent session, so the listener
+   * registered here on new (e.g. tab) sessions runs before the one Puppeteer's
+   * TargetManager registers later while handling the same event.
+   */
+  #onSessionAttached = (session: CDPSession): void => {
+    if (this.#disposed) {
+      return;
+    }
+    session.on('Target.attachedToTarget', this.#onAttachedToTarget);
+    this.#hookedSessions.add(session);
+  };
+
+  #onSessionDetached = (session: CDPSession): void => {
+    this.#hookedSessions.delete(session);
+    for (const [targetId, entry] of this.#buffers) {
+      if (entry.session === session) {
+        this.#dropBuffer(targetId);
+      }
+    }
+  };
+
+  #onAttachedToTarget = (
+    event: Protocol.Target.AttachedToTargetEvent,
+  ): void => {
+    if (this.#disposed) {
+      return;
+    }
+    const {sessionId, targetInfo} = event;
+    if (targetInfo.type !== 'page' || this.#buffers.has(targetInfo.targetId)) {
+      return;
+    }
+    const session = this.#connection?.session(sessionId);
+    if (!session) {
+      return;
+    }
+    // Enable the Network domain before Puppeteer's TargetManager resumes the
+    // target so that the very first (navigation) request is reported.
+    session.send('Network.enable').catch(() => {
+      // The target may be gone already.
+    });
+    const entry: BufferedTarget = {
+      session,
+      events: [],
+      listeners: [],
+      timeout: setTimeout(() => {
+        this.#dropBuffer(targetInfo.targetId);
+      }, NetworkEventBuffer.BUFFER_TIMEOUT),
+    };
+    entry.timeout.unref?.();
+    for (const name of NETWORK_EVENTS) {
+      const listener: Handler<unknown> = networkEvent => {
+        if (session.listenerCount(name) > 1) {
+          // Another consumer (Puppeteer's NetworkManager) has attached in the
+          // meantime and processes events as they arrive.
+          return;
+        }
+        if (entry.events.length >= NetworkEventBuffer.MAX_EVENTS_PER_TARGET) {
+          return;
+        }
+        entry.events.push({name, event: networkEvent});
+      };
+      session.on(name, listener);
+      entry.listeners.push([name, listener]);
+    }
+    this.#buffers.set(targetInfo.targetId, entry);
+  };
+
+  /**
+   * Replays the events buffered for the page's target into its CDP session so
+   * that Puppeteer's NetworkManager turns them into HTTPRequests. Must be
+   * called after the page's collectors are wired up.
+   */
+  flush(page: Page): void {
+    let targetId: string;
+    try {
+      // @ts-expect-error use internal Puppeteer API to get the target ID.
+      targetId = page.target()._targetId as string;
+    } catch {
+      return;
+    }
+    const entry = this.#buffers.get(targetId);
+    if (!entry) {
+      return;
+    }
+    // Remove the buffer (and its listeners) first so that replayed events are
+    // not buffered again.
+    this.#dropBuffer(targetId);
+    for (const {name, event} of entry.events) {
+      try {
+        entry.session.emit(name, event as never);
+      } catch (err) {
+        logger?.('Error replaying buffered network event', err);
+      }
+    }
+  }
+
+  #dropBuffer(targetId: string): void {
+    const entry = this.#buffers.get(targetId);
+    if (!entry) {
+      return;
+    }
+    this.#buffers.delete(targetId);
+    clearTimeout(entry.timeout);
+    for (const [name, listener] of entry.listeners) {
+      entry.session.off(name, listener);
+    }
+  }
+}

--- a/tests/tools/network.test.ts
+++ b/tests/tools/network.test.ts
@@ -131,6 +131,62 @@ describe('network', () => {
         );
       });
     });
+
+    it('lists the initial navigation request of pages opened via window.open', async () => {
+      server.addHtmlRoute('/opener', html`<main>Opener</main>`);
+      server.addRoute('/popup-redirect', (_req, res) => {
+        // Delay the redirect a bit so that the redirect chain is still in
+        // flight while the popup's McpPage is being wired up.
+        setTimeout(() => {
+          res.writeHead(302, {
+            Location: server.getRoute('/popup'),
+          });
+          res.end();
+        }, 250);
+      });
+      server.addHtmlRoute('/popup', html`<main>Popup</main>`);
+
+      await withMcpContext(async (response, context) => {
+        const openerPage = context.getSelectedMcpPage().pptrPage;
+        await openerPage.goto(server.getRoute('/opener'));
+
+        await openerPage.evaluate(url => {
+          window.open(url, '_blank');
+        }, server.getRoute('/popup-redirect'));
+
+        // The popup's McpPage is created asynchronously via targetcreated.
+        const popupUrl = server.getRoute('/popup');
+        const deadline = Date.now() + 10_000;
+        let popupMcpPage;
+        while (!popupMcpPage && Date.now() < deadline) {
+          popupMcpPage = context
+            .getPages()
+            .find(page => page.pptrPage.url() === popupUrl);
+          if (!popupMcpPage) {
+            await new Promise(resolve => setTimeout(resolve, 50));
+          }
+        }
+        assert.ok(popupMcpPage, 'Popup page was not reported');
+
+        context.selectPage(popupMcpPage);
+        response.setPage(popupMcpPage);
+        await listNetworkRequests.handler(
+          {params: {}, page: popupMcpPage},
+          response,
+          context,
+        );
+        const responseData = await response.handle(context);
+        const text = getTextContent(responseData.content[0]);
+        assert.ok(
+          text.includes(server.getRoute('/popup-redirect')),
+          `Expected the popup's initial navigation request to be listed:\n${text}`,
+        );
+        assert.ok(
+          text.includes(popupUrl),
+          `Expected the popup's redirect target to be listed:\n${text}`,
+        );
+      });
+    });
   });
   describe('network_get_request', () => {
     it('attaches request', async () => {


### PR DESCRIPTION
## What

`list_network_requests` on a tab that the page opened itself (`window.open`, `target=_blank`) returned an empty listing: the entire initial navigation, redirect chain included, was missing, and `includePreservedRequests: true` could not help because nothing was ever recorded.

Repro from the issue: `new_page` with a link that calls `window.open(<redirecting url>)`, `click` it, `select_page` the popup, `list_network_requests` → empty, even though the popup has long landed on the final URL.

## Root cause

New targets are wired up reactively: `targetcreated` → `await target.page()` → `#createMcpPage(page)`. But Puppeteer's `TargetManager` sends `Runtime.runIfWaitingForDebugger` immediately when the target attaches, so the popup starts navigating right away — long before `target.page()` creates the `CdpPage` whose `NetworkManager` sends `Network.enable`. Chromium does not replay Network events to sessions that enable the domain late (unlike e.g. console messages), so the navigation request is unobservable by the time the collector is listening.

Note: a second browser-level `Target.setAutoAttach` with `waitForDebuggerOnStart: true` (as proposed in the issue) does not work from within this server: I verified empirically that the target resumes as soon as Puppeteer sends its own `Runtime.runIfWaitingForDebugger`, regardless of another session still holding.

## Fix

New `NetworkEventBuffer` (owned by `McpContext`), based on two ordering guarantees:

1. Puppeteer's `Connection` emits `SessionAttached` for a new session *before* it routes the `Target.attachedToTarget` event to the parent session where `TargetManager`'s listener runs. A `Target.attachedToTarget` listener registered on each new session at that moment therefore runs *before* `TargetManager`'s for all child attaches (popup pages attach under their fresh tab session).
2. CDP processes the commands of a session in order. Sending `Network.enable` from that listener means it is dispatched — and processed — before the `Runtime.runIfWaitingForDebugger` with which `TargetManager` resumes the target moments later on the same session.

With the Network domain enabled from the first moment, the buffer records the Network events (capped, with timeout/detach cleanup) while nothing else is listening, and stops recording as soon as Puppeteer's `NetworkManager` attaches (detected via `listenerCount`). Once the `McpPage`'s collectors are wired up, `McpContext` flushes the buffer by re-emitting the events on the session: `NetworkManager` processes them as if live and produces regular `HTTPRequest`s — so the navigation request and its redirect chain show up in `list_network_requests` like any other request, with no second bookkeeping path.

## Latency

None. Unlike the pause-based proposal in the issue, this approach never delays the new tab: it only enqueues one extra `Network.enable` command per newly attached page target and buffers events that would otherwise be dropped. There is a small remaining theoretical gap (events arriving in the few milliseconds between `NetworkManager` attaching and the collectors being wired are processed live before the collector listens), but the navigation request and its redirect chain fire well before that window and are reliably captured.

## Testing

- New regression test: opener page calls `window.open()` on a URL that 302-redirects (with a small delay so the chain is in flight while the popup is being wired up); asserts both the initial navigation request and the redirect target appear in `list_network_requests` for the popup. The test fails without the fix with exactly the reported symptom (empty listing) and passes with it.
- Verified the repro standalone: without the fix the popup's request list is empty; with it, `GET /redirect` (`isNavigationRequest() === true`) and the redirect target are captured.
- `npm run build && npm run test:no-build`: 689/689 pass.
- `npm run check-format` clean.

Fixes #2395

🤖 Generated with [Claude Code](https://claude.com/claude-code)
