### PR TITLE
fix: validate pagination params in memory tools

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -487,8 +487,8 @@ in the DevTools Elements panel (if any).
 - **id** (number) **(required)**: The ID for the class, obtained from details.
 - **filterName** (enum: "objectsRetainedByDetachedDomNodes", "objectsRetainedByConsole", "objectsRetainedByEventHandlers", "objectsRetainedByContexts", "sharedNativeContext", "noNativeContext", "attributedToSpecificNativeContext") _(optional)_: An optional filter to apply to the nodes.
 - **objectId** (number) _(optional)_: The object ID (nodeId) of the specific native context to filter by when filterName is attributedToSpecificNativeContext.
-- **pageIdx** (number) _(optional)_: The page index for pagination.
-- **pageSize** (number) _(optional)_: The page size for pagination.
+- **pageIdx** (integer) _(optional)_: Page number to return (0-based). When omitted, returns the first page.
+- **pageSize** (integer) _(optional)_: Maximum number of items to return. When omitted, returns all items.
 
 ---
 
@@ -501,8 +501,8 @@ in the DevTools Elements panel (if any).
 - **filePath** (string) **(required)**: A path to a .heapsnapshot file to read.
 - **filterName** (enum: "objectsRetainedByDetachedDomNodes", "objectsRetainedByConsole", "objectsRetainedByEventHandlers", "objectsRetainedByContexts", "sharedNativeContext", "noNativeContext", "attributedToSpecificNativeContext") _(optional)_: An optional filter to apply to the aggregates.
 - **objectId** (number) _(optional)_: The object ID (nodeId) of the specific native context to filter by when filterName is attributedToSpecificNativeContext.
-- **pageIdx** (number) _(optional)_: The page index for pagination of aggregates.
-- **pageSize** (number) _(optional)_: The page size for pagination of aggregates.
+- **pageIdx** (integer) _(optional)_: Page number of aggregates to return (0-based). When omitted, returns the first page.
+- **pageSize** (integer) _(optional)_: Maximum number of aggregates to return. When omitted, returns all aggregates.
 
 ---
 
@@ -524,8 +524,8 @@ in the DevTools Elements panel (if any).
 **Parameters:**
 
 - **filePath** (string) **(required)**: A path to a .heapsnapshot file to read.
-- **pageIdx** (number) _(optional)_: The page index for pagination.
-- **pageSize** (number) _(optional)_: The page size for pagination.
+- **pageIdx** (integer) _(optional)_: Page number to return (0-based). When omitted, returns the first page.
+- **pageSize** (integer) _(optional)_: Maximum number of items to return. When omitted, returns all items.
 
 ---
 
@@ -537,8 +537,8 @@ in the DevTools Elements panel (if any).
 
 - **filePath** (string) **(required)**: A path to a .heapsnapshot file to read.
 - **nodeId** (number) **(required)**: The node ID to get outgoing edges for.
-- **pageIdx** (number) _(optional)_: The page index for pagination.
-- **pageSize** (number) _(optional)_: The page size for pagination.
+- **pageIdx** (integer) _(optional)_: Page number to return (0-based). When omitted, returns the first page.
+- **pageSize** (integer) _(optional)_: Maximum number of items to return. When omitted, returns all items.
 
 ---
 
@@ -561,8 +561,8 @@ in the DevTools Elements panel (if any).
 
 - **filePath** (string) **(required)**: A path to a .heapsnapshot file to read.
 - **nodeId** (number) **(required)**: The node ID to get retainers for.
-- **pageIdx** (number) _(optional)_: The page index for pagination.
-- **pageSize** (number) _(optional)_: The page size for pagination.
+- **pageIdx** (integer) _(optional)_: Page number to return (0-based). When omitted, returns the first page.
+- **pageSize** (integer) _(optional)_: Maximum number of items to return. When omitted, returns all items.
 
 ---
 

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -373,14 +373,16 @@ export const commands: Commands = {
       },
       pageIdx: {
         name: 'pageIdx',
-        type: 'number',
-        description: 'The page index for pagination.',
+        type: 'integer',
+        description:
+          'Page number to return (0-based). When omitted, returns the first page.',
         required: false,
       },
       pageSize: {
         name: 'pageSize',
-        type: 'number',
-        description: 'The page size for pagination.',
+        type: 'integer',
+        description:
+          'Maximum number of items to return. When omitted, returns all items.',
         required: false,
       },
     },
@@ -420,14 +422,16 @@ export const commands: Commands = {
       },
       pageIdx: {
         name: 'pageIdx',
-        type: 'number',
-        description: 'The page index for pagination of aggregates.',
+        type: 'integer',
+        description:
+          'Page number of aggregates to return (0-based). When omitted, returns the first page.',
         required: false,
       },
       pageSize: {
         name: 'pageSize',
-        type: 'number',
-        description: 'The page size for pagination of aggregates.',
+        type: 'integer',
+        description:
+          'Maximum number of aggregates to return. When omitted, returns all aggregates.',
         required: false,
       },
     },
@@ -464,14 +468,16 @@ export const commands: Commands = {
       },
       pageIdx: {
         name: 'pageIdx',
-        type: 'number',
-        description: 'The page index for pagination.',
+        type: 'integer',
+        description:
+          'Page number to return (0-based). When omitted, returns the first page.',
         required: false,
       },
       pageSize: {
         name: 'pageSize',
-        type: 'number',
-        description: 'The page size for pagination.',
+        type: 'integer',
+        description:
+          'Maximum number of items to return. When omitted, returns all items.',
         required: false,
       },
     },
@@ -495,14 +501,16 @@ export const commands: Commands = {
       },
       pageIdx: {
         name: 'pageIdx',
-        type: 'number',
-        description: 'The page index for pagination.',
+        type: 'integer',
+        description:
+          'Page number to return (0-based). When omitted, returns the first page.',
         required: false,
       },
       pageSize: {
         name: 'pageSize',
-        type: 'number',
-        description: 'The page size for pagination.',
+        type: 'integer',
+        description:
+          'Maximum number of items to return. When omitted, returns all items.',
         required: false,
       },
     },
@@ -545,14 +553,16 @@ export const commands: Commands = {
       },
       pageIdx: {
         name: 'pageIdx',
-        type: 'number',
-        description: 'The page index for pagination.',
+        type: 'integer',
+        description:
+          'Page number to return (0-based). When omitted, returns the first page.',
         required: false,
       },
       pageSize: {
         name: 'pageSize',
-        type: 'number',
-        description: 'The page size for pagination.',
+        type: 'integer',
+        description:
+          'Maximum number of items to return. When omitted, returns all items.',
         required: false,
       },
     },

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -98,12 +98,20 @@ export const getHeapSnapshotDetails = defineTool({
       ),
     pageIdx: zod
       .number()
+      .int()
+      .min(0)
       .optional()
-      .describe('The page index for pagination of aggregates.'),
+      .describe(
+        'Page number of aggregates to return (0-based). When omitted, returns the first page.',
+      ),
     pageSize: zod
       .number()
+      .int()
+      .positive()
       .optional()
-      .describe('The page size for pagination of aggregates.'),
+      .describe(
+        'Maximum number of aggregates to return. When omitted, returns all aggregates.',
+      ),
   },
   blockedByDialog: false,
   verifyFilesSchema: ['filePath'],
@@ -143,8 +151,22 @@ export const getHeapSnapshotClassNodes = defineTool({
       .describe(
         'The object ID (nodeId) of the specific native context to filter by when filterName is attributedToSpecificNativeContext.',
       ),
-    pageIdx: zod.number().optional().describe('The page index for pagination.'),
-    pageSize: zod.number().optional().describe('The page size for pagination.'),
+    pageIdx: zod
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        'Page number to return (0-based). When omitted, returns the first page.',
+      ),
+    pageSize: zod
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Maximum number of items to return. When omitted, returns all items.',
+      ),
   },
   blockedByDialog: false,
   verifyFilesSchema: ['filePath'],
@@ -177,8 +199,22 @@ export const getHeapSnapshotRetainers = defineTool({
   schema: {
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
     nodeId: zod.number().describe('The node ID to get retainers for.'),
-    pageIdx: zod.number().optional().describe('The page index for pagination.'),
-    pageSize: zod.number().optional().describe('The page size for pagination.'),
+    pageIdx: zod
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        'Page number to return (0-based). When omitted, returns the first page.',
+      ),
+    pageSize: zod
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Maximum number of items to return. When omitted, returns all items.',
+      ),
   },
   handler: async (request, response, context) => {
     const retainers = await context.getHeapSnapshotRetainers(
@@ -276,8 +312,22 @@ export const getHeapSnapshotEdges = defineTool({
   schema: {
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
     nodeId: zod.number().describe('The node ID to get outgoing edges for.'),
-    pageIdx: zod.number().optional().describe('The page index for pagination.'),
-    pageSize: zod.number().optional().describe('The page size for pagination.'),
+    pageIdx: zod
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        'Page number to return (0-based). When omitted, returns the first page.',
+      ),
+    pageSize: zod
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Maximum number of items to return. When omitted, returns all items.',
+      ),
   },
   handler: async (request, response, context) => {
     const edges = await context.getHeapSnapshotEdges(
@@ -375,8 +425,22 @@ export const getHeapSnapshotDuplicateStrings = defineTool({
   verifyFilesSchema: ['filePath'],
   schema: {
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
-    pageIdx: zod.number().optional().describe('The page index for pagination.'),
-    pageSize: zod.number().optional().describe('The page size for pagination.'),
+    pageIdx: zod
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        'Page number to return (0-based). When omitted, returns the first page.',
+      ),
+    pageSize: zod
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Maximum number of items to return. When omitted, returns all items.',
+      ),
   },
   handler: async (request, response, context) => {
     const duplicateStrings = await context.getHeapSnapshotDuplicateStrings(

--- a/tests/tools/memory.test.ts
+++ b/tests/tools/memory.test.ts
@@ -648,4 +648,48 @@ describe('memory', () => {
       });
     });
   });
+
+  describe('pagination schemas', () => {
+    const paginatedTools = [
+      getHeapSnapshotDetails,
+      getHeapSnapshotClassNodes,
+      getHeapSnapshotRetainers,
+      getHeapSnapshotEdges,
+      getHeapSnapshotDuplicateStrings,
+    ];
+
+    it('rejects a non-positive pageSize', () => {
+      for (const tool of paginatedTools) {
+        for (const pageSize of [0, -1, 1.5]) {
+          assert.strictEqual(
+            tool.schema.pageSize.safeParse(pageSize).success,
+            false,
+            `${tool.name} should reject pageSize ${pageSize}`,
+          );
+        }
+        assert.strictEqual(tool.schema.pageSize.safeParse(1).success, true);
+        assert.strictEqual(
+          tool.schema.pageSize.safeParse(undefined).success,
+          true,
+        );
+      }
+    });
+
+    it('rejects a negative or non-integer pageIdx', () => {
+      for (const tool of paginatedTools) {
+        for (const pageIdx of [-1, 0.5]) {
+          assert.strictEqual(
+            tool.schema.pageIdx.safeParse(pageIdx).success,
+            false,
+            `${tool.name} should reject pageIdx ${pageIdx}`,
+          );
+        }
+        assert.strictEqual(tool.schema.pageIdx.safeParse(0).success, true);
+        assert.strictEqual(
+          tool.schema.pageIdx.safeParse(undefined).success,
+          true,
+        );
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The pagination params in `src/tools/memory.ts` were declared as plain `zod.number().optional()`, while the equivalent params in `console.ts` and `network.ts` use stricter schemas (`.int().positive()` for `pageSize`, `.int().min(0)` for `pageIdx`).

Because of the laxer schemas, invalid values reached `paginate()` in `src/utils/pagination.ts`:

- `pageSize: 0` produces `totalPages: Infinity` (`Math.ceil(total / 0)`) with an empty `items` array
- negative or fractional `pageSize` slices nonsensical ranges

This PR aligns all five paginated memory tools (`get_heapsnapshot_details`, `get_heapsnapshot_class_nodes`, `get_heapsnapshot_retainers`, `get_heapsnapshot_edges`, `get_heapsnapshot_duplicate_strings`) with the console/network schema pattern, including the `describe()` wording, so invalid values are rejected at the schema layer with a clear validation error instead of producing broken pagination output.

`docs/tool-reference.md` and `src/bin/chrome-devtools-cli-options.ts` are regenerated via `npm run gen`.

This inconsistency was noticed while writing pagination tests in #2510.

## Changes

- `src/tools/memory.ts`: `pageSize` → `zod.number().int().positive().optional()`, `pageIdx` → `zod.number().int().min(0).optional()` for all paginated memory tools
- `tests/tools/memory.test.ts`: new `pagination schemas` tests asserting that `0`, `-1`, and non-integer values are rejected and valid values still parse
- `docs/tool-reference.md`, `src/bin/chrome-devtools-cli-options.ts`: regenerated

## Testing

- `npm run build` — passes
- `npm run gen` — regenerated docs/CLI options, no unexpected diffs
- `node scripts/test.js tests/tools/memory.test.ts` — passes, including the new schema-rejection tests
- `npm run test:no-build` — full suite passes (exit 0)
- `npm run check-format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)