### PR TITLE
test: add unit tests for trace processing helpers

### DIFF
--- a/tests/trace-processing/parse.test.ts
+++ b/tests/trace-processing/parse.test.ts
@@ -7,12 +7,28 @@
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 
+import type {
+  InsightName,
+  TraceParseError,
+  TraceResult,
+} from '../../src/trace-processing/parse.js';
 import {
+  getInsightOutput,
   getTraceSummary,
   parseRawTraceBuffer,
+  traceResultIsSuccess,
 } from '../../src/trace-processing/parse.js';
 
 import {loadTraceAsBuffer} from './fixtures/load.js';
+
+async function parseTrace(fileName: string): Promise<TraceResult> {
+  const rawData = loadTraceAsBuffer(fileName);
+  const result = await parseRawTraceBuffer(rawData);
+  if (!traceResultIsSuccess(result)) {
+    assert.fail(`Unexpected trace parse error: ${result.error}`);
+  }
+  return result;
+}
 
 describe('Trace parsing', async () => {
   it('can parse a Uint8Array from Tracing.stop())', async () => {
@@ -42,6 +58,114 @@ describe('Trace parsing', async () => {
     const result = await parseRawTraceBuffer(undefined);
     assert.deepEqual(result, {
       error: 'No buffer was provided.',
+    });
+  });
+
+  it('will return a message if the buffer decodes to an empty string', async () => {
+    const result = await parseRawTraceBuffer(new Uint8Array());
+    assert.deepEqual(result, {
+      error: 'Decoding the trace buffer returned an empty string.',
+    });
+  });
+
+  it('will return a message if the buffer is not valid JSON', async () => {
+    const result = await parseRawTraceBuffer(
+      new TextEncoder().encode('this is not valid JSON'),
+    );
+    if (traceResultIsSuccess(result)) {
+      assert.fail('Expected a parse error for invalid JSON input.');
+    }
+    assert.match(result.error, /JSON/);
+  });
+
+  it('will return a message if the JSON is not a valid trace', async () => {
+    const result = await parseRawTraceBuffer(
+      new TextEncoder().encode('{"notATrace": true}'),
+    );
+    if (traceResultIsSuccess(result)) {
+      assert.fail('Expected a parse error for a non-trace JSON input.');
+    }
+    assert.ok(result.error.length > 0);
+  });
+});
+
+describe('traceResultIsSuccess', () => {
+  it('returns true for the result of a successful parse', async () => {
+    const rawData = loadTraceAsBuffer('basic-trace.json.gz');
+    const result = await parseRawTraceBuffer(rawData);
+    assert.strictEqual(traceResultIsSuccess(result), true);
+  });
+
+  it('returns true for a trace result without insights', async () => {
+    const result = await parseTrace('basic-trace.json.gz');
+    const withoutInsights: TraceResult = {
+      parsedTrace: result.parsedTrace,
+      insights: null,
+    };
+    assert.strictEqual(traceResultIsSuccess(withoutInsights), true);
+  });
+
+  it('returns false for the result of a failed parse', async () => {
+    const result = await parseRawTraceBuffer(undefined);
+    assert.strictEqual(traceResultIsSuccess(result), false);
+  });
+
+  it('returns false for a parse error object', () => {
+    const error: TraceParseError = {error: 'Something went wrong.'};
+    assert.strictEqual(traceResultIsSuccess(error), false);
+  });
+
+  it('checks for the parsedTrace key, not the error message contents', () => {
+    const error: TraceParseError = {error: 'parsedTrace'};
+    assert.strictEqual(traceResultIsSuccess(error), false);
+  });
+});
+
+describe('getInsightOutput', () => {
+  it('returns the formatted output for a known insight', async () => {
+    const result = await parseTrace('web-dev-with-commit.json.gz');
+    const insight = getInsightOutput(result, 'NAVIGATION_0', 'LCPBreakdown');
+    if ('error' in insight) {
+      assert.fail(`Unexpected insight error: ${insight.error}`);
+    }
+    assert.match(insight.output, /Insight Title: LCP breakdown/);
+  });
+
+  it('returns an error if the trace has no insights', async () => {
+    const result = await parseTrace('web-dev-with-commit.json.gz');
+    const withoutInsights: TraceResult = {
+      parsedTrace: result.parsedTrace,
+      insights: null,
+    };
+    const insight = getInsightOutput(
+      withoutInsights,
+      'NAVIGATION_0',
+      'LCPBreakdown',
+    );
+    assert.deepEqual(insight, {
+      error: 'No Performance insights are available for this trace.',
+    });
+  });
+
+  it('returns an error for an unknown insight set id', async () => {
+    const result = await parseTrace('web-dev-with-commit.json.gz');
+    const insight = getInsightOutput(result, 'NOT_A_SET_ID', 'LCPBreakdown');
+    assert.deepEqual(insight, {
+      error:
+        'No Performance Insights for the given insight set id. Only use ids given in the "Available insight sets" list.',
+    });
+  });
+
+  it('returns an error for an unknown insight name', async () => {
+    const result = await parseTrace('web-dev-with-commit.json.gz');
+    const insight = getInsightOutput(
+      result,
+      'NAVIGATION_0',
+      'NotARealInsight' as InsightName,
+    );
+    assert.deepEqual(insight, {
+      error:
+        'No Insight with the name NotARealInsight found. Double check the name you provided is accurate and try again.',
     });
   });
 });


### PR DESCRIPTION
## Why

`src/trace-processing/parse.ts` exports several pure, browser-free helpers, but `tests/trace-processing/parse.test.ts` only exercised the happy parse path, the trace summary snapshot, and the `undefined`-buffer error. This PR adds direct unit tests for the remaining exported helpers and branches, so regressions in the discriminant logic or the error contracts are caught without needing a browser.

## Coverage added

- `traceResultIsSuccess`
  - returns `true` for the result of a real successful parse (fixture trace)
  - returns `true` for a `TraceResult` whose `insights` is `null` (the guard must only depend on `parsedTrace`)
  - returns `false` for the result of a failed parse
  - returns `false` for a `TraceParseError` object
  - returns `false` for a near-miss where the error *message text* is `'parsedTrace'` — the guard checks the key, not values
- `parseRawTraceBuffer` (previously untested error branches)
  - empty buffer → `'Decoding the trace buffer returned an empty string.'`
  - invalid JSON → returns a `TraceParseError` instead of throwing
  - valid JSON that is not a trace → returns a `TraceParseError` instead of throwing
- `getInsightOutput` (previously untested)
  - formatted output for a known insight (`NAVIGATION_0` / `LCPBreakdown` from the `web-dev-with-commit` fixture)
  - error when the trace has no insights
  - error for an unknown insight set id
  - error for an unknown insight name

Tests only — no changes under `src/`, and no new snapshots (the insight output is asserted with a targeted match so devtools-frontend formatter updates don't churn a snapshot).

## Testing

- `npm run build` — clean
- `node scripts/test.js tests/trace-processing/parse.test.ts` — 15/15 pass (3 suites)
- `npm run test:no-build` — full suite green (exit 0)
- `npm run check-format` — eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)