### PR TITLE
refactor(performance): use default trace categories from DevTools

### DIFF
--- a/src/tools/performance.ts
+++ b/src/tools/performance.ts
@@ -70,25 +70,12 @@ export const startTrace = definePageTool({
         });
       }
 
-      // Keep in sync with the categories arrays in:
-      // https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/panels/timeline/TimelineController.ts
-      // https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/gather/gatherers/trace.js
       const categories = [
         '-*',
-        'blink.console',
-        'blink.user_timing',
-        'devtools.timeline',
-        'disabled-by-default-devtools.screenshot',
-        'disabled-by-default-devtools.timeline',
-        'disabled-by-default-devtools.timeline.frame',
-        'disabled-by-default-devtools.timeline.stack',
-        'disabled-by-default-v8.cpu_profiler',
-        'disabled-by-default-v8.cpu_profiler.hires',
-        'latencyInfo',
-        'loading',
-        'disabled-by-default-lighthouse',
-        'v8.execute',
-        'v8',
+        ...DevTools.TracingDefaultCategories,
+        // These categories are optional in DevTools, but enabled by default in the DevTools UI, so we enable them here too.
+        ...DevTools.TracingOptionalCategories.JsSampling,
+        ...DevTools.TracingOptionalCategories.Screenshot,
       ];
       await page.pptrPage.tracing.start({
         categories,

--- a/tests/tools/performance.test.ts
+++ b/tests/tools/performance.test.ts
@@ -20,6 +20,7 @@ import {
   type TraceResult,
   traceResultIsSuccess,
 } from '../../src/processors/PerformanceTrace.js';
+import {DevTools} from '../../src/third_party/index.js';
 import {loadTraceAsBuffer} from '../trace-processing/fixtures/load.js';
 import {withMcpContext} from '../utils.js';
 
@@ -59,6 +60,14 @@ describe('performance', () => {
           context,
         );
         sinon.assert.calledOnce(startTracingStub);
+        sinon.assert.calledWithExactly(startTracingStub, {
+          categories: [
+            '-*',
+            ...DevTools.TracingDefaultCategories,
+            ...DevTools.TracingOptionalCategories.JsSampling,
+            ...DevTools.TracingOptionalCategories.Screenshot,
+          ],
+        });
         assert.ok(context.isRunningPerformanceTrace());
         assert.ok(
           response.responseLines


### PR DESCRIPTION
Instead of maintaining a separate, manual list of tracing categories that can drift out of sync with DevTools, consume TracingDefaultCategories exposed by devtools-frontend.

Additionally include optional categories (JsSampling and Screenshot) enabled by default in the DevTools UI to retain JavaScript profiling samples and timeline screenshots.