### PR TITLE
test: use 127.0.0.1 to avoid host resolution

### DIFF
--- a/tests/server.ts
+++ b/tests/server.ts
@@ -38,7 +38,7 @@ export class TestServer {
   }
 
   get baseUrl(): string {
-    return `http://localhost:${this.#port}`;
+    return `http://127.0.0.1:${this.#port}`;
   }
 
   getRoute(path: string) {

--- a/tests/tools/console.test.js.snapshot
+++ b/tests/tools/console.test.js.snapshot
@@ -123,7 +123,7 @@ Note that if an opaque response is sufficient, the request’s mode can be set t
 Learn more:
 [Cross-Origin Resource Sharing (CORS)](https://web.dev/cross-origin-resource-sharing)
 ### Affected resources
-reqid=<reqid> data={"corsErrorStatus":{"corsError":"PreflightMissingAllowOriginHeader","failedParameter":""},"isWarning":false,"request":{"url":"http://hostname:port/data.json"},"initiatorOrigin":"","clientSecurityState":{"initiatorIsSecureContext":false,"initiatorIPAddressSpace":"Loopback","localNetworkAccessRequestPolicy":"BlockFromInsecureToMorePrivate"}}
+reqid=<reqid> data={"corsErrorStatus":{"corsError":"PreflightMissingAllowOriginHeader","failedParameter":""},"isWarning":false,"request":{"url":"http://127.0.0.1:<port>/data.json"},"initiatorOrigin":"","clientSecurityState":{"initiatorIsSecureContext":false,"initiatorIPAddressSpace":"Loopback","localNetworkAccessRequestPolicy":"BlockFromInsecureToMorePrivate"}}
 `;
 
 exports[`console > get_console_message > when dialog is open 1`] = `

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -29,6 +29,7 @@ import {
   extractExtensionId,
   assertNoServiceWorkerReported,
   waitExecutionFor,
+  stabilizeResponseOutput,
 } from '../utils.js';
 
 const EXTENSION_LOGGING_PATH = path.join(
@@ -478,11 +479,13 @@ describe('console', () => {
           );
           const formattedResponse = await response2.handle(context);
           const rawText = getTextContent(formattedResponse.content[0]);
-          const sanitizedText = rawText
-            .replaceAll(/ID: \d+/g, 'ID: <ID>')
-            .replaceAll(/reqid=\d+/g, 'reqid=<reqid>')
-            .replaceAll(/localhost:\d+/g, 'hostname:port');
-          t.assert.snapshot(sanitizedText);
+          t.assert.snapshot(
+            stabilizeResponseOutput(
+              rawText
+                .replaceAll(/ID: \d+/g, 'ID: <ID>')
+                .replaceAll(/reqid=\d+/g, 'reqid=<reqid>'),
+            ),
+          );
         });
       });
     });

--- a/tests/tools/network.test.js.snapshot
+++ b/tests/tools/network.test.js.snapshot
@@ -1,5 +1,5 @@
 exports[`network > network_get_request > should get request from previous navigations 1`] = `
-## Request http://localhost:<port>/one
+## Request http://127.0.0.1:<port>/one
 Status: 200
 ### Request Headers
 - accept-language:<lang>
@@ -11,7 +11,7 @@ Status: 200
 - accept:text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
 - accept-encoding:gzip, deflate, br, zstd
 - connection:keep-alive
-- host:localhost:<port>
+- host:127.0.0.1:<port>
 - sec-fetch-dest:<redacted>
 - sec-fetch-mode:<redacted>
 - sec-fetch-site:<redacted>
@@ -29,21 +29,21 @@ Status: 200
 exports[`network > network_list_requests > list requests form current navigations only 1`] = `
 ## Network requests
 Showing 1-1 of 1 (Page 1 of 1).
-reqid=3 GET http://localhost:<port>/three [200]
+reqid=3 GET http://127.0.0.1:<port>/three [200]
 `;
 
 exports[`network > network_list_requests > list requests from previous navigations 1`] = `
 ## Network requests
 Showing 1-3 of 3 (Page 1 of 1).
-reqid=1 GET http://localhost:<port>/one [200]
-reqid=2 GET http://localhost:<port>/two [200]
-reqid=3 GET http://localhost:<port>/three [200]
+reqid=1 GET http://127.0.0.1:<port>/one [200]
+reqid=2 GET http://127.0.0.1:<port>/two [200]
+reqid=3 GET http://127.0.0.1:<port>/three [200]
 `;
 
 exports[`network > network_list_requests > list requests from previous navigations from redirects 1`] = `
 ## Network requests
 Showing 1-3 of 3 (Page 1 of 1).
-reqid=1 GET http://localhost:<port>/redirect [302]
-reqid=2 GET http://localhost:<port>/redirected [200]
-reqid=3 GET http://localhost:<port>/redirected-page [200]
+reqid=1 GET http://127.0.0.1:<port>/redirect [302]
+reqid=2 GET http://127.0.0.1:<port>/redirected [200]
+reqid=3 GET http://127.0.0.1:<port>/redirected-page [200]
 `;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -331,6 +331,9 @@ export function stabilizeResponseOutput(text: unknown) {
   const localhostRegEx = /localhost:\d{5}/g;
   output = output.replaceAll(localhostRegEx, 'localhost:<port>');
 
+  const loopbackAddress = /127.0.0.1:\d{5}/g;
+  output = output.replaceAll(loopbackAddress, '127.0.0.1:<port>');
+
   const userAgentRegEx = /user-agent:.*\n/g;
   output = output.replaceAll(userAgentRegEx, 'user-agent:<user-agent>\n');
 


### PR DESCRIPTION
Attempt to fix flakiness in e2e tests that could be potentially caused by a host lookup that resolves to an IPV6 address.