### PR TITLE
test: cover symbolized error message extraction

### DIFF
--- a/tests/devtools/DevtoolsUtils.test.ts
+++ b/tests/devtools/DevtoolsUtils.test.ts
@@ -9,8 +9,12 @@ import {afterEach, describe, it} from 'node:test';
 
 import sinon from 'sinon';
 
-import {createTargetUniverse} from '../../src/devtools/DevtoolsUtils.js';
+import {
+  createTargetUniverse,
+  SymbolizedError,
+} from '../../src/devtools/DevtoolsUtils.js';
 import {DevTools} from '../../src/third_party/index.js';
+import type {Protocol} from '../../src/third_party/index.js';
 import {serverHooks} from '../server.js';
 import {html, withBrowser} from '../utils.js';
 
@@ -73,6 +77,223 @@ describe('createTargetUniverse', () => {
       await page.goto(server.getRoute('/test'));
 
       sinon.assert.notCalled(requestStartedSpy);
+    });
+  });
+});
+
+describe('SymbolizedError', () => {
+  function exceptionDetails(
+    overrides: Partial<Protocol.Runtime.ExceptionDetails> = {},
+  ): Protocol.Runtime.ExceptionDetails {
+    return {
+      exceptionId: 1,
+      text: 'Uncaught',
+      lineNumber: 0,
+      columnNumber: 0,
+      ...overrides,
+    };
+  }
+
+  describe('fromDetails', () => {
+    it('extracts the message from the exception description', async () => {
+      const error = await SymbolizedError.fromDetails({
+        details: exceptionDetails({
+          exception: {
+            type: 'object',
+            subtype: 'error',
+            className: 'Error',
+            description:
+              'Error: Something went wrong\n    at foo (http://example.com/app.js:10:15)\n    at http://example.com/app.js:20:3',
+          },
+        }),
+        targetId: '',
+      });
+
+      assert.strictEqual(error.message, 'Uncaught Error: Something went wrong');
+      assert.strictEqual(error.stackTrace, undefined);
+      assert.strictEqual(error.cause, undefined);
+    });
+
+    it('keeps the full description when it has no stack frames', async () => {
+      const error = await SymbolizedError.fromDetails({
+        details: exceptionDetails({
+          exception: {
+            type: 'object',
+            subtype: 'error',
+            className: 'Error',
+            description: 'Error: no frames here',
+          },
+        }),
+        targetId: '',
+      });
+
+      assert.strictEqual(error.message, 'Uncaught Error: no frames here');
+    });
+
+    it('keeps multi-line messages up to the first stack frame', async () => {
+      const error = await SymbolizedError.fromDetails({
+        details: exceptionDetails({
+          exception: {
+            type: 'object',
+            subtype: 'error',
+            className: 'Error',
+            description:
+              'Error: first line\nsecond line\n    at foo (http://example.com/app.js:1:1)',
+          },
+        }),
+        targetId: '',
+      });
+
+      assert.strictEqual(
+        error.message,
+        'Uncaught Error: first line\nsecond line',
+      );
+    });
+
+    it('uses an empty exception message when the exception only has a value', async () => {
+      // A thrown primitive (e.g. `throw 'oops'`) has no description.
+      const error = await SymbolizedError.fromDetails({
+        details: exceptionDetails({
+          exception: {
+            type: 'string',
+            value: 'oops',
+          },
+        }),
+        targetId: '',
+      });
+
+      assert.strictEqual(error.message, 'Uncaught ');
+    });
+
+    it('uses the details text verbatim when there is no exception object', async () => {
+      const error = await SymbolizedError.fromDetails({
+        details: exceptionDetails(),
+        targetId: '',
+      });
+
+      assert.strictEqual(error.message, 'Uncaught');
+    });
+
+    it('uses the details text verbatim when it is not "Uncaught"', async () => {
+      // Runtime.getExceptionDetails puts the Error.message into `text`.
+      const error = await SymbolizedError.fromDetails({
+        details: exceptionDetails({
+          text: 'Error: boom',
+          exception: {
+            type: 'object',
+            subtype: 'error',
+            className: 'Error',
+            description: 'Error: a different description',
+          },
+        }),
+        targetId: '',
+      });
+
+      assert.strictEqual(error.message, 'Error: boom');
+    });
+
+    it('ignores url, line, column and raw stack trace for the message', async () => {
+      const error = await SymbolizedError.fromDetails({
+        details: exceptionDetails({
+          scriptId: '42',
+          url: 'http://example.com/app.js',
+          lineNumber: 42,
+          columnNumber: 7,
+          stackTrace: {
+            callFrames: [
+              {
+                functionName: 'foo',
+                scriptId: '42',
+                url: 'http://example.com/app.js',
+                lineNumber: 42,
+                columnNumber: 7,
+              },
+            ],
+          },
+          exception: {
+            type: 'object',
+            subtype: 'error',
+            className: 'Error',
+            description:
+              'Error: with locations\n    at foo (http://example.com/app.js:43:8)',
+          },
+        }),
+        targetId: '',
+        includeStackAndCause: true,
+      });
+
+      assert.strictEqual(error.message, 'Uncaught Error: with locations');
+      // Without a DevTools universe the raw stack trace cannot be resolved.
+      assert.strictEqual(error.stackTrace, undefined);
+    });
+
+    it('retains the resolved stack trace and cause provided for testing', async () => {
+      const stackTrace = {} as DevTools.StackTrace.StackTrace.StackTrace;
+      const cause = SymbolizedError.createForTesting('cause message');
+
+      const error = await SymbolizedError.fromDetails({
+        details: exceptionDetails({
+          exception: {
+            type: 'object',
+            subtype: 'error',
+            className: 'Error',
+            description: 'Error: effect',
+          },
+        }),
+        targetId: '',
+        resolvedStackTraceForTesting: stackTrace,
+        resolvedCauseForTesting: cause,
+      });
+
+      assert.strictEqual(error.message, 'Uncaught Error: effect');
+      assert.strictEqual(error.stackTrace, stackTrace);
+      assert.strictEqual(error.cause, cause);
+      assert.strictEqual(error.cause?.message, 'cause message');
+    });
+  });
+
+  describe('fromError', () => {
+    it('extracts the message from the error description', async () => {
+      const error = await SymbolizedError.fromError({
+        error: {
+          type: 'object',
+          subtype: 'error',
+          className: 'TypeError',
+          description:
+            'TypeError: x is not a function\n    at bar (http://example.com/b.js:5:3)',
+        },
+        targetId: '',
+      });
+
+      assert.strictEqual(error.message, 'TypeError: x is not a function');
+      assert.strictEqual(error.stackTrace, undefined);
+      assert.strictEqual(error.cause, undefined);
+    });
+
+    it('uses the full description when there are no stack frames', async () => {
+      const error = await SymbolizedError.fromError({
+        error: {
+          type: 'object',
+          subtype: 'error',
+          className: 'TypeError',
+          description: 'TypeError: nope',
+        },
+        targetId: '',
+      });
+
+      assert.strictEqual(error.message, 'TypeError: nope');
+    });
+
+    it('falls back to an empty message without a description', async () => {
+      const error = await SymbolizedError.fromError({
+        error: {
+          type: 'string',
+          value: 'oops',
+        },
+        targetId: '',
+      });
+
+      assert.strictEqual(error.message, '');
     });
   });
 });


### PR DESCRIPTION
## Why

`SymbolizedError.fromDetails`/`fromError` in `src/devtools/DevtoolsUtils.ts` implement the message-extraction rules used to surface page exceptions to agent users, but were only exercised indirectly through one browser-based test. This adds direct coverage of the extraction permutations (222 added lines, tests only — no `src/` changes).

## Coverage

- `fromDetails`: message taken from the exception description up to the first stack frame; full description kept when it has no frames; multi-line messages preserved; exception with only a value → empty message; no exception object → details text used verbatim (including non-"Uncaught" text); url/line/column/raw stack trace ignored for the message; resolved stack trace and cause retained
- `fromError`: message from the error description; full description without frames; empty-message fallback when no description exists

## Testing

- `node scripts/test.js tests/devtools/DevtoolsUtils.test.ts` → pass (exit 0)
- `npm run test:no-build` → full suite pass (exit 0)
- `npm run check-format` → eslint + prettier clean