### PR TITLE
test: add unit tests for logger and update check utils

### DIFF
--- a/tests/utils/check-for-updates.test.ts
+++ b/tests/utils/check-for-updates.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import childProcess from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import {afterEach, beforeEach, describe, it, mock} from 'node:test';
+
+import {
+  checkForUpdates,
+  resetUpdateCheckFlagForTesting,
+} from '../../src/utils/check-for-updates.js';
+import {VERSION} from '../../src/version.js';
+
+const NO_UPDATE_CHECKS_ENV = 'CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS';
+const NEWER_VERSION = '999.999.999';
+
+describe('checkForUpdates', () => {
+  let tmpHome: string;
+  let savedEnv: string | undefined;
+  let warnings: string[];
+  let spawnCalls: Array<{
+    command: string;
+    args: string[];
+    options: childProcess.SpawnOptions;
+  }>;
+
+  function cachePath(): string {
+    return path.join(tmpHome, '.cache', 'chrome-devtools-mcp', 'latest.json');
+  }
+
+  async function writeCache(content: string): Promise<void> {
+    await fs.mkdir(path.dirname(cachePath()), {recursive: true});
+    await fs.writeFile(cachePath(), content);
+  }
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'check-for-updates-test-'),
+    );
+    // The test runner sets this variable globally, but these tests need to
+    // exercise the code paths behind the early return.
+    savedEnv = process.env[NO_UPDATE_CHECKS_ENV];
+    delete process.env[NO_UPDATE_CHECKS_ENV];
+    resetUpdateCheckFlagForTesting();
+    warnings = [];
+    spawnCalls = [];
+    mock.method(os, 'homedir', () => tmpHome);
+    mock.method(console, 'warn', (message: string) => {
+      warnings.push(String(message));
+    });
+    mock.method(
+      childProcess,
+      'spawn',
+      (command: string, args: string[], options: childProcess.SpawnOptions) => {
+        spawnCalls.push({command, args, options});
+        return {
+          unref() {
+            // No-op for tests.
+          },
+        } as unknown as childProcess.ChildProcess;
+      },
+    );
+  });
+
+  afterEach(async () => {
+    mock.restoreAll();
+    if (savedEnv === undefined) {
+      delete process.env[NO_UPDATE_CHECKS_ENV];
+    } else {
+      process.env[NO_UPDATE_CHECKS_ENV] = savedEnv;
+    }
+    resetUpdateCheckFlagForTesting();
+    await fs.rm(tmpHome, {recursive: true, force: true});
+  });
+
+  it('does nothing when update checks are disabled via the environment', async () => {
+    process.env[NO_UPDATE_CHECKS_ENV] = 'true';
+    await checkForUpdates('update me');
+    assert.strictEqual(warnings.length, 0);
+    assert.strictEqual(spawnCalls.length, 0);
+    await assert.rejects(fs.stat(cachePath()));
+  });
+
+  it('creates a cache file with the current version and spawns the checker when no cache exists', async () => {
+    await checkForUpdates('update me');
+    const content = JSON.parse(await fs.readFile(cachePath(), 'utf8'));
+    assert.deepStrictEqual(content, {version: VERSION});
+    assert.strictEqual(warnings.length, 0);
+    assert.strictEqual(spawnCalls.length, 1);
+    const call = spawnCalls[0];
+    assert.strictEqual(call.command, process.execPath);
+    assert.strictEqual(path.basename(call.args[0]), 'check-latest-version.js');
+    assert.strictEqual(call.args[1], cachePath());
+    assert.strictEqual(call.options.detached, true);
+    assert.strictEqual(call.options.stdio, 'ignore');
+  });
+
+  it('warns when the cached version is newer than the current version', async () => {
+    await writeCache(JSON.stringify({version: NEWER_VERSION}));
+    await checkForUpdates('Run npm update to get the latest version.');
+    assert.strictEqual(warnings.length, 1);
+    assert.ok(
+      warnings[0].includes(`Update available: ${VERSION} -> ${NEWER_VERSION}`),
+    );
+    assert.ok(
+      warnings[0].includes('Run npm update to get the latest version.'),
+    );
+  });
+
+  it('does not warn or re-check when the cache is fresh and not newer', async () => {
+    await writeCache(JSON.stringify({version: VERSION}));
+    await checkForUpdates('update me');
+    assert.strictEqual(warnings.length, 0);
+    assert.strictEqual(spawnCalls.length, 0);
+  });
+
+  it('does not re-check when the cache is fresh even if an update is available', async () => {
+    await writeCache(JSON.stringify({version: NEWER_VERSION}));
+    await checkForUpdates('update me');
+    assert.strictEqual(warnings.length, 1);
+    assert.strictEqual(spawnCalls.length, 0);
+    // The fresh cache is left untouched.
+    const content = JSON.parse(await fs.readFile(cachePath(), 'utf8'));
+    assert.deepStrictEqual(content, {version: NEWER_VERSION});
+  });
+
+  it('ignores a cache file that does not contain valid JSON', async () => {
+    await writeCache('not json');
+    await checkForUpdates('update me');
+    assert.strictEqual(warnings.length, 0);
+    // The file exists with a fresh mtime, so no new check is started.
+    assert.strictEqual(spawnCalls.length, 0);
+  });
+
+  it('re-checks and refreshes the mtime when the cache is older than 24 hours', async () => {
+    await writeCache(JSON.stringify({version: '0.0.0'}));
+    const yesterday = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    await fs.utimes(cachePath(), yesterday, yesterday);
+
+    await checkForUpdates('update me');
+
+    assert.strictEqual(warnings.length, 0);
+    assert.strictEqual(spawnCalls.length, 1);
+    const stats = await fs.stat(cachePath());
+    assert.ok(Date.now() - stats.mtimeMs < 60 * 1000);
+    // The stale cache content is preserved; only the mtime is bumped.
+    const content = JSON.parse(await fs.readFile(cachePath(), 'utf8'));
+    assert.deepStrictEqual(content, {version: '0.0.0'});
+  });
+
+  it('only checks once per process unless the flag is reset', async () => {
+    await writeCache(JSON.stringify({version: NEWER_VERSION}));
+    await checkForUpdates('update me');
+    assert.strictEqual(warnings.length, 1);
+
+    await checkForUpdates('update me');
+    assert.strictEqual(warnings.length, 1);
+
+    resetUpdateCheckFlagForTesting();
+    await checkForUpdates('update me');
+    assert.strictEqual(warnings.length, 2);
+  });
+});

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import type fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {after, before, describe, it} from 'node:test';
+
+import {debug} from '../../src/third_party/index.js';
+import {flushLogs, logger, saveLogsToFile} from '../../src/utils/logger.js';
+
+describe('logger', () => {
+  let savedNamespaces: string;
+  let originalLog: typeof debug.log;
+  let tmpDir: string;
+
+  before(async () => {
+    // Capture the globally enabled debug namespaces and the log sink so they
+    // can be restored after the suite (saveLogsToFile mutates both).
+    savedNamespaces = debug.disable();
+    debug.enable(savedNamespaces);
+    originalLog = debug.log;
+    tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'logger-test-'));
+  });
+
+  after(async () => {
+    debug.log = originalLog;
+    debug.disable();
+    if (savedNamespaces) {
+      debug.enable(savedNamespaces);
+    }
+    await fsPromises.rm(tmpDir, {recursive: true, force: true});
+  });
+
+  describe('saveLogsToFile', () => {
+    it('writes logger output to the given file', async () => {
+      const file = path.join(tmpDir, 'basic.log');
+      const stream = saveLogsToFile(file);
+      assert.ok(logger);
+      logger('hello world');
+      await flushLogs(stream);
+      const content = await fsPromises.readFile(file, 'utf8');
+      assert.ok(content.includes('mcp:log'));
+      assert.ok(content.includes('hello world'));
+      assert.ok(content.endsWith('\n'));
+    });
+
+    it('enables the mcp:log debug namespace', async () => {
+      debug.disable();
+      assert.strictEqual(debug.enabled('mcp:log'), false);
+      const stream = saveLogsToFile(path.join(tmpDir, 'namespace.log'));
+      assert.strictEqual(debug.enabled('mcp:log'), true);
+      await flushLogs(stream);
+    });
+
+    it('appends to an existing file instead of truncating it', async () => {
+      const file = path.join(tmpDir, 'append.log');
+      await fsPromises.writeFile(file, 'existing content\n');
+      const stream = saveLogsToFile(file);
+      assert.ok(logger);
+      logger('new entry');
+      await flushLogs(stream);
+      const content = await fsPromises.readFile(file, 'utf8');
+      assert.ok(content.startsWith('existing content\n'));
+      assert.ok(content.includes('new entry'));
+    });
+
+    it('writes one line per log call', async () => {
+      const file = path.join(tmpDir, 'lines.log');
+      const stream = saveLogsToFile(file);
+      assert.ok(logger);
+      logger('first entry');
+      logger('second entry');
+      await flushLogs(stream);
+      const content = await fsPromises.readFile(file, 'utf8');
+      const lines = content.split('\n').filter(line => line.length > 0);
+      assert.strictEqual(lines.length, 2);
+      assert.ok(lines[0].includes('first entry'));
+      assert.ok(lines[1].includes('second entry'));
+    });
+  });
+
+  describe('flushLogs', () => {
+    it('resolves once the stream has finished', async () => {
+      const file = path.join(tmpDir, 'flush.log');
+      const stream = saveLogsToFile(file);
+      assert.ok(logger);
+      logger('flushed');
+      await flushLogs(stream);
+      assert.strictEqual(stream.writableFinished, true);
+    });
+
+    it('rejects when the stream does not finish within the timeout', async () => {
+      const neverFinishing = {
+        end() {
+          // Never invokes the callback.
+        },
+      } as unknown as fs.WriteStream;
+      let rejected = false;
+      try {
+        await flushLogs(neverFinishing, 10);
+      } catch {
+        rejected = true;
+      }
+      assert.strictEqual(rejected, true);
+    });
+  });
+});


### PR DESCRIPTION
## Why

`src/utils/logger.ts` and `src/utils/check-for-updates.ts` had no unit test coverage in `tests/utils/`. Both contain observable behavior (file log sink, namespace enabling, flush timeout, update cache freshness/once-per-process logic) that can regress silently, so this adds focused tests asserting the current behavior. No `src/` changes.

## What's covered

**`tests/utils/logger.test.ts` (6 tests)**
- `saveLogsToFile` writes `mcp:log` output to the given file, appends (flag `a+`) instead of truncating, writes one newline-terminated line per log call, and enables the `mcp:log` debug namespace even when previously disabled.
- `flushLogs` resolves once the stream has finished, and rejects when the stream does not finish within the timeout (via a stub stream whose `end` callback never fires).
- Global `debug` state (enabled namespaces, `debug.log` sink) is saved and restored around the suite.

**`tests/utils/check-for-updates.test.ts` (8 tests)**
- Early return when `CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS` is set (the test runner sets this globally, so the tests save/clear/restore it).
- First run with no cache: writes `{version: VERSION}` to `~/.cache/chrome-devtools-mcp/latest.json` and spawns `check-latest-version.js` detached with `stdio: 'ignore'`.
- Warns with `Update available: <current> -> <cached>` plus the caller-provided message when the cached version is newer; no warning when equal.
- Fresh cache (<24h): no re-check spawn, cache untouched. Stale cache (>24h): re-check spawn, mtime refreshed, content preserved.
- Invalid-JSON cache is ignored without throwing.
- Once-per-process guard, including `resetUpdateCheckFlagForTesting()`.
- Tests redirect `os.homedir()` to a per-test temp dir and stub `child_process.spawn`/`console.warn` via `node:test`'s `mock.method`, so no real home-directory files are touched and no subprocess/network activity happens.

## What's not covered (and why)

- `saveLogsToFile`'s stream `error` handler calls `process.exit(1)`, which cannot be exercised in-process without killing the test runner.
- The spawned `bin/check-latest-version.js` subprocess itself (registry fetch) is out of scope for these unit tests; `spawn` is stubbed.
- Observation (not asserted, no behavior change made): while logs are redirected to a file, `debug.log` is replaced with a plain `chunks.join(' ')` sink, so printf-style placeholders (e.g. `logger('hello %s', 'world')`) are written literally as `hello %s world` instead of being substituted the way the default `util.formatWithOptions`-based sink does. The tests use plain messages to assert current behavior; happy to file a follow-up issue if that quirk is worth fixing.

## Testing

- `npm run build` — clean.
- `node scripts/test.js tests/utils/logger.test.ts tests/utils/check-for-updates.test.ts` — 14/14 pass.
- `npm run test:no-build` — 702 tests, 702 pass, 0 fail.
- `npm run check-format` — eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)