### PR TITLE
test: add unit tests for keyboard key parsing

### DIFF
--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -25,7 +25,6 @@ import {
   clickAt,
   typeText,
 } from '../../src/tools/input.js';
-import {parseKey} from '../../src/utils/keyboard.js';
 import {serverHooks} from '../server.js';
 import {html, withMcpContext, getTextContent} from '../utils.js';
 
@@ -1299,33 +1298,6 @@ describe('input', () => {
   });
 
   describe('press_key', () => {
-    it('parses keys', () => {
-      assert.deepStrictEqual(parseKey('Shift+A'), ['A', 'Shift']);
-      assert.deepStrictEqual(parseKey('Shift++'), ['+', 'Shift']);
-      assert.deepStrictEqual(parseKey('Control+Shift++'), [
-        '+',
-        'Control',
-        'Shift',
-      ]);
-      assert.deepStrictEqual(parseKey('Shift'), ['Shift']);
-      assert.deepStrictEqual(parseKey('KeyA'), ['KeyA']);
-    });
-    it('throws on empty key', () => {
-      assert.throws(() => {
-        parseKey('');
-      });
-    });
-    it('throws on invalid key', () => {
-      assert.throws(() => {
-        parseKey('aaaaa');
-      });
-    });
-    it('throws on multiple keys', () => {
-      assert.throws(() => {
-        parseKey('Shift+Shift');
-      });
-    });
-
     it('processes press_key', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedMcpPage().pptrPage;

--- a/tests/utils/keyboard.test.ts
+++ b/tests/utils/keyboard.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {describe, it} from 'node:test';
+
+import {parseKey} from '../../src/utils/keyboard.js';
+
+describe('parseKey', () => {
+  it('parses single keys', () => {
+    assert.deepStrictEqual(parseKey('Enter'), ['Enter']);
+    assert.deepStrictEqual(parseKey('Escape'), ['Escape']);
+    assert.deepStrictEqual(parseKey('F5'), ['F5']);
+    assert.deepStrictEqual(parseKey('5'), ['5']);
+    assert.deepStrictEqual(parseKey('Numpad5'), ['Numpad5']);
+    assert.deepStrictEqual(parseKey('KeyA'), ['KeyA']);
+    assert.deepStrictEqual(parseKey('a'), ['a']);
+    assert.deepStrictEqual(parseKey('A'), ['A']);
+    assert.deepStrictEqual(parseKey(' '), [' ']);
+    assert.deepStrictEqual(parseKey('\r'), ['\r']);
+    assert.deepStrictEqual(parseKey('\n'), ['\n']);
+  });
+
+  it('parses a modifier on its own', () => {
+    assert.deepStrictEqual(parseKey('Shift'), ['Shift']);
+    assert.deepStrictEqual(parseKey('Control'), ['Control']);
+    assert.deepStrictEqual(parseKey('Meta'), ['Meta']);
+  });
+
+  it('returns the primary key first, then modifiers in original order', () => {
+    assert.deepStrictEqual(parseKey('Shift+Enter'), ['Enter', 'Shift']);
+    assert.deepStrictEqual(parseKey('Shift+A'), ['A', 'Shift']);
+    assert.deepStrictEqual(parseKey('Control+Shift+P'), [
+      'P',
+      'Control',
+      'Shift',
+    ]);
+    assert.deepStrictEqual(parseKey('Control+Alt+Delete'), [
+      'Delete',
+      'Control',
+      'Alt',
+    ]);
+    assert.deepStrictEqual(parseKey('Alt+Control+Delete'), [
+      'Delete',
+      'Alt',
+      'Control',
+    ]);
+    assert.deepStrictEqual(parseKey('Control+Shift'), ['Shift', 'Control']);
+  });
+
+  it('parses a literal plus as a key', () => {
+    assert.deepStrictEqual(parseKey('+'), ['+']);
+    assert.deepStrictEqual(parseKey('Shift++'), ['+', 'Shift']);
+    assert.deepStrictEqual(parseKey('Control+Shift++'), [
+      '+',
+      'Control',
+      'Shift',
+    ]);
+  });
+
+  it('ignores a trailing separator', () => {
+    assert.deepStrictEqual(parseKey('Shift+'), ['Shift']);
+    assert.deepStrictEqual(parseKey('++'), ['+']);
+  });
+
+  it('is case-sensitive', () => {
+    assert.deepStrictEqual(parseKey('Shift+a'), ['a', 'Shift']);
+    assert.deepStrictEqual(parseKey('Shift+A'), ['A', 'Shift']);
+    assert.throws(
+      () => {
+        parseKey('shift+a');
+      },
+      {message: /^shift is invalid\. Valid keys are: /},
+    );
+    assert.throws(
+      () => {
+        parseKey('ENTER');
+      },
+      {message: /^ENTER is invalid\. Valid keys are: /},
+    );
+  });
+
+  it('does not trim whitespace around keys', () => {
+    assert.throws(
+      () => {
+        parseKey('Shift + a');
+      },
+      {message: /is invalid\. Valid keys are: /},
+    );
+    assert.throws(
+      () => {
+        parseKey('Enter ');
+      },
+      {message: /is invalid\. Valid keys are: /},
+    );
+  });
+
+  it('throws on invalid key names with a helpful message', () => {
+    assert.throws(
+      () => {
+        parseKey('aaaaa');
+      },
+      {message: /^aaaaa is invalid\. Valid keys are: /},
+    );
+    assert.throws(
+      () => {
+        parseKey('NotAKey+Enter');
+      },
+      {message: /^NotAKey is invalid\. Valid keys are: /},
+    );
+    assert.throws(
+      () => {
+        parseKey('+a');
+      },
+      {message: /^\+a is invalid\. Valid keys are: /},
+    );
+  });
+
+  it('throws on empty input', () => {
+    assert.throws(
+      () => {
+        parseKey('');
+      },
+      {message: 'Key  could not be parsed.'},
+    );
+  });
+
+  it('throws on duplicate keys', () => {
+    assert.throws(
+      () => {
+        parseKey('Shift+Shift');
+      },
+      {message: 'Key Shift+Shift contains duplicate keys.'},
+    );
+    assert.throws(
+      () => {
+        parseKey('Control+a+Control');
+      },
+      {message: 'Key Control+a+Control contains duplicate keys.'},
+    );
+    assert.throws(
+      () => {
+        parseKey('a+a');
+      },
+      {message: 'Key a+a contains duplicate keys.'},
+    );
+  });
+});


### PR DESCRIPTION
## Why

`src/utils/keyboard.ts` (`parseKey`) validates and parses the user-supplied `key` argument for the `press_key` tool, so it is a small but agent-facing input-validation path. Its only coverage so far was a handful of inline assertions inside `tests/tools/input.test.ts`. This PR gives the module a dedicated unit test file under `tests/utils/` (alongside `files.test.ts` and `url.test.ts`), moves the existing inline assertions there, and expands coverage.

## Coverage

- Single keys (`Enter`, `Escape`, `F5`, `5`, `Numpad5`, `KeyA`, `a`, `A`, `' '`, `\r`, `\n`) and lone modifiers (`Shift`, `Control`, `Meta`)
- Primary key returned first, followed by modifiers in original order (`Control+Shift+P` → `['P', 'Control', 'Shift']`, `Alt+Control+Delete` vs `Control+Alt+Delete`)
- Literal plus as a key (`+`, `Shift++`, `Control+Shift++`)
- Trailing separator is ignored (`Shift+` → `['Shift']`, `++` → `['+']`)
- Case sensitivity (`Shift+a` vs `Shift+A`; `shift+a` and `ENTER` throw)
- No whitespace trimming (`Shift + a`, `Enter ` throw)
- Invalid key names throw with the `<key> is invalid. Valid keys are: ...` message shape (including `NotAKey+Enter` and `+a`)
- Empty input throws `Key  could not be parsed.`
- Duplicate keys throw (`Shift+Shift`, `Control+a+Control`, `a+a`)

No `src/` changes; the tests assert current behavior. One observation (not changed here): a trailing `+` after a valid key is silently dropped (`Shift+` parses as just `Shift`), which may or may not be intended.

## Testing

- `npm run build` — clean
- `node scripts/test.js tests/utils/keyboard.test.ts tests/tools/input.test.ts` — all pass (exit 0)
- `npm run test:no-build` — only failures were the known `Timeout uninstalling extension` flakes in `console`/`extensions`/`pages`; re-ran `node scripts/test.js tests/tools/console.test.ts tests/tools/extensions.test.ts tests/tools/pages.test.ts` in isolation — all pass (exit 0)
- `npm run check-format` — eslint and prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)