### PR TITLE
chore: fix typos in network formatter function names

### DIFF
--- a/src/formatters/NetworkFormatter.ts
+++ b/src/formatters/NetworkFormatter.ts
@@ -148,7 +148,7 @@ export class NetworkFormatter {
   }
 
   toStringDetailed(): string {
-    return converNetworkRequestDetailedToStringDetailed(this.toJSONDetailed());
+    return convertNetworkRequestDetailedToStringDetailed(this.toJSONDetailed());
   }
 
   toJSON(): NetworkRequestConcise {
@@ -263,7 +263,7 @@ function convertNetworkRequestConciseToString(
   return `reqid=${data.requestId} ${data.method} ${data.url} [${data.status}]${data.selectedInDevToolsUI ? ` [selected in the DevTools Network panel]` : ''}`;
 }
 
-function formatHeadlers(headers: Record<string, string>): string[] {
+function formatHeaders(headers: Record<string, string>): string[] {
   const response: string[] = [];
   for (const [name, value] of Object.entries(headers)) {
     response.push(`- ${name}:${value}`);
@@ -271,14 +271,14 @@ function formatHeadlers(headers: Record<string, string>): string[] {
   return response;
 }
 
-function converNetworkRequestDetailedToStringDetailed(
+function convertNetworkRequestDetailedToStringDetailed(
   data: NetworkRequestDetailed,
 ): string {
   const response: string[] = [];
   response.push(`## Request ${data.url}`);
   response.push(`Status: ${data.status}`);
   response.push(`### Request Headers`);
-  for (const line of formatHeadlers(data.requestHeaders)) {
+  for (const line of formatHeaders(data.requestHeaders)) {
     response.push(line);
   }
 
@@ -292,7 +292,7 @@ function converNetworkRequestDetailedToStringDetailed(
 
   if (data.responseHeaders) {
     response.push(`### Response Headers`);
-    for (const line of formatHeadlers(data.responseHeaders)) {
+    for (const line of formatHeaders(data.responseHeaders)) {
       response.push(line);
     }
   }


### PR DESCRIPTION
Fixes two typos in module-local (non-exported) function names in `src/formatters/NetworkFormatter.ts`:

- `formatHeadlers` → `formatHeaders` (declaration + 2 call sites)
- `converNetworkRequestDetailedToStringDetailed` → `convertNetworkRequestDetailedToStringDetailed` (declaration + 1 call site)

Both functions are only referenced within this file, so this is a pure rename with no behavior change and no public API impact. Output snapshots are unchanged.

## Testing

- `npm run build` — passes
- `npm run test:no-build` — passes (a handful of extension-related tests hit the known `Timeout uninstalling extension` flake under parallel load; all of them pass when re-run in isolation: `npm run test:no-build -- tests/tools/script.test.ts tests/tools/console.test.ts tests/tools/pages.test.ts tests/tools/extensions.test.ts` exits 0)
- `npm run test:no-build -- tests/formatters/NetworkFormatter.test.ts` — passes, no snapshot changes
- `npm run check-format` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)