### PR TITLE
Fix arbitrary file write via dangling symlink escaping workspace root

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -15,50 +15,105 @@ export async function getTempFilePath(filename: string) {
   return filepath;
 }
 
-export async function resolveCanonicalPath(filePath: string): Promise<string> {
+export async function resolveCanonicalPath(
+  filePath: string,
+  visited: Set<string> = new Set(),
+): Promise<string> {
   const absolutePath = path.resolve(filePath);
+
+  // Guard against symlink cycles (A -> B -> A) causing infinite recursion.
+  if (visited.has(absolutePath)) {
+    throw new Error(
+      `Symlink cycle detected while resolving canonical path for: ${filePath}`,
+    );
+  }
+
   try {
     // Get the true canonical path, resolving all symlinks.
     return await fs.realpath(absolutePath);
   } catch (err) {
     if (
-      err &&
-      typeof err === 'object' &&
-      'code' in err &&
-      err.code === 'ENOENT'
+      !(
+        err &&
+        typeof err === 'object' &&
+        'code' in err &&
+        err.code === 'ENOENT'
+      )
     ) {
-      // Find the nearest existing ancestor directory on the filesystem.
-      let current = absolutePath;
-      const missingSegments: string[] = [];
-      while (true) {
-        const parent = path.dirname(current);
-        if (parent === current) {
-          // Reached root directory but still couldn't resolve anything.
-          throw err;
-        }
-        try {
-          const canonicalParent = await fs.realpath(parent);
-          return path.join(
-            canonicalParent,
-            path.basename(current),
-            ...missingSegments,
+      throw err;
+    }
+
+    // The path doesn't fully resolve via realpath. This can happen for two
+    // different reasons that must be handled differently:
+    //   (a) The path simply doesn't exist yet (e.g. a new output file that
+    //       is about to be created) - in this case, falling back to the
+    //       nearest existing ancestor directory + the requested basename is
+    //       correct.
+    //   (b) The path (or an ancestor of it) IS an existing symlink, but its
+    //       target doesn't exist (a "dangling" symlink) - in this case we
+    //       must resolve to where the symlink actually points, recursively.
+    //       Otherwise, a dangling symlink placed inside an allowed root
+    //       that points *outside* of it would be silently treated as if it
+    //       were a plain new file inside the root, defeating root-based
+    //       path validation.
+    let current = absolutePath;
+    const missingSegments: string[] = [];
+    while (true) {
+      try {
+        const lstat = await fs.lstat(current);
+        if (lstat.isSymbolicLink()) {
+          const linkTarget = await fs.readlink(current);
+          const resolvedTarget = path.isAbsolute(linkTarget)
+            ? linkTarget
+            : path.resolve(path.dirname(current), linkTarget);
+          const nextVisited = new Set(visited);
+          nextVisited.add(absolutePath);
+          const canonicalTarget = await resolveCanonicalPath(
+            resolvedTarget,
+            nextVisited,
           );
-        } catch (parentErr) {
-          if (
-            parentErr &&
-            typeof parentErr === 'object' &&
-            'code' in parentErr &&
-            parentErr.code === 'ENOENT'
-          ) {
-            missingSegments.unshift(path.basename(current));
-            current = parent;
-          } else {
-            throw parentErr;
-          }
+          return path.join(canonicalTarget, ...missingSegments);
+        }
+      } catch (lstatErr) {
+        if (
+          !(
+            lstatErr &&
+            typeof lstatErr === 'object' &&
+            'code' in lstatErr &&
+            lstatErr.code === 'ENOENT'
+          )
+        ) {
+          throw lstatErr;
+        }
+        // `current` doesn't exist at all (not even as a dangling symlink) -
+        // fall through to the ancestor walk below.
+      }
+
+      const parent = path.dirname(current);
+      if (parent === current) {
+        // Reached root directory but still couldn't resolve anything.
+        throw err;
+      }
+      try {
+        const canonicalParent = await fs.realpath(parent);
+        return path.join(
+          canonicalParent,
+          path.basename(current),
+          ...missingSegments,
+        );
+      } catch (parentErr) {
+        if (
+          parentErr &&
+          typeof parentErr === 'object' &&
+          'code' in parentErr &&
+          parentErr.code === 'ENOENT'
+        ) {
+          missingSegments.unshift(path.basename(current));
+          current = parent;
+        } else {
+          throw parentErr;
         }
       }
-    } else {
-      throw err;
     }
   }
 }

--- a/tests/roots.test.ts
+++ b/tests/roots.test.ts
@@ -5,6 +5,7 @@
  */
 
 import assert from 'node:assert';
+import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -150,6 +151,52 @@ describe('McpContext Roots', () => {
         );
       } finally {
         await fs.rm(workspacePath, {recursive: true, force: true});
+      }
+    });
+  });
+
+  it('should deny a dangling symlink inside the root that points outside of it', async () => {
+    // Regression test for an arbitrary-file-write bypass: a workspace
+    // (e.g. an untrusted repository checked out for automated browser
+    // testing) can contain a dangling symlink whose target does not yet
+    // exist and points outside the configured root. Tools such as
+    // heap-snapshot capture and screencast recording delegate their actual
+    // file writes to third-party code (Puppeteer/ffmpeg) that follows
+    // symlinks with no O_NOFOLLOW protection, so validatePath /
+    // ensureExtension must reject such a path based on where the symlink
+    // actually resolves to, not where the symlink itself sits.
+    await withMcpContext(async (_response, context) => {
+      const workspacePath = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'workspace-root-'),
+      );
+      const outsideTarget = path.resolve(
+        os.homedir(),
+        `outside-target-${crypto.randomUUID()}`,
+      );
+      try {
+        context.setRoots([
+          {uri: pathToFileURL(workspacePath).href, name: 'workspace'},
+        ]);
+
+        await fs.rm(outsideTarget, {force: true});
+        const danglingLink = path.join(workspacePath, 'snapshot.heapsnapshot');
+        await fs.symlink(outsideTarget, danglingLink);
+
+        await assert.rejects(
+          context.validatePath(danglingLink),
+          /Access denied/,
+        );
+        await assert.rejects(
+          context.ensureExtension(danglingLink, '.heapsnapshot'),
+          /Access denied/,
+        );
+
+        // The outside target must never actually get created by this
+        // rejected validation.
+        await assert.rejects(fs.access(outsideTarget));
+      } finally {
+        await fs.rm(workspacePath, {recursive: true, force: true});
+        await fs.rm(outsideTarget, {force: true});
       }
     });
   });

--- a/tests/utils/files.test.ts
+++ b/tests/utils/files.test.ts
@@ -5,6 +5,7 @@
  */
 
 import assert from 'node:assert';
+import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -88,6 +89,80 @@ describe('resolveCanonicalPath', () => {
       const resolved = await resolveCanonicalPath(filePathWithSymlink);
       const canonicalTargetDir = await fs.realpath(targetDir);
       assert.strictEqual(resolved, path.join(canonicalTargetDir, 'file.txt'));
+    } finally {
+      await fs.rm(tmpDir, {recursive: true, force: true});
+    }
+  });
+
+  it('should resolve a dangling symlink to its actual (non-existent) target, not its own location', async () => {
+    // Regression test: previously, a dangling symlink (one whose target
+    // does not exist) was indistinguishable from a plain non-existent
+    // path, and resolveCanonicalPath would incorrectly return the
+    // symlink's *own* location instead of following it to where it
+    // actually points. This meant a dangling symlink placed inside an
+    // allowed root, pointing outside of it, would be treated by
+    // validatePath as if it were safely inside the root - allowing a
+    // subsequent write (e.g. a heap snapshot or screencast, whose actual
+    // file I/O is performed by third-party code that follows symlinks)
+    // to escape the sandboxed root entirely.
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'resolve-canonical-test-'),
+    );
+    const outsideTarget = path.join(
+      os.tmpdir(),
+      `dangling-target-${crypto.randomUUID()}.txt`,
+    );
+    try {
+      await fs.rm(outsideTarget, {force: true});
+      const linkPath = path.join(tmpDir, 'dangling-link.txt');
+      await fs.symlink(outsideTarget, linkPath);
+
+      const resolved = await resolveCanonicalPath(linkPath);
+      assert.strictEqual(resolved, outsideTarget);
+      assert.ok(
+        !resolved.startsWith(tmpDir),
+        `expected resolved path to be outside ${tmpDir}, got ${resolved}`,
+      );
+    } finally {
+      await fs.rm(tmpDir, {recursive: true, force: true});
+      await fs.rm(outsideTarget, {force: true});
+    }
+  });
+
+  it('should resolve a chained dangling symlink to its ultimate target', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'resolve-canonical-test-'),
+    );
+    const outsideTarget = path.join(
+      os.tmpdir(),
+      `chain-target-${crypto.randomUUID()}.txt`,
+    );
+    try {
+      await fs.rm(outsideTarget, {force: true});
+      const linkB = path.join(tmpDir, 'chain-b');
+      await fs.symlink(outsideTarget, linkB);
+      const linkA = path.join(tmpDir, 'chain-a');
+      await fs.symlink(linkB, linkA);
+
+      const resolved = await resolveCanonicalPath(linkA);
+      assert.strictEqual(resolved, outsideTarget);
+    } finally {
+      await fs.rm(tmpDir, {recursive: true, force: true});
+      await fs.rm(outsideTarget, {force: true});
+    }
+  });
+
+  it('should throw on a symlink cycle instead of looping forever', async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'resolve-canonical-test-'),
+    );
+    try {
+      const a = path.join(tmpDir, 'cycle-a');
+      const b = path.join(tmpDir, 'cycle-b');
+      await fs.symlink(b, a);
+      await fs.symlink(a, b);
+
+      await assert.rejects(resolveCanonicalPath(a));
     } finally {
       await fs.rm(tmpDir, {recursive: true, force: true});
     }


### PR DESCRIPTION
## Summary
`resolveCanonicalPath()` treated a dangling symlink (target does not exist) the same as a plain non-existent path - it fell back to the nearest existing ancestor + the symlink's own basename, instead of resolving to where the symlink actually points.

## Impact
A dangling symlink placed inside an allowed workspace root, pointing outside of it, was treated by `validatePath()`/`ensureExtension()` as safely inside the root. `takeHeapSnapshot` (Puppeteer's `captureHeapSnapshot`, which uses plain `fs.createWriteStream` with no `O_NOFOLLOW`) and `startScreencast` (spawns `ffmpeg`, which also follows symlinks by default) would then write their output through the symlink to the attacker-chosen location outside the sandboxed root - e.g. a malicious/untrusted repository checked out for automated browser testing could contain a symlink like `snapshot.heapsnapshot -> ~/.ssh/authorized_keys` and have a routine heap-snapshot tool call overwrite it.

This is the same bug class already fixed for the screenshot path in #2269 (which added `O_NOFOLLOW` to the internal `#writeFile` helper) - heap snapshots and screencasts don't go through that helper, since their actual file I/O is delegated to Puppeteer-core/ffmpeg.

## Fix
`resolveCanonicalPath` now detects when the unresolvable path (or an ancestor of it) is itself a symlink, and recursively resolves to its actual target (handling chained symlinks), with cycle detection to prevent infinite recursion on a symlink loop.

## Testing
- Added unit tests in `tests/utils/files.test.ts`: dangling symlink resolves to its real outside target, chained dangling symlinks resolve to the ultimate target, symlink cycles throw instead of hanging.
- Added an end-to-end test in `tests/roots.test.ts` confirming `validatePath`/`ensureExtension` reject a dangling symlink pointing outside the root, and that the outside target is never created.
- All tests, including the Chrome-dependent `roots.test.ts` suite, were run and passed locally with a real Chrome install.
- Confirmed via revert-and-retest that the new tests correctly fail against the unfixed code (not tautological).