### PR TITLE
chore: remove imported panel code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,7 +76,6 @@
     "third_party/devtools-frontend/front_end/services/tracing",
     "third_party/devtools-frontend/front_end/models/workspace",
     "third_party/devtools-frontend/front_end/models/workspace_diff",
-    "third_party/devtools-frontend/front_end/panels/issues/IssueAggregator.ts",
     "third_party/devtools-frontend/front_end/third_party/acorn",
     "third_party/devtools-frontend/front_end/third_party/codemirror",
     "third_party/devtools-frontend/front_end/third_party/diff",


### PR DESCRIPTION
This was added long time ago, and now the code is correctly moved into the models/