### PR TITLE
feat: add --disabled-tool flag to disable individual tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,11 @@ The Chrome DevTools MCP server supports the following configuration option:
   - **Type:** array
   - **Default:** `false`
 
+- **`--disabledTool`/ `--disabled-tool`**
+  Disables the tool with the given name so that it is not exposed to the MCP client. Accepts an array of tool names. Useful as a security guardrail when MCP clients process untrusted content, e.g. --disabled-tool=evaluate_script prevents arbitrary JavaScript execution in the browser.
+  - **Type:** array
+  - **Default:** `false`
+
 - **`--ignoreDefaultChromeArg`/ `--ignore-default-chrome-arg`**
   Explicitly disable default arguments for Chrome. Only applies when Chrome is launched by chrome-devtools-mcp.
   - **Type:** array

--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -76,10 +76,24 @@ function getConditionStatus(
   return {disabled: false};
 }
 
+export function getDisabledToolNames(
+  serverArgs: Pick<ReturnType<typeof parseArguments>, 'disabledTool'>,
+): Set<string> {
+  return new Set((serverArgs.disabledTool ?? []).map(String));
+}
+
 function getToolStatusInfo(
   tool: ToolDefinition | DefinedPageTool,
   serverArgs: ReturnType<typeof parseArguments>,
-): {disabled: boolean; reason?: string} {
+): {disabled: boolean; reason?: string; disabledByName?: boolean} {
+  if (getDisabledToolNames(serverArgs).has(tool.name)) {
+    return {
+      disabled: true,
+      disabledByName: true,
+      reason: `Tool ${tool.name} has been disabled via the --disabled-tool option by the operator of this MCP server.`,
+    };
+  }
+
   const category = tool.annotations.category;
   const categoryCheck = getCategoryStatus(category, serverArgs);
 
@@ -160,9 +174,16 @@ export class ToolHandler {
     private readonly getContext: () => Promise<McpContext>,
     private readonly toolMutex: Mutex,
   ) {
-    const {disabled, reason} = getToolStatusInfo(tool, serverArgs);
+    const {disabled, reason, disabledByName} = getToolStatusInfo(
+      tool,
+      serverArgs,
+    );
     this.disabledReason = reason;
-    this.shouldRegister = !(disabled && !serverArgs.viaCli);
+    // Tools disabled by category or condition are still registered when
+    // running via the CLI so that a helpful message can be shown. Tools
+    // explicitly disabled by name via --disabled-tool are never registered
+    // since the operator opted out of them entirely.
+    this.shouldRegister = !disabled || (!!serverArgs.viaCli && !disabledByName);
 
     this.inputSchema =
       'pageScoped' in tool &&

--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -225,6 +225,11 @@ export const cliOptions = {
       "Restricts browser's network access by allowing only specified URL patterns (uses https://urlpattern.spec.whatwg.org/). Requires Chrome 149+. Silently detaches from targets with unallowed URLs upon connection, and blocks runtime requests (including navigations and subresources). Accepts an array of patterns.",
     conflicts: ['blockedUrlPattern'],
   },
+  disabledTool: {
+    type: 'array',
+    describe:
+      'Disables the tool with the given name so that it is not exposed to the MCP client. Accepts an array of tool names. Useful as a security guardrail when MCP clients process untrusted content, e.g. --disabled-tool=evaluate_script prevents arbitrary JavaScript execution in the browser.',
+  },
   ignoreDefaultChromeArg: {
     type: 'array',
     describe:
@@ -432,6 +437,10 @@ export function parseArguments(
         'Disable tools in the performance category',
       ],
       ['$0 --no-category-network', 'Disable tools in the network category'],
+      [
+        '$0 --disabled-tool=evaluate_script',
+        'Do not expose the evaluate_script tool to the MCP client',
+      ],
       [
         '$0 --user-data-dir=/tmp/user-data-dir',
         'Use a custom user data directory',

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
   ListRootsResultSchema,
   RootsListChangedNotificationSchema,
 } from './third_party/index.js';
-import {ToolHandler} from './ToolHandler.js';
+import {getDisabledToolNames, ToolHandler} from './ToolHandler.js';
 import type {DefinedPageTool, ToolDefinition} from './tools/ToolDefinition.js';
 import {createTools} from './tools/tools.js';
 import {logger} from './utils/logger.js';
@@ -191,6 +191,17 @@ export async function createMcpServer(
   }
 
   const tools = createTools(serverArgs);
+  // Fail fast on typos so that a misspelled --disabled-tool value does not
+  // silently leave the tool enabled.
+  const toolNames = new Set(tools.map(tool => tool.name));
+  const unknownDisabledTools = [...getDisabledToolNames(serverArgs)].filter(
+    name => !toolNames.has(name),
+  );
+  if (unknownDisabledTools.length) {
+    throw new Error(
+      `Unknown tool name(s) passed to --disabled-tool: ${unknownDisabledTools.join(', ')}.`,
+    );
+  }
   for (const tool of tools) {
     registerTool(tool);
   }

--- a/src/telemetry/flag_usage_metrics.json
+++ b/src/telemetry/flag_usage_metrics.json
@@ -371,5 +371,9 @@
   {
     "name": "allow_unrestricted_paths",
     "flagType": "boolean"
+  },
+  {
+    "name": "disabled_tool_present",
+    "flagType": "boolean"
   }
 ]

--- a/tests/ToolHandler.test.ts
+++ b/tests/ToolHandler.test.ts
@@ -301,4 +301,104 @@ describe('ToolHandler', () => {
     );
     assert.strictEqual(handlerCalled, false);
   });
+
+  describe('disabledTool', () => {
+    function createTool(name: string): {
+      tool: ToolDefinition;
+      wasCalled: () => boolean;
+    } {
+      let handlerCalled = false;
+      const tool: ToolDefinition = {
+        name,
+        description: 'A test tool',
+        annotations: {
+          category: ToolCategory.NAVIGATION,
+          readOnlyHint: true,
+        },
+        schema: {},
+        blockedByDialog: false,
+        verifyFilesSchema: [],
+        handler: async () => {
+          handlerCalled = true;
+        },
+      };
+      return {
+        tool,
+        wasCalled: () => handlerCalled,
+      };
+    }
+
+    function createToolHandler(tool: ToolDefinition, argv: string[]) {
+      const mockContext = sinon.createStubInstance(McpContext);
+      const serverArgs = parseArguments(
+        '1.0.0',
+        ['node', 'script.js', ...argv],
+        {CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true'},
+      );
+      return new ToolHandler(
+        tool,
+        serverArgs,
+        async () => mockContext,
+        new Mutex(),
+      );
+    }
+
+    it('does not register tools disabled via --disabled-tool', async () => {
+      const {tool, wasCalled} = createTool('dangerous_tool');
+      const toolHandler = createToolHandler(tool, [
+        '--disabled-tool=dangerous_tool',
+      ]);
+
+      assert.strictEqual(toolHandler.shouldRegister, false);
+
+      const result = await toolHandler.handle({});
+      assert.strictEqual(result.isError, true);
+      assert.match(
+        result.content[0].type === 'text' ? result.content[0].text : '',
+        /Tool dangerous_tool has been disabled via the --disabled-tool option/,
+      );
+      assert.strictEqual(wasCalled(), false);
+    });
+
+    it('supports disabling multiple tools', () => {
+      const first = createTool('first_tool');
+      const second = createTool('second_tool');
+      const argv = [
+        '--disabled-tool=first_tool',
+        '--disabled-tool=second_tool',
+      ];
+
+      assert.strictEqual(
+        createToolHandler(first.tool, argv).shouldRegister,
+        false,
+      );
+      assert.strictEqual(
+        createToolHandler(second.tool, argv).shouldRegister,
+        false,
+      );
+    });
+
+    it('does not register tools disabled via --disabled-tool when running via the CLI', () => {
+      const {tool} = createTool('dangerous_tool');
+      const toolHandler = createToolHandler(tool, [
+        '--disabled-tool=dangerous_tool',
+        '--viaCli',
+      ]);
+
+      assert.strictEqual(toolHandler.shouldRegister, false);
+    });
+
+    it('does not affect tools with other names', async () => {
+      const {tool, wasCalled} = createTool('other_tool');
+      const toolHandler = createToolHandler(tool, [
+        '--disabled-tool=dangerous_tool',
+      ]);
+
+      assert.strictEqual(toolHandler.shouldRegister, true);
+
+      const result = await toolHandler.handle({});
+      assert.strictEqual(result.isError, undefined);
+      assert.strictEqual(wasCalled(), true);
+    });
+  });
 });


### PR DESCRIPTION
## What

Adds a `--disabledTool` / `--disabled-tool` CLI option (array, repeatable) that prevents the named tools from being exposed to the MCP client:

```
npx chrome-devtools-mcp@latest --disabled-tool=evaluate_script
```

- Disabled tools are never registered with the MCP client (not even in `--viaCli` mode), and `ToolHandler.handle()` additionally refuses to execute them as defense in depth.
- Unknown tool names fail fast at server startup, so a typo cannot silently leave a tool enabled.
- Telemetry only records the presence of the flag (`disabled_tool_present`), not which tools were disabled.

## Why

#2179 asks for security guardrails when `chrome-devtools-mcp` is used by MCP clients that process untrusted content. Several of the requested guardrails already exist (`--allowedUrlPattern`/`--blockedUrlPattern` for URL policy, `--allowUnrestrictedPaths` for file paths), but one concrete request is still open: *"An option to disable the `evaluate_script` tool entirely."*

Category flags (`--no-category-*`) are too coarse for this: script tools cannot be turned off individually. A per-tool disable flag lets operators remove high-impact capabilities (script evaluation, file upload, etc.) from the toolset when tool calls may be influenced by untrusted web content, while keeping the rest of the server fully functional. It is generic, so it also covers future tools without adding one flag per capability.

**Default behavior is unchanged** — the flag is opt-in; without it, the exposed toolset is identical to before.

## Testing

- `npm run build`, `npm run test:no-build` (full suite green) and `npm run check-format`.
- New unit tests in `tests/ToolHandler.test.ts`: disabled tool is not registered and refuses invocation with a clear message; multiple names supported; not registered even with `--viaCli`; other tools unaffected.
- Manual stdio smoke test against the built server: default run lists 29 tools including `evaluate_script`; with `--disabled-tool=evaluate_script` the list drops to 28 without it; `--disabled-tool=bogus_tool` exits at startup with `Unknown tool name(s) passed to --disabled-tool: bogus_tool.`
- `npm run gen` regenerated the README flag reference and `flag_usage_metrics.json`.

Refs #2179

🤖 Generated with [Claude Code](https://claude.com/claude-code)