### PR TITLE
fix: reject unknown MCP server options

### DIFF
--- a/src/bin/chrome-devtools-mcp-cli-options.ts
+++ b/src/bin/chrome-devtools-mcp-cli-options.ts
@@ -381,9 +381,23 @@ export function parseArguments(
   argv = process.argv,
   env = process.env,
 ) {
+  // Preserve yargs' mixed camel/kebab-case expansion under strict validation.
+  const kebabCaseAliases: Record<string, string> = {};
+  for (const option of Object.keys(cliOptions)) {
+    const alias = option.replace(
+      /[A-Z]/g,
+      letter => `-${letter.toLowerCase()}`,
+    );
+    if (alias !== option) {
+      kebabCaseAliases[option] = alias;
+    }
+  }
+
   const yargsInstance = yargs(hideBin(argv))
     .scriptName('npx chrome-devtools-mcp@latest')
     .options(cliOptions)
+    .alias(kebabCaseAliases)
+    .strictOptions()
     .middleware(args => {
       // We can't set default in the options else
       // Yargs will complain

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,6 +5,7 @@
  */
 
 import assert from 'node:assert';
+import {spawnSync} from 'node:child_process';
 import {describe, it} from 'node:test';
 
 import {parseArguments} from '../src/bin/chrome-devtools-mcp-cli-options.js';
@@ -59,6 +60,35 @@ describe('cli args parsing', () => {
       browserUrl: 'http://localhost:3000',
       u: 'http://localhost:3000',
     });
+  });
+
+  it('rejects unknown options', async () => {
+    const moduleUrl = new URL(
+      '../src/bin/chrome-devtools-mcp-cli-options.js',
+      import.meta.url,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `import {parseArguments} from ${JSON.stringify(moduleUrl.href)}; parseArguments('1.0.0', ['node', 'main.js', '--browserURL', 'http://localhost:3000'], {});`,
+      ],
+      {encoding: 'utf8'},
+    );
+
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /Unknown argument: browserURL/);
+  });
+
+  it('parses mixed-form option names', async () => {
+    const args = parseArguments(
+      '1.0.0',
+      ['node', 'main.js', '--category-experimentalWebmcp'],
+      {},
+    );
+
+    assert.strictEqual(args.categoryExperimentalWebmcp, true);
   });
 
   it('parses with user data dir', async () => {


### PR DESCRIPTION
## Summary

- reject unknown MCP server options instead of silently ignoring them
- preserve accepted mixed camel/kebab option forms by registering aliases before strict validation

## Testing

- `npm run test -- tests/cli.test.ts`
- `npm run test`
- `npm run check-format`

Fixes #2530

AI assistance: This change was implemented and verified with OpenAI Codex.

BEGIN_COMMIT_OVERRIDE
chore: reject unknown MCP server options