### PR TITLE
fix(clI): print the errror message alone instead of JSON in the CLI

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -224,6 +224,15 @@ export async function handleResponse(
   format: 'json' | 'md',
 ): Promise<string> {
   if (response.isError) {
+    if (format === 'md') {
+      const chunks = [];
+      for (const content of response.content) {
+        if (content.type === 'text') {
+          chunks.push(content.text);
+        }
+      }
+      return chunks.join(' ');
+    }
     return JSON.stringify(response.content);
   }
   const chunks = [];

--- a/tests/daemon/client.test.ts
+++ b/tests/daemon/client.test.ts
@@ -126,13 +126,24 @@ describe('daemon client', () => {
       );
     });
 
-    it('handles error response when isError is true', async () => {
+    it('handles error response when isError is true with md format', async () => {
       const errorResponse = {
         isError: true,
         content: [{type: 'text' as const, text: 'Something went wrong'}],
       };
       assert.strictEqual(
         await handleResponse(errorResponse, 'md'),
+        'Something went wrong',
+      );
+    });
+
+    it('handles error response when isError is true with json format', async () => {
+      const errorResponse = {
+        isError: true,
+        content: [{type: 'text' as const, text: 'Something went wrong'}],
+      };
+      assert.strictEqual(
+        await handleResponse(errorResponse, 'json'),
         JSON.stringify(errorResponse.content),
       );
     });


### PR DESCRIPTION
Currently we print the JSON structure even when used in the CLI.