### PR TITLE
fix: ensure debugger statements are skipped by devtools

### DIFF
--- a/src/devtools/DevtoolsUtils.ts
+++ b/src/devtools/DevtoolsUtils.ts
@@ -155,12 +155,16 @@ export async function createTargetUniverse(
   );
   setting.set(true);
 
+  const skipAllPausesSetting = universe.settings.resolve(
+    DevTools.skipAllPausesSettingDescriptor,
+  );
+  skipAllPausesSetting.set(true);
+
   // @ts-expect-error devtools-frontend has diffrent types.
   const connection = new DevTools.PuppeteerDevToolsConnection(session);
 
   const targetManager = universe.context.get(DevTools.TargetManager);
 
-  targetManager.observeModels(DevTools.DebuggerModel, SKIP_ALL_PAUSES);
   targetManager.observeModels(
     DevTools.NetworkManager.NetworkManager,
     DISABLE_NETWORK,
@@ -175,23 +179,9 @@ export async function createTargetUniverse(
     undefined,
     connection,
   );
+
   return {target, universe, session};
 }
-
-// We don't want to pause any DevTools universe session ever on the MCP side.
-//
-// Note that calling `setSkipAllPauses` only affects the session on which it was
-// sent. This means DevTools can still pause, step and do whatever. We just won't
-// see the `Debugger.paused`/`Debugger.resumed` events on the MCP side.
-const SKIP_ALL_PAUSES = {
-  modelAdded(model: DevTools.DebuggerModel): void {
-    void model.agent.invoke_setSkipAllPauses({skip: true});
-  },
-
-  modelRemoved(): void {
-    // Do nothing.
-  },
-};
 
 // Not recording network requests in the DevTools universe.
 //

--- a/tests/devtools/DevtoolsUtils.test.ts
+++ b/tests/devtools/DevtoolsUtils.test.ts
@@ -54,6 +54,27 @@ describe('createTargetUniverse', () => {
     });
   });
 
+  it('ignores pauses during navigation', async () => {
+    server.addHtmlRoute(
+      '/debugger',
+      html`<script>
+          debugger;
+        </script>
+        <h1>Loaded</h1>`,
+    );
+
+    await withBrowser(async (browser, page) => {
+      const targetUniverse = await createTargetUniverse(
+        await page.createCDPSession(),
+      );
+      assert.ok(targetUniverse);
+
+      await page.goto(server.getRoute('/debugger'));
+      const text = await page.$eval('h1', el => el.textContent);
+      assert.strictEqual(text, 'Loaded');
+    });
+  });
+
   it('disables network domain', async () => {
     server.addHtmlRoute('/test', html`<div>Test</div>`);
 


### PR DESCRIPTION
Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/2539