### PR TITLE
test: cover waitforhelper network multiplier and navigation paths

### DIFF
--- a/tests/WaitForHelper.test.ts
+++ b/tests/WaitForHelper.test.ts
@@ -150,8 +150,6 @@ describe('WaitForHelper', () => {
         `expected the wait to be bounded by the internal timeouts, took ${elapsed}ms`,
       );
 
-      // Note: no in-page cleanup here. Evaluations do not settle while the
-      // navigation is pending; the harness closes the page during teardown.
     });
   });
 
@@ -168,8 +166,6 @@ describe('WaitForHelper', () => {
         });
       });
 
-      // Same-document navigations skip the full navigation wait but are still
-      // surfaced through the before/after URL comparison.
       assert.strictEqual(result.navigatedToUrl, `${pageUrl}#section`);
       assert.strictEqual(result.dialogHandled, false);
     });

--- a/tests/WaitForHelper.test.ts
+++ b/tests/WaitForHelper.test.ts
@@ -7,9 +7,33 @@
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 
+import {getNetworkMultiplierFromString} from '../src/WaitForHelper.js';
+
+import {serverHooks} from './server.js';
 import {html, withMcpContext} from './utils.js';
 
+describe('getNetworkMultiplierFromString', () => {
+  it('maps each predefined network condition to its multiplier', () => {
+    assert.strictEqual(getNetworkMultiplierFromString('Fast 4G'), 1);
+    assert.strictEqual(getNetworkMultiplierFromString('Slow 4G'), 2.5);
+    assert.strictEqual(getNetworkMultiplierFromString('Fast 3G'), 5);
+    assert.strictEqual(getNetworkMultiplierFromString('Slow 3G'), 10);
+  });
+
+  it('falls back to 1 for unknown condition strings', () => {
+    assert.strictEqual(getNetworkMultiplierFromString('2G'), 1);
+    assert.strictEqual(getNetworkMultiplierFromString('No emulation'), 1);
+    assert.strictEqual(getNetworkMultiplierFromString(''), 1);
+  });
+
+  it('falls back to 1 when no condition is set', () => {
+    assert.strictEqual(getNetworkMultiplierFromString(null), 1);
+  });
+});
+
 describe('WaitForHelper', () => {
+  const server = serverHooks();
+
   it('does not stall when an action opens a dialog without handleDialog', async () => {
     await withMcpContext(async (response, context) => {
       const mcpPage = context.getSelectedMcpPage();
@@ -41,6 +65,127 @@ describe('WaitForHelper', () => {
       // The dialog is still open and recorded, so the next blockedByDialog tool
       // correctly refuses to run.
       assert.throws(() => mcpPage.throwIfDialogOpen());
+    });
+  });
+
+  it('reports navigatedToUrl when the action starts a cross-document navigation', async () => {
+    await withMcpContext(async (response, context) => {
+      const mcpPage = context.getSelectedMcpPage();
+      server.addHtmlRoute('/target.html', html`<h1>target</h1>`);
+      const targetUrl = server.getRoute('/target.html');
+
+      const result = await mcpPage.waitForEventsAfterAction(async () => {
+        await mcpPage.pptrPage.evaluate(url => {
+          // Navigate asynchronously so the evaluate call returns before the
+          // execution context is destroyed by the navigation.
+          setTimeout(() => {
+            window.location.href = url;
+          }, 0);
+        }, targetUrl);
+      });
+
+      assert.strictEqual(result.navigatedToUrl, targetUrl);
+      assert.strictEqual(result.dialogHandled, false);
+      assert.strictEqual(mcpPage.pptrPage.url(), targetUrl);
+    });
+  });
+
+  it('resolves quickly without navigatedToUrl when no navigation happens', async () => {
+    await withMcpContext(async (response, context) => {
+      const mcpPage = context.getSelectedMcpPage();
+      await mcpPage.pptrPage.setContent(html`<div id="root"></div>`);
+
+      const start = Date.now();
+      const result = await mcpPage.waitForEventsAfterAction(async () => {
+        await mcpPage.pptrPage.evaluate(() => {
+          document.querySelector('#root')!.append('done');
+        });
+      });
+      const elapsed = Date.now() - start;
+
+      assert.strictEqual(result.navigatedToUrl, undefined);
+      assert.strictEqual(result.dialogHandled, false);
+      // Expected wait is ~200ms (#expectNavigationIn 100ms + #stableDomFor
+      // 100ms). Assert we stayed below #stableDomTimeout/#navigationTimeout
+      // (3s each) to prove neither full timeout was consumed.
+      assert.ok(
+        elapsed < 2_000,
+        `expected a fast return without navigation, took ${elapsed}ms`,
+      );
+    });
+  });
+
+  it('swallows navigation timeouts and still resolves with a result', async () => {
+    await withMcpContext(async (response, context) => {
+      const mcpPage = context.getSelectedMcpPage();
+      server.addRoute('/hang.html', () => {
+        // Never respond so the started navigation cannot complete.
+      });
+      const hangUrl = server.getRoute('/hang.html');
+
+      const start = Date.now();
+      const result = await mcpPage.waitForEventsAfterAction(
+        async () => {
+          await mcpPage.pptrPage.evaluate(url => {
+            setTimeout(() => {
+              window.location.href = url;
+            }, 0);
+          }, hangUrl);
+        },
+        {timeout: 500},
+      );
+      const elapsed = Date.now() - start;
+
+      // The navigation started but timed out; the timeout error is logged and
+      // swallowed rather than thrown, and the pending navigation never
+      // committed, so the URL is unchanged and no navigatedToUrl is reported.
+      assert.strictEqual(result.navigatedToUrl, undefined);
+      assert.strictEqual(result.dialogHandled, false);
+      // Current behavior: the total wait is the 500ms navigation timeout plus
+      // the full 3s #stableDomTimeout, because the stable-DOM evaluation does
+      // not settle while the navigation is still pending (~3.5s in total).
+      // Assert an upper bound well below protocolTimeout-scale hangs.
+      assert.ok(
+        elapsed < 8_000,
+        `expected the wait to be bounded by the internal timeouts, took ${elapsed}ms`,
+      );
+
+      // Note: no in-page cleanup here. Evaluations do not settle while the
+      // navigation is pending; the harness closes the page during teardown.
+    });
+  });
+
+  it('reports same-document hash navigations via the URL comparison', async () => {
+    await withMcpContext(async (response, context) => {
+      const mcpPage = context.getSelectedMcpPage();
+      server.addHtmlRoute('/page.html', html`<p>content</p>`);
+      const pageUrl = server.getRoute('/page.html');
+      await mcpPage.pptrPage.goto(pageUrl);
+
+      const result = await mcpPage.waitForEventsAfterAction(async () => {
+        await mcpPage.pptrPage.evaluate(() => {
+          window.location.hash = '#section';
+        });
+      });
+
+      // Same-document navigations skip the full navigation wait but are still
+      // surfaced through the before/after URL comparison.
+      assert.strictEqual(result.navigatedToUrl, `${pageUrl}#section`);
+      assert.strictEqual(result.dialogHandled, false);
+    });
+  });
+
+  it('rethrows errors from the action', async () => {
+    await withMcpContext(async (response, context) => {
+      const mcpPage = context.getSelectedMcpPage();
+      await mcpPage.pptrPage.setContent(html`<p>content</p>`);
+
+      await assert.rejects(
+        mcpPage.waitForEventsAfterAction(() =>
+          Promise.reject(new Error('action failed')),
+        ),
+        /action failed/,
+      );
     });
   });
 });


### PR DESCRIPTION
## Why

`tests/WaitForHelper.test.ts` currently only covers dialog handling. The exported pure function `getNetworkMultiplierFromString` (`src/WaitForHelper.ts`) had no coverage at all, and the navigation/timeout paths of `waitForEventsAfterAction` were untested. This PR expands the test file to lock in the current behavior of those paths. No `src/` changes.

## Coverage added

- `getNetworkMultiplierFromString`: exact multipliers for each predefined condition (`Fast 4G` → 1, `Slow 4G` → 2.5, `Fast 3G` → 5, `Slow 3G` → 10), fallback to 1 for unknown strings and for `null`.
- Cross-document navigation: an action that navigates resolves with `navigatedToUrl` set to the destination.
- No navigation: resolves quickly (bounded well below `#stableDomTimeout`) with no `navigatedToUrl`.
- Navigation timeout: a navigation that starts but never completes has its timeout error swallowed (logged, not thrown) and still resolves with a result; the URL stays unchanged so no `navigatedToUrl` is reported.
- Same-document hash navigation: skips the full navigation wait but is still surfaced via the before/after URL comparison.
- Action errors are rethrown to the caller.

## Observation (current behavior, asserted as-is)

When a started navigation times out and remains pending, the subsequent stable-DOM wait cannot settle (in-page evaluations do not complete while the navigation is pending), so it consumes the full `#stableDomTimeout`. With `{timeout: 500}` the call still takes ~3.5s total (500ms navigation timeout + 3s stable-DOM timeout). The test documents this rather than changing it.

Note: this is independent of the open PR #2504 (popup tracking in `WaitForHelper`); it only touches network-multiplier and navigation/timeout behavior, so the two do not conflict.

## Testing

- `node scripts/test.js tests/WaitForHelper.test.ts` — 11/11 pass (run 3x to check for flakes)
- `npm run test:no-build` — full suite green
- `npm run check-format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)