### PR TITLE
chore: clarify saveFile error messages in network formatter

### DIFF
--- a/src/formatters/NetworkFormatter.ts
+++ b/src/formatters/NetworkFormatter.ts
@@ -86,7 +86,9 @@ export class NetworkFormatter {
         '<Request body not available anymore>';
       if (this.#options.requestFilePath) {
         if (!this.#options.saveFile) {
-          throw new Error('saveFile is not provided');
+          throw new Error(
+            'Unable to save the request body to a file: no saveFile callback was configured.',
+          );
         }
         if (data) {
           const result = await this.#options.saveFile(
@@ -119,7 +121,9 @@ export class NetworkFormatter {
         try {
           const buffer = await response.buffer();
           if (!this.#options.saveFile) {
-            throw new Error('saveFile is not provided');
+            throw new Error(
+              'Unable to save the response body to a file: no saveFile callback was configured.',
+            );
           }
           const result = await this.#options.saveFile(
             buffer,


### PR DESCRIPTION
When `list_network_requests` / `get_network_request` is asked to save a request or response body to a file but no `saveFile` callback was passed to `NetworkFormatter`, the formatter throws a generic error that gives the caller no idea what operation failed or how to fix it.

**Before** (both sites):

```
saveFile is not provided
```

**After:**

```
Unable to save the request body to a file: no saveFile callback was configured.
Unable to save the response body to a file: no saveFile callback was configured.
```

Why it helps: the request-body error propagates out of `NetworkFormatter.from()` into the tool response, so an MCP client (typically a coding agent) sees the raw message. The new wording states what was attempted (saving the request vs. response body) and the cause (missing `saveFile` callback), instead of an internal identifier with no context. The response-body site is currently flattened by the surrounding `try/catch`, but the clearer message still helps anyone debugging that path.

No behavior change beyond the message text; the exact strings are not asserted in any test or snapshot.

## Testing

- `npm run build` — passes
- `npm run test:no-build` — full suite passes (exit 0)
- `npm run check-format` — eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)