### PR TITLE
fix: do not validate local files for remote browsers

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -169,7 +169,7 @@
 
 **Parameters:**
 
-- **filePaths** (array) **(required)**: One or more local paths of files to upload.
+- **filePaths** (array) **(required)**: One or more files paths to upload. File paths have to be local to the browser instance (not the MCP).
 - **uid** (string) **(required)**: The uid of the file input element or an element that will open file chooser on the page from the page content snapshot
 - **includeSnapshot** (boolean) _(optional)_: Whether to include a snapshot in the response. Default is false.
 

--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -156,19 +156,16 @@ function extractPaths(value: unknown): string[] {
     return [value];
   }
   if (Array.isArray(value)) {
-    return values.filter(item => typeof item === 'string');
+    return value.filter(item => typeof item === 'string');
   }
   return [];
 }
 
 function isLocalBrowser(context: McpContext): boolean {
-  if (!context.browser) {
-    return false;
-  }
-  if (context.browser.process?.()) {
+  if (context.browser.process()) {
     return true;
   }
-  const wsEndpoint = context.browser.wsEndpoint?.();
+  const wsEndpoint = context.browser.wsEndpoint();
   if (wsEndpoint && isLocalhost(wsEndpoint)) {
     return true;
   }

--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -196,9 +196,6 @@ async function validateToolFiles(
   params: Record<string, unknown>,
   context: McpContext,
 ): Promise<void> {
-  if (!tool.verifyFilesSchema) {
-    return;
-  }
   const isLocal = isLocalBrowser(context);
   const pathsOrUrlsToValidate: string[] = [];
   for (const [key, option] of Object.entries(tool.verifyFilesSchema)) {

--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -19,11 +19,14 @@ import {labels, OFF_BY_DEFAULT_CATEGORIES} from './tools/categories.js';
 import type {
   DefinedPageTool,
   DevToolsData,
+  FileVerificationOption,
   ToolDefinition,
 } from './tools/ToolDefinition.js';
 import {pageIdSchema} from './tools/ToolDefinition.js';
 import {logger} from './utils/logger.js';
 import type {Mutex} from './third_party/index.js';
+import {fileURLToPath} from 'node:url';
+import {isLocalhost} from './utils/url.js';
 
 export function buildFlag(category: ToolCategory) {
   return `category${category.charAt(0).toUpperCase() + category.slice(1)}`;
@@ -148,6 +151,83 @@ function buildUnknownArgumentsMessage(
   return `Unknown ${unknownLabel} for tool "${toolName}": ${formatArgumentNames(unknownArgumentNames)}. ${expectedArguments} ${correction} and retry.`;
 }
 
+function extractPaths(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    const paths: string[] = [];
+    for (const item of value) {
+      if (typeof item === 'string') {
+        paths.push(item);
+      }
+    }
+    return paths;
+  }
+  return [];
+}
+
+function isLocalBrowser(context: McpContext): boolean {
+  if (!context.browser) {
+    return false;
+  }
+  if (context.browser.process?.()) {
+    return true;
+  }
+  const wsEndpoint = context.browser.wsEndpoint?.();
+  if (wsEndpoint && isLocalhost(wsEndpoint)) {
+    return true;
+  }
+  return false;
+}
+
+function shouldValidateFile(
+  option: FileVerificationOption | undefined,
+  isLocal: boolean,
+): boolean {
+  if (option === true) {
+    return true;
+  }
+  if (typeof option === 'object' && option !== null) {
+    if (isLocal) {
+      return Boolean(option.local);
+    }
+    return Boolean(option.remote);
+  }
+  return false;
+}
+
+async function validateToolFiles(
+  tool: ToolDefinition | DefinedPageTool,
+  params: Record<string, unknown>,
+  context: McpContext,
+): Promise<void> {
+  if (!tool.verifyFilesSchema) {
+    return;
+  }
+  const isLocal = isLocalBrowser(context);
+  const pathsOrUrlsToValidate: string[] = [];
+  for (const [key, option] of Object.entries(tool.verifyFilesSchema)) {
+    if (shouldValidateFile(option, isLocal)) {
+      pathsOrUrlsToValidate.push(...extractPaths(params[key]));
+    }
+  }
+  for (const filePathOrUrl of pathsOrUrlsToValidate) {
+    let filePath = filePathOrUrl;
+    try {
+      const url = new URL(filePathOrUrl);
+      if (url.protocol === 'file:') {
+        filePath = fileURLToPath(url);
+      } else if (['http:', 'https:', 'ws:', 'wss:'].includes(url.protocol)) {
+        continue;
+      }
+    } catch {
+      // Suppress parsing errors for regular file paths.
+    }
+    await context.validatePath(filePath);
+  }
+}
+
 export class ToolHandler {
   readonly inputSchema: zod.ZodRawShape;
   readonly registeredInputSchema: zod.ZodTypeAny;
@@ -231,15 +311,7 @@ export class ToolHandler {
       }
       let page: McpPage | undefined;
       try {
-        if (this.tool.verifyFilesSchema) {
-          for (const key of this.tool.verifyFilesSchema) {
-            const filePath = params[key];
-            const paths = Array.isArray(filePath) ? filePath : [filePath];
-            for (const path of paths) {
-              await context.validatePath(path as string);
-            }
-          }
-        }
+        await validateToolFiles(this.tool, params, context);
         if (isPageScopedTool(this.tool)) {
           const pageId =
             typeof params.pageId === 'number' ? params.pageId : undefined;

--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -156,13 +156,7 @@ function extractPaths(value: unknown): string[] {
     return [value];
   }
   if (Array.isArray(value)) {
-    const paths: string[] = [];
-    for (const item of value) {
-      if (typeof item === 'string') {
-        paths.push(item);
-      }
-    }
-    return paths;
+    return values.filter(item => typeof item === 'string');
   }
   return [];
 }

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -1310,7 +1310,8 @@ export const commands: Commands = {
       filePaths: {
         name: 'filePaths',
         type: 'array',
-        description: 'One or more local paths of files to upload.',
+        description:
+          'One or more files paths to upload. File paths have to be local to the browser instance (not the MCP).',
         required: true,
       },
       includeSnapshot: {

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -44,6 +44,13 @@ import type {
 import type {ToolCategory} from './categories.js';
 import type {ToolGroups} from './thirdPartyDeveloper.js';
 
+export type FileVerificationOption =
+  | true
+  | {
+      local?: boolean;
+      remote?: boolean;
+    };
+
 export interface BaseToolDefinition<
   Schema extends zod.ZodRawShape = zod.ZodRawShape,
 > {
@@ -60,7 +67,7 @@ export interface BaseToolDefinition<
   };
   schema: Schema;
   blockedByDialog: boolean;
-  verifyFilesSchema: Array<keyof Schema>;
+  verifyFilesSchema: Partial<Record<keyof Schema, FileVerificationOption>>;
 }
 
 export interface ToolDefinition<
@@ -203,7 +210,6 @@ export type SupportedExtensions =
  * Only add methods used by tools/*.
  */
 export type Context = Readonly<{
-  validatePath(filePath?: string): Promise<void>;
   installPWA(options: InstallPWAOptions): Promise<string>;
   uninstallPWA(options: UninstallPWAOptions): Promise<void>;
   launchPWA(options: LaunchPWAOptions): Promise<Page>;

--- a/src/tools/console.ts
+++ b/src/tools/console.ts
@@ -92,7 +92,7 @@ export const listConsoleMessages = definePageTool(cliArgs => {
         ),
     },
     blockedByDialog: false,
-    verifyFilesSchema: [],
+    verifyFilesSchema: {},
     handler: async (request, response) => {
       response.setIncludeConsoleData(true, {
         pageSize: request.params.pageSize,
@@ -121,7 +121,7 @@ export const getConsoleMessage = definePageTool({
       ),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     response.attachConsoleMessage(request.params.msgid);
   },

--- a/src/tools/emulation.ts
+++ b/src/tools/emulation.ts
@@ -100,7 +100,7 @@ export const emulate = definePageTool({
       ),
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const page = request.page;
     await page.emulate(request.params);

--- a/src/tools/extensions.ts
+++ b/src/tools/extensions.ts
@@ -22,7 +22,9 @@ export const installExtension = defineTool({
       .describe('Absolute path to the unpacked extension folder.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['path'],
+  verifyFilesSchema: {
+    path: true,
+  },
   handler: async (request, response, context) => {
     const {path} = request.params;
     const id = await context.installExtension(path);
@@ -41,7 +43,7 @@ export const uninstallExtension = defineTool({
     id: zod.string().describe('ID of the extension to uninstall.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const {id} = request.params;
     await context.uninstallExtension(id);
@@ -59,7 +61,7 @@ export const listExtensions = defineTool({
   },
   schema: {},
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (_request, response) => {
     response.setListExtensions();
   },
@@ -76,7 +78,7 @@ export const reloadExtension = defineTool({
     id: zod.string().describe('ID of the extension to reload.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const {id} = request.params;
     const extension = await context.getExtension(id);
@@ -99,7 +101,7 @@ export const triggerExtensionAction = defineTool({
     id: zod.string().describe('ID of the extension to trigger the action for.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const {id} = request.params;
     await context.triggerExtensionAction(id);

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -98,7 +98,7 @@ export const click = definePageTool({
     includeSnapshot: includeSnapshotSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const uid = request.params.uid;
     using handle = await request.page.getElementByUid(uid);
@@ -148,7 +148,7 @@ export const clickAt = definePageTool({
     includeSnapshot: includeSnapshotSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const page = request.page;
     const result = await page.waitForEventsAfterAction(async () => {
@@ -184,7 +184,7 @@ export const hover = definePageTool({
     includeSnapshot: includeSnapshotSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const uid = request.params.uid;
     using handle = await request.page.getElementByUid(uid);
@@ -302,7 +302,7 @@ export const fill = definePageTool({
     includeSnapshot: includeSnapshotSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const page = request.page;
     const result = await page.waitForEventsAfterAction(async () => {
@@ -333,7 +333,7 @@ export const typeText = definePageTool({
     submitKey: submitKeySchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const page = request.page;
     const result = await page.waitForEventsAfterAction(async () => {
@@ -364,7 +364,7 @@ export const drag = definePageTool({
     includeSnapshot: includeSnapshotSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     using fromHandle = await request.page.getElementByUid(
       request.params.from_uid,
@@ -408,7 +408,7 @@ export const fillForm = definePageTool({
     includeSnapshot: includeSnapshotSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const page = request.page;
     let lastResult: WaitForEventsResult = {};
@@ -446,11 +446,20 @@ export const uploadFile = definePageTool({
     filePaths: zod
       .array(zod.string())
       .min(1)
-      .describe('One or more local paths of files to upload.'),
+      .describe(
+        'One or more files paths to upload. File paths have to be local to the browser instance (not the MCP).',
+      ),
     includeSnapshot: includeSnapshotSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: ['filePaths'],
+  // We do not validate file paths for remote browser instances
+  // because they are on the remote host and not accessed by the MCP server.
+  verifyFilesSchema: {
+    filePaths: {
+      local: true,
+      remote: false,
+    },
+  },
   handler: async (request, response) => {
     const {uid, filePaths} = request.params;
     using handle = (await request.page.getElementByUid(
@@ -498,7 +507,7 @@ export const pressKey = definePageTool({
     includeSnapshot: includeSnapshotSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const page = request.page;
     const tokens = parseKey(request.params.key);

--- a/src/tools/lighthouse.ts
+++ b/src/tools/lighthouse.ts
@@ -44,7 +44,9 @@ export const lighthouseAudit = definePageTool({
       .describe('Directory for reports. If omitted, uses temporary files.'),
   },
   blockedByDialog: true,
-  verifyFilesSchema: ['outputDirPath'],
+  verifyFilesSchema: {
+    outputDirPath: true,
+  },
   handler: async (request, response, context) => {
     const page = request.page;
     const categories = [

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -32,7 +32,9 @@ export const takeHeapSnapshot = definePageTool({
       .describe('A path to a .heapsnapshot file to save the heapsnapshot to.'),
   },
   blockedByDialog: true,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   handler: async (request, response, context) => {
     const page = request.page;
     const snapshotPath = await context.ensureExtension(
@@ -61,7 +63,9 @@ export const getHeapSnapshotSummary = defineTool({
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   handler: async (request, response, context) => {
     const stats = await context.getHeapSnapshotStats(request.params.filePath);
     const staticData = await context.getHeapSnapshotStaticData(
@@ -106,7 +110,9 @@ export const getHeapSnapshotDetails = defineTool({
       .describe('The page size for pagination of aggregates.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   handler: async (request, response, context) => {
     const aggregates = await context.getHeapSnapshotAggregates(
       request.params.filePath,
@@ -147,7 +153,9 @@ export const getHeapSnapshotClassNodes = defineTool({
     pageSize: zod.number().optional().describe('The page size for pagination.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   handler: async (request, response, context) => {
     const nodes = await context.getHeapSnapshotNodesById(
       request.params.filePath,
@@ -173,7 +181,9 @@ export const getHeapSnapshotRetainers = defineTool({
     conditions: ['memoryDebugging'],
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   schema: {
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
     nodeId: zod.number().describe('The node ID to get retainers for.'),
@@ -202,7 +212,9 @@ export const closeHeapSnapshot = defineTool({
     readOnlyHint: false,
     conditions: ['memoryDebugging'],
   },
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   schema: {
     filePath: zod
       .string()
@@ -231,7 +243,9 @@ export const getHeapSnapshotRetainingPaths = defineTool({
     readOnlyHint: true,
     conditions: ['memoryDebugging'],
   },
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   blockedByDialog: false,
   schema: {
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
@@ -272,7 +286,9 @@ export const getHeapSnapshotEdges = defineTool({
     conditions: ['memoryDebugging'],
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   schema: {
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
     nodeId: zod.number().describe('The node ID to get outgoing edges for.'),
@@ -319,7 +335,9 @@ export const getHeapSnapshotDominators = defineTool({
     conditions: ['memoryDebugging'],
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   schema: {
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
     nodeId: zod
@@ -345,7 +363,10 @@ export const compareHeapSnapshots = defineTool({
     readOnlyHint: true,
     conditions: ['memoryDebugging'],
   },
-  verifyFilesSchema: ['baseFilePath', 'currentFilePath'],
+  verifyFilesSchema: {
+    baseFilePath: true,
+    currentFilePath: true,
+  },
   schema: {
     baseFilePath: zod
       .string()
@@ -389,7 +410,9 @@ export const getHeapSnapshotDuplicateStrings = defineTool({
     conditions: ['memoryDebugging'],
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   schema: {
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
     pageIdx: zod.number().optional().describe('The page index for pagination.'),
@@ -417,7 +440,9 @@ export const getHeapSnapshotObjectDetails = defineTool({
     conditions: ['memoryDebugging'],
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   schema: {
     filePath: zod.string().describe('A path to a .heapsnapshot file to read.'),
     nodeId: zod.number().describe('The node ID to get object details for.'),

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -71,7 +71,7 @@ export const listNetworkRequests = definePageTool({
       ),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const data = await request.page.getDevToolsData();
     response.attachDevToolsData(data);
@@ -116,7 +116,10 @@ export const getNetworkRequest = definePageTool({
       ),
   },
   blockedByDialog: true,
-  verifyFilesSchema: ['requestFilePath', 'responseFilePath'],
+  verifyFilesSchema: {
+    requestFilePath: true,
+    responseFilePath: true,
+  },
   handler: async (request, response) => {
     if (request.params.reqid) {
       response.attachNetworkRequest(request.params.reqid, {

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -26,7 +26,7 @@ export const listPages = defineTool(args => {
     },
     schema: {},
     blockedByDialog: false,
-    verifyFilesSchema: [],
+    verifyFilesSchema: {},
     handler: async (_request, response) => {
       response.setIncludePages(true);
       response.setListThirdPartyDeveloperTools();
@@ -54,7 +54,7 @@ export const selectPage = defineTool({
       .describe('Whether to focus the page and bring it to the top.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const page = context.getPageById(request.params.pageId);
     context.selectPage(page);
@@ -80,7 +80,7 @@ export const closePage = defineTool({
       .describe('The ID of the page to close. Call list_pages to list pages.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     try {
       await context.closePage(request.params.pageId);
@@ -123,7 +123,7 @@ export const newPage = defineTool(() => {
       ...timeoutSchema,
     },
     blockedByDialog: false,
-    verifyFilesSchema: [],
+    verifyFilesSchema: {},
     handler: async (request, response, context) => {
       const page = await context.newPage(
         request.params.background,
@@ -180,7 +180,7 @@ export const navigatePage = definePageTool(() => {
       ...timeoutSchema,
     },
     blockedByDialog: false,
-    verifyFilesSchema: [],
+    verifyFilesSchema: {},
     handler: async (request, response) => {
       const page = request.page;
       const options = {
@@ -306,7 +306,7 @@ export const resizePage = definePageTool({
     height: zod.number().describe('Page height'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const page = request.page;
 
@@ -352,7 +352,7 @@ export const handleDialog = definePageTool({
       .describe('Optional prompt text to enter into the dialog.'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const page = request.page;
     const dialog = page.getDialog();
@@ -404,7 +404,7 @@ export const getTabId = definePageTool({
       ),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const page = context.getPageById(request.params.pageId);
     const tabId = (page.pptrPage as unknown as CdpPage)._tabId;

--- a/src/tools/performance.ts
+++ b/src/tools/performance.ts
@@ -48,7 +48,9 @@ export const startTrace = definePageTool({
     filePath: filePathSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   handler: async (request, response, context) => {
     if (context.isRunningPerformanceTrace()) {
       response.appendResponseLine(
@@ -145,7 +147,9 @@ export const stopTrace = definePageTool({
     filePath: filePathSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   handler: async (request, response, context) => {
     if (!context.isRunningPerformanceTrace()) {
       return;
@@ -181,7 +185,7 @@ export const analyzeInsight = definePageTool({
       ),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const lastRecording = context.recordedTraces().at(-1);
     if (!lastRecording) {

--- a/src/tools/pwa.ts
+++ b/src/tools/pwa.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {fileURLToPath} from 'node:url';
-
 import {zod} from '../third_party/index.js';
 
 import {ToolCategory} from './categories.js';
@@ -52,13 +50,16 @@ export const installPwa = defineTool({
     displayMode: displayModeSchema,
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  // We do not validate file paths for remote browser instances
+  // because they are on the remote host and not accessed by the MCP server.
+  verifyFilesSchema: {
+    installUrlOrBundleUrl: {
+      local: true,
+      remote: false,
+    },
+  },
   handler: async (request, response, context) => {
     const {manifestId, installUrlOrBundleUrl, displayMode} = request.params;
-    const installUrl = new URL(installUrlOrBundleUrl);
-    if (installUrl.protocol === 'file:') {
-      await context.validatePath(fileURLToPath(installUrl));
-    }
     await context.installPWA({
       manifestId,
       installUrlOrBundleUrl,
@@ -86,7 +87,7 @@ export const uninstallPwa = defineTool({
     manifestId: manifestIdSchema,
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const {manifestId} = request.params;
     await context.uninstallPWA({manifestId});
@@ -117,7 +118,7 @@ export const launchPwa = defineTool({
       ),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const {manifestId, url} = request.params;
     const page = await context.launchPWA({manifestId, url});
@@ -141,7 +142,7 @@ export const getOsAppState = defineTool({
     manifestId: manifestIdSchema,
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const {manifestId} = request.params;
     const state = await context.getPWAState({manifestId});

--- a/src/tools/screencast.ts
+++ b/src/tools/screencast.ts
@@ -40,7 +40,9 @@ export const startScreencast = definePageTool(args => ({
       ),
   },
   blockedByDialog: false,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   handler: async (request, response, context) => {
     if (context.getScreenRecorder() !== null) {
       response.appendResponseLine(
@@ -129,7 +131,7 @@ export const stopScreencast = definePageTool({
   },
   schema: {},
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (_request, response, context) => {
     const data = context.getScreenRecorder();
     if (!data) {

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -138,7 +138,9 @@ export const screenshot = definePageTool(args => {
         ),
     },
     blockedByDialog: true,
-    verifyFilesSchema: ['filePath'],
+    verifyFilesSchema: {
+      filePath: true,
+    },
     handler: async (request, response, context) => {
       if (request.params.uid && request.params.fullPage) {
         throw new Error('Providing both "uid" and "fullPage" is not allowed.');

--- a/src/tools/script.ts
+++ b/src/tools/script.ts
@@ -70,7 +70,9 @@ Example with arguments: \`(el) => el.innerText\`
         : {}),
     },
     blockedByDialog: true,
-    verifyFilesSchema: ['filePath'],
+    verifyFilesSchema: {
+      filePath: true,
+    },
     handler: async (request, response, context) => {
       const {
         serviceWorkerId,

--- a/src/tools/slim/tools.ts
+++ b/src/tools/slim/tools.ts
@@ -19,7 +19,7 @@ export const screenshot = definePageTool({
   },
   schema: {},
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response, context) => {
     const page = request.page;
     const screenshot = await page.pptrPage.screenshot({
@@ -45,7 +45,7 @@ export const navigate = definePageTool({
     url: zod.string().describe('URL to navigate to'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const page = request.page;
 
@@ -84,7 +84,7 @@ export const evaluate = definePageTool({
     script: zod.string().describe(`JS script to run on the page`),
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const page = request.page;
     try {

--- a/src/tools/snapshot.ts
+++ b/src/tools/snapshot.ts
@@ -34,7 +34,9 @@ in the DevTools Elements panel (if any).`,
       ),
   },
   blockedByDialog: true,
-  verifyFilesSchema: ['filePath'],
+  verifyFilesSchema: {
+    filePath: true,
+  },
   handler: async (request, response) => {
     response.includeSnapshot({
       verbose: request.params.verbose ?? false,
@@ -60,7 +62,7 @@ export const waitFor = definePageTool({
     ...timeoutSchema,
   },
   blockedByDialog: true,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const page = request.page;
     await page.waitForTextOnPage(request.params.text, request.params.timeout);

--- a/src/tools/thirdPartyDeveloper.ts
+++ b/src/tools/thirdPartyDeveloper.ts
@@ -57,7 +57,7 @@ third-party developer tools with additional functionality.`,
   },
   schema: {},
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (_request, response) => {
     response.setListThirdPartyDeveloperTools();
   },
@@ -78,7 +78,7 @@ export const executeThirdPartyDeveloperTool = definePageTool({
       .describe('The JSON-stringified parameters to pass to the tool'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const toolName = request.params.toolName;
     let params: Record<string, unknown> = {};

--- a/src/tools/webmcp.ts
+++ b/src/tools/webmcp.ts
@@ -18,7 +18,7 @@ export const listWebMcpTools = definePageTool({
   },
   schema: {},
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (_request, response) => {
     response.setListWebMcpTools();
   },
@@ -39,7 +39,7 @@ export const executeWebMcpTool = definePageTool({
       .describe('The JSON-stringified parameters to pass to the WebMCP tool'),
   },
   blockedByDialog: false,
-  verifyFilesSchema: [],
+  verifyFilesSchema: {},
   handler: async (request, response) => {
     const toolName = request.params.toolName;
 

--- a/tests/ToolHandler.test.ts
+++ b/tests/ToolHandler.test.ts
@@ -5,7 +5,10 @@
  */
 
 import assert from 'node:assert';
+import {ChildProcess} from 'node:child_process';
+import path from 'node:path';
 import {afterEach, describe, it} from 'node:test';
+import {pathToFileURL} from 'node:url';
 
 import sinon from 'sinon';
 
@@ -20,6 +23,7 @@ import type {
   DefinedPageTool,
   ToolDefinition,
 } from '../src/tools/ToolDefinition.js';
+import {getMockBrowser} from './utils.js';
 import {Mutex} from '../src/third_party/index.js';
 
 describe('ToolHandler', () => {
@@ -39,7 +43,7 @@ describe('ToolHandler', () => {
       },
       schema: {},
       blockedByDialog: false,
-      verifyFilesSchema: [],
+      verifyFilesSchema: {},
       pageScoped: true,
       handler: async () => {
         handlerCalled = true;
@@ -80,7 +84,7 @@ describe('ToolHandler', () => {
       },
       schema: {},
       blockedByDialog: false,
-      verifyFilesSchema: [],
+      verifyFilesSchema: {},
       handler: async () => {
         handlerCalled = true;
       },
@@ -120,7 +124,7 @@ describe('ToolHandler', () => {
       },
       schema: {},
       blockedByDialog: false,
-      verifyFilesSchema: [],
+      verifyFilesSchema: {},
       handler: async () => {
         return;
       },
@@ -223,7 +227,7 @@ describe('ToolHandler', () => {
         url: zod.string(),
       },
       blockedByDialog: false,
-      verifyFilesSchema: [],
+      verifyFilesSchema: {},
       handler: async () => {
         handlerCalled = true;
       },
@@ -270,7 +274,7 @@ describe('ToolHandler', () => {
       },
       schema: {},
       blockedByDialog: false,
-      verifyFilesSchema: [],
+      verifyFilesSchema: {},
       handler: async () => {
         handlerCalled = true;
       },
@@ -300,5 +304,549 @@ describe('ToolHandler', () => {
       /is currently disabled/,
     );
     assert.strictEqual(handlerCalled, false);
+  });
+
+  it('validates files specified in verifyFilesSchema', async () => {
+    let handlerCalled = false;
+    const tool: ToolDefinition = {
+      name: 'file_tool',
+      description: 'A tool requiring file validation',
+      annotations: {
+        category: ToolCategory.PERFORMANCE,
+        readOnlyHint: true,
+      },
+      schema: {
+        filePath: zod.string(),
+        fileList: zod.array(zod.string()),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        filePath: true,
+        fileList: true,
+      },
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    mockContext.validatePath.resolves();
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const testFile = path.resolve('/workspace/url-file.txt');
+    const testFileUrl = pathToFileURL(testFile).href;
+    const testListFile1 = path.resolve('/workspace/list1.txt');
+    const testListFile2 = path.resolve('/workspace/list2.txt');
+
+    const result = await toolHandler.handle({
+      filePath: testFileUrl,
+      fileList: [
+        testListFile1,
+        testListFile2,
+        'https://example.com/remote.txt',
+      ],
+    });
+
+    assert.strictEqual(result.isError, undefined);
+    assert.strictEqual(handlerCalled, true);
+    assert.strictEqual(mockContext.validatePath.callCount, 3);
+    assert.strictEqual(mockContext.validatePath.calledWith(testFile), true);
+    assert.strictEqual(
+      mockContext.validatePath.calledWith(testListFile1),
+      true,
+    );
+    assert.strictEqual(
+      mockContext.validatePath.calledWith(testListFile2),
+      true,
+    );
+  });
+
+  it('returns error when file validation fails for verifyFilesSchema', async () => {
+    let handlerCalled = false;
+    const tool: ToolDefinition = {
+      name: 'file_tool',
+      description: 'A tool requiring file validation',
+      annotations: {
+        category: ToolCategory.PERFORMANCE,
+        readOnlyHint: true,
+      },
+      schema: {
+        filePath: zod.string(),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        filePath: true,
+      },
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    mockContext.validatePath.rejects(
+      new Error('Access denied: path is outside roots'),
+    );
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const result = await toolHandler.handle({
+      filePath: '/outside/workspace/file.txt',
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.match(
+      result.content[0].type === 'text' ? result.content[0].text : '',
+      /Access denied/,
+    );
+    assert.strictEqual(handlerCalled, false);
+  });
+
+  it('validates verifyFilesSchema when local: true and browser is running locally via process', async () => {
+    let handlerCalled = false;
+    const tool: ToolDefinition = {
+      name: 'upload_tool',
+      description: 'A tool with local-only file verification',
+      annotations: {
+        category: ToolCategory.INPUT,
+        readOnlyHint: false,
+      },
+      schema: {
+        filePaths: zod.array(zod.string()),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        filePaths: {
+          local: true,
+          remote: false,
+        },
+      },
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockContext.browser = getMockBrowser({process: mockProcess});
+    mockContext.validatePath.resolves();
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const testPath = path.resolve('/workspace/upload.png');
+    const result = await toolHandler.handle({
+      filePaths: [testPath],
+    });
+
+    assert.strictEqual(result.isError, undefined);
+    assert.strictEqual(handlerCalled, true);
+    assert.strictEqual(mockContext.validatePath.calledOnceWith(testPath), true);
+  });
+
+  it('validates verifyFilesSchema when local: true and browser is connected to localhost wsEndpoint', async () => {
+    let handlerCalled = false;
+    const tool: ToolDefinition = {
+      name: 'install_pwa_tool',
+      description: 'PWA tool with local-only file verification',
+      annotations: {
+        category: ToolCategory.INPUT,
+        readOnlyHint: false,
+      },
+      schema: {
+        installUrlOrBundleUrl: zod.string(),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        installUrlOrBundleUrl: {
+          local: true,
+        },
+      },
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    mockContext.browser = getMockBrowser({
+      wsEndpoint: 'ws://127.0.0.1:9222/devtools/browser/test',
+    });
+    mockContext.validatePath.resolves();
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const bundlePath = path.resolve('/workspace/app.swbn');
+    const fileUrl = pathToFileURL(bundlePath).href;
+    const result = await toolHandler.handle({
+      installUrlOrBundleUrl: fileUrl,
+    });
+
+    assert.strictEqual(result.isError, undefined);
+    assert.strictEqual(handlerCalled, true);
+    assert.strictEqual(
+      mockContext.validatePath.calledOnceWith(bundlePath),
+      true,
+    );
+  });
+
+  it('skips local-only verifyFilesSchema when browser is remote', async () => {
+    let handlerCalled = false;
+    const tool: ToolDefinition = {
+      name: 'upload_tool',
+      description: 'A tool with local-only file verification',
+      annotations: {
+        category: ToolCategory.INPUT,
+        readOnlyHint: false,
+      },
+      schema: {
+        filePaths: zod.array(zod.string()),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        filePaths: {
+          local: true,
+          remote: false,
+        },
+      },
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    mockContext.browser = getMockBrowser({
+      wsEndpoint: 'ws://remote-host.com:9222/devtools/browser/test',
+    });
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const result = await toolHandler.handle({
+      filePaths: ['/remote/server/path.txt'],
+    });
+
+    assert.strictEqual(result.isError, undefined);
+    assert.strictEqual(handlerCalled, true);
+    assert.strictEqual(mockContext.validatePath.called, false);
+  });
+
+  it('skips local-only verifyFilesSchema when context has no browser', async () => {
+    let handlerCalled = false;
+    const tool: ToolDefinition = {
+      name: 'upload_tool',
+      description: 'A tool with local-only file verification',
+      annotations: {
+        category: ToolCategory.INPUT,
+        readOnlyHint: false,
+      },
+      schema: {
+        filePaths: zod.array(zod.string()),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        filePaths: {
+          local: true,
+        },
+      },
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const result = await toolHandler.handle({
+      filePaths: ['/path/to/upload.txt'],
+    });
+
+    assert.strictEqual(result.isError, undefined);
+    assert.strictEqual(handlerCalled, true);
+    assert.strictEqual(mockContext.validatePath.called, false);
+  });
+
+  it('skips non-file URLs for local-only verifyFilesSchema even on local browser', async () => {
+    let handlerCalled = false;
+    const tool: ToolDefinition = {
+      name: 'install_pwa_tool',
+      description: 'PWA tool with local-only file verification',
+      annotations: {
+        category: ToolCategory.INPUT,
+        readOnlyHint: false,
+      },
+      schema: {
+        installUrlOrBundleUrl: zod.string(),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        installUrlOrBundleUrl: {
+          local: true,
+        },
+      },
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockContext.browser = getMockBrowser({process: mockProcess});
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const result = await toolHandler.handle({
+      installUrlOrBundleUrl: 'https://example.com/app',
+    });
+
+    assert.strictEqual(result.isError, undefined);
+    assert.strictEqual(handlerCalled, true);
+    assert.strictEqual(mockContext.validatePath.called, false);
+  });
+
+  it('validates verifyFilesSchema with true but skips local: true on remote browser', async () => {
+    let handlerCalled = false;
+    const tool: ToolDefinition = {
+      name: 'hybrid_tool',
+      description: 'A tool with both schema file verifications',
+      annotations: {
+        category: ToolCategory.PERFORMANCE,
+        readOnlyHint: false,
+      },
+      schema: {
+        outputFile: zod.string(),
+        inputFile: zod.string(),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        outputFile: true,
+        inputFile: {
+          local: true,
+          remote: false,
+        },
+      },
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    mockContext.browser = getMockBrowser({
+      wsEndpoint: 'ws://remote-host.com:9222/devtools/browser/test',
+    });
+    mockContext.validatePath.resolves();
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const outputPath = path.resolve('/local/output.json');
+    const result = await toolHandler.handle({
+      outputFile: outputPath,
+      inputFile: '/remote/input.json',
+    });
+
+    assert.strictEqual(result.isError, undefined);
+    assert.strictEqual(handlerCalled, true);
+    assert.strictEqual(
+      mockContext.validatePath.calledOnceWith(outputPath),
+      true,
+    );
+  });
+
+  it('returns error when file validation fails for local: true on local browser', async () => {
+    let handlerCalled = false;
+    const tool: ToolDefinition = {
+      name: 'upload_tool',
+      description: 'A tool with local-only file verification',
+      annotations: {
+        category: ToolCategory.INPUT,
+        readOnlyHint: false,
+      },
+      schema: {
+        filePaths: zod.array(zod.string()),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        filePaths: {
+          local: true,
+          remote: false,
+        },
+      },
+      handler: async () => {
+        handlerCalled = true;
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockContext.browser = getMockBrowser({process: mockProcess});
+    mockContext.validatePath.rejects(
+      new Error('Path is outside configured roots'),
+    );
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+    );
+
+    const result = await toolHandler.handle({
+      filePaths: ['/forbidden/path.txt'],
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.match(
+      result.content[0].type === 'text' ? result.content[0].text : '',
+      /Path is outside configured roots/,
+    );
+    assert.strictEqual(handlerCalled, false);
+  });
+
+  it('validates remote: true on remote browser and skips on local browser', async () => {
+    const tool: ToolDefinition = {
+      name: 'remote_file_tool',
+      description: 'A tool with remote-only file verification',
+      annotations: {
+        category: ToolCategory.PERFORMANCE,
+        readOnlyHint: false,
+      },
+      schema: {
+        remoteFile: zod.string(),
+      },
+      blockedByDialog: false,
+      verifyFilesSchema: {
+        remoteFile: {
+          local: false,
+          remote: true,
+        },
+      },
+      handler: async () => {
+        // no-op
+      },
+    };
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    // Remote browser: should validate
+    const mockRemoteContext = sinon.createStubInstance(McpContext);
+    mockRemoteContext.browser = getMockBrowser({
+      wsEndpoint: 'ws://remote-host.com:9222/devtools/browser/test',
+    });
+    mockRemoteContext.validatePath.resolves();
+
+    const remoteToolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockRemoteContext,
+      toolMutex,
+    );
+
+    const remotePath = path.resolve('/remote/file.txt');
+    await remoteToolHandler.handle({remoteFile: remotePath});
+    assert.strictEqual(
+      mockRemoteContext.validatePath.calledOnceWith(remotePath),
+      true,
+    );
+
+    // Local browser: should skip
+    const mockLocalContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockLocalContext.browser = getMockBrowser({process: mockProcess});
+
+    const localToolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockLocalContext,
+      toolMutex,
+    );
+
+    await localToolHandler.handle({remoteFile: remotePath});
+    assert.strictEqual(mockLocalContext.validatePath.called, false);
   });
 });

--- a/tests/ToolHandler.test.ts
+++ b/tests/ToolHandler.test.ts
@@ -51,6 +51,8 @@ describe('ToolHandler', () => {
     };
 
     const mockContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockContext.browser = getMockBrowser({process: mockProcess});
     const mockPage = sinon.createStubInstance(McpPage);
     mockContext.getSelectedMcpPage.returns(mockPage);
 
@@ -91,6 +93,8 @@ describe('ToolHandler', () => {
     };
 
     const mockContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockContext.browser = getMockBrowser({process: mockProcess});
 
     const toolMutex = new Mutex();
     const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
@@ -172,6 +176,8 @@ describe('ToolHandler', () => {
       };
 
       const mockContext = sinon.createStubInstance(McpContext);
+      const mockProcess = sinon.createStubInstance(ChildProcess);
+      mockContext.browser = getMockBrowser({process: mockProcess});
       mockContext.getDevToolsData.resolves(testCase.devToolsData);
       if (testCase.pageUrl) {
         const mockPage = {
@@ -330,6 +336,8 @@ describe('ToolHandler', () => {
     };
 
     const mockContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockContext.browser = getMockBrowser({process: mockProcess});
     mockContext.validatePath.resolves();
 
     const toolMutex = new Mutex();
@@ -394,6 +402,8 @@ describe('ToolHandler', () => {
     };
 
     const mockContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockContext.browser = getMockBrowser({process: mockProcess});
     mockContext.validatePath.rejects(
       new Error('Access denied: path is outside roots'),
     );
@@ -578,7 +588,7 @@ describe('ToolHandler', () => {
     assert.strictEqual(mockContext.validatePath.called, false);
   });
 
-  it('skips local-only verifyFilesSchema when context has no browser', async () => {
+  it('skips local-only verifyFilesSchema when browser has no process', async () => {
     let handlerCalled = false;
     const tool: ToolDefinition = {
       name: 'upload_tool',
@@ -602,6 +612,7 @@ describe('ToolHandler', () => {
     };
 
     const mockContext = sinon.createStubInstance(McpContext);
+    mockContext.browser = getMockBrowser();
 
     const toolMutex = new Mutex();
     const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {

--- a/tests/telemetry/metricsRegistry.test.ts
+++ b/tests/telemetry/metricsRegistry.test.ts
@@ -47,7 +47,7 @@ describe('metricsRegistry', () => {
           uid: zod.string(), // Should be blocked
         },
         blockedByDialog: false,
-        verifyFilesSchema: [],
+        verifyFilesSchema: {},
         handler: async () => {
           // no-op
         },
@@ -73,7 +73,7 @@ describe('metricsRegistry', () => {
           argEnum: zod.enum(['foo', 'bar']),
         },
         blockedByDialog: false,
-        verifyFilesSchema: [],
+        verifyFilesSchema: {},
         handler: async () => {
           // no-op
         },
@@ -97,7 +97,7 @@ describe('metricsRegistry', () => {
           argEnum: zod.enum(['foo', 'bar']).default('foo').optional(),
         },
         blockedByDialog: false,
-        verifyFilesSchema: [],
+        verifyFilesSchema: {},
         handler: async () => {
           // no-op
         },
@@ -119,7 +119,7 @@ describe('metricsRegistry', () => {
         },
         schema: {},
         blockedByDialog: false,
-        verifyFilesSchema: [],
+        verifyFilesSchema: {},
         handler: async () => {
           // no-op
         },

--- a/tests/tools/pwa.test.ts
+++ b/tests/tools/pwa.test.ts
@@ -5,9 +5,7 @@
  */
 
 import assert from 'node:assert';
-import path from 'node:path';
 import {afterEach, describe, it} from 'node:test';
-import {pathToFileURL} from 'node:url';
 
 import sinon from 'sinon';
 
@@ -124,42 +122,6 @@ describe('pwa', () => {
         await assert.rejects(
           getOsAppState.handler({params: {manifestId}}, response, context),
         );
-      },
-      PWA_BROWSER_OPTIONS,
-      {categoryPwa: true},
-    );
-  });
-
-  it('validates file bundle paths before installation', async () => {
-    await withMcpContext(
-      async (response, context) => {
-        const manifestId = 'isolated-app://example/';
-        const filePath = path.resolve('test-app.swbn');
-        const installUrlOrBundleUrl = pathToFileURL(filePath).href;
-        const validatePath = sinon.stub(context, 'validatePath').resolves();
-        const install = sinon.stub(context, 'installPWA').resolves(manifestId);
-
-        await installPwa.handler(
-          {params: {manifestId, installUrlOrBundleUrl}},
-          response,
-          context,
-        );
-
-        assert.ok(validatePath.calledOnceWithExactly(filePath));
-        assert.ok(install.calledOnce);
-
-        validatePath.reset();
-        validatePath.rejects(new Error('Path is outside configured roots'));
-        install.resetHistory();
-        await assert.rejects(
-          installPwa.handler(
-            {params: {manifestId, installUrlOrBundleUrl}},
-            response,
-            context,
-          ),
-          /Path is outside configured roots/,
-        );
-        assert.ok(install.notCalled);
       },
       PWA_BROWSER_OPTIONS,
       {categoryPwa: true},

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -5,7 +5,7 @@
  */
 
 import assert from 'node:assert';
-import {spawn} from 'node:child_process';
+import {spawn, type ChildProcess} from 'node:child_process';
 import path from 'node:path';
 
 import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
@@ -411,9 +411,18 @@ export function getMockPage(): Page {
   } satisfies Page;
 }
 
-export function getMockBrowser(): Browser {
+export function getMockBrowser(options?: {
+  process?: ChildProcess | null;
+  wsEndpoint?: string;
+}): Browser {
   const pages = [getMockPage()];
   return {
+    process() {
+      return options?.process ?? null;
+    },
+    wsEndpoint() {
+      return options?.wsEndpoint ?? '';
+    },
     pages() {
       return Promise.resolve(pages);
     },


### PR DESCRIPTION
I noticed that we validate file paths locally that are handled by potentially remote browsers.  This PR extends `verifyFilesSchema` to validate file paths for local or remote browsers or both  + test coverage.