### PR TITLE
fix: require .heapsnapshot (or .heaptimeline) as file extension

### DIFF
--- a/src/processors/HeapSnapshotManager.ts
+++ b/src/processors/HeapSnapshotManager.ts
@@ -49,6 +49,12 @@ export type HeapQueryOptions =
 export type HeapEdgesQueryOptions =
   DevTools.HeapSnapshotModel.HeapSnapshotModel.HeapEdgesQueryOptions;
 
+const VALID_EXTENSIONS: readonly string[] = ['.heapsnapshot', '.heaptimeline'];
+
+function hasValidHeapSnapshotExtension(filePath: string): boolean {
+  return VALID_EXTENSIONS.some(ext => filePath.endsWith(ext));
+}
+
 export class HeapSnapshotManager {
   #snapshotIdGenerator = createIdGenerator();
   #snapshots = new Map<
@@ -65,6 +71,11 @@ export class HeapSnapshotManager {
   async getSnapshot(
     filePath: string,
   ): Promise<DevTools.HeapSnapshotModel.HeapSnapshotProxy.HeapSnapshotProxy> {
+    if (!hasValidHeapSnapshotExtension(filePath)) {
+      throw new Error(
+        `File ${filePath} must have a .heapsnapshot or .heaptimeline extension.`,
+      );
+    }
     const absolutePath = path.resolve(filePath);
     const cached = this.#snapshots.get(absolutePath);
     if (cached) {

--- a/tests/processors/HeapSnapshotManager.test.ts
+++ b/tests/processors/HeapSnapshotManager.test.ts
@@ -17,6 +17,15 @@ describe('HeapSnapshotManager', () => {
     sinon.restore();
   });
 
+  it('rejects when a file without .heapsnapshot or .heaptimeline extension is passed', async () => {
+    const manager = new HeapSnapshotManager();
+
+    await assert.rejects(
+      manager.getSnapshot('tests/fixtures/snapshot_diffs.js'),
+      /must have a \.heapsnapshot or \.heaptimeline extension/,
+    );
+  });
+
   it('disposes the worker when snapshot loading fails', async () => {
     const disposeSpy = sinon.spy(
       DevTools.HeapSnapshotModel.HeapSnapshotProxy.HeapSnapshotWorkerProxy


### PR DESCRIPTION
This makes it harder to pass wrong arguments to the CLI tools.