### PR TITLE
fix(cli): enable tools which require --memoryDebugging on the CLI

### DIFF
--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -31,41 +31,39 @@ import {checkForUpdates} from '../utils/check-for-updates.js';
 import {VERSION} from '../version.js';
 
 import {commands} from '../config/cli-options.js';
-import {mcpOptions, parseArguments} from '../config/mcp-options.js';
+import {
+  mcpOptions,
+  parseArguments,
+  getMcpOptionsForViaCli,
+} from '../config/mcp-options.js';
 
 await checkForUpdates(
   'Run `npm install -g chrome-devtools-mcp@latest` and `chrome-devtools start` to update and restart the daemon.',
 );
 
+const DEFAULT_CLI_ARGS = ['--viaCli'];
+
 async function start(args: string[], sessionId: string) {
-  const combinedArgs = [...args, ...defaultArgs];
+  const combinedArgs = [...DEFAULT_CLI_ARGS, ...args];
   await startDaemon(combinedArgs, sessionId);
   logDisclaimers(parseArguments(VERSION, combinedArgs));
 }
 
-const defaultArgs = ['--viaCli', '--experimentalStructuredContent'];
+function getCliOptions() {
+  const options: Partial<typeof mcpOptions> = {
+    ...getMcpOptionsForViaCli(),
+  };
 
-const startCliOptions = {
-  ...mcpOptions,
-} as Partial<typeof mcpOptions>;
+  // Missing CLI serialization.
+  delete options.viewport;
 
-// Missing CLI serialization.
-delete startCliOptions.viewport;
+  // Change the defaults for the CLI.
+  delete options.experimentalStructuredContent;
+  delete options.experimentalInteropTools;
+  delete options.experimentalPageIdRouting;
 
-// Change the defaults for the CLI.
-delete startCliOptions.experimentalStructuredContent;
-delete startCliOptions.experimentalInteropTools;
-delete startCliOptions.experimentalPageIdRouting;
-if (!('default' in mcpOptions.headless)) {
-  throw new Error('headless cli option unexpectedly does not have a default');
+  return options;
 }
-if ('default' in mcpOptions.isolated) {
-  throw new Error('isolated cli option unexpectedly has a default');
-}
-startCliOptions.headless!.default = true;
-startCliOptions.isolated!.description =
-  'If specified, creates a temporary user-data-dir that is automatically cleaned up after the browser is closed. Defaults to true unless userDataDir is provided.';
-startCliOptions.categoryExtensions!.default = true;
 
 const y = yargs(hideBin(process.argv))
   .locale('en') // Force English to ensure error string matching works in .fail, all custom messages we output are in English anyways
@@ -132,7 +130,7 @@ y.command(
   'Start or restart chrome-devtools-mcp',
   y =>
     y
-      .options(startCliOptions)
+      .options(getCliOptions())
       .example(
         '$0 start --browserUrl http://localhost:9222',
         'Start the server connecting to an existing browser',

--- a/src/config/cli-options.ts
+++ b/src/config/cli-options.ts
@@ -223,7 +223,7 @@ export const commands: Commands = {
   },
   evaluate_script: {
     description:
-      'Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON, so returned values have to be JSON-serializable.',
+      'Evaluate a JavaScript function inside the currently selected page or service worker. Returns the response as JSON, so returned values have to be JSON-serializable.',
     category: 'Debugging',
     args: {
       function: {
@@ -258,6 +258,13 @@ export const commands: Commands = {
         type: 'boolean',
         description:
           'Whether to wait for the DOM to settle. Pass false if the script only reads data. Defaults to true.',
+        required: false,
+      },
+      serviceWorkerId: {
+        name: 'serviceWorkerId',
+        type: 'string',
+        description:
+          "The optional service worker id to evaluate the script in. If provided, 'pageId' should be omitted. Note: 'args' (element UIDs) cannot be used when evaluating in a service worker.",
         required: false,
       },
     },
@@ -821,7 +828,7 @@ export const commands: Commands = {
   },
   list_console_messages: {
     description:
-      'List all console messages for the currently selected page since the last navigation.',
+      'List all console messages for the currently selected page since the last navigation. This includes console messages originating from extensions content scripts.',
     category: 'Debugging',
     args: {
       pageSize: {
@@ -913,7 +920,8 @@ export const commands: Commands = {
     },
   },
   list_pages: {
-    description: 'Get a list of pages open in the browser.',
+    description:
+      'Get a list of pages including extension service workers open in the browser.',
     category: 'Navigation automation',
     args: {},
   },

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -163,11 +163,13 @@ export const mcpOptions = {
   },
   memoryDebugging: {
     type: 'boolean',
+    default: false,
     describe: 'Whether to enable memory debugging tools.',
     alias: 'experimentalMemory',
   },
   experimentalStructuredContent: {
     type: 'boolean',
+    default: false,
     describe: 'Whether to output structured formatted content.',
   },
   experimentalToonFormat: {
@@ -376,6 +378,45 @@ export const mcpOptions = {
 
 export type ParsedArguments = ReturnType<typeof parseArguments>;
 
+export function getMcpOptionsForViaCli(): typeof mcpOptions {
+  if (!('default' in mcpOptions.headless)) {
+    throw new Error('headless cli option unexpectedly does not have a default');
+  }
+  if (!('default' in mcpOptions.experimentalStructuredContent)) {
+    throw new Error(
+      'experimentalStructuredContent cli option unexpectedly does not have a default',
+    );
+  }
+  if ('default' in mcpOptions.isolated) {
+    throw new Error('isolated cli option unexpectedly has a default');
+  }
+
+  return {
+    ...mcpOptions,
+    headless: {
+      ...mcpOptions.headless,
+      default: true,
+    },
+    memoryDebugging: {
+      ...mcpOptions.memoryDebugging,
+      default: true,
+    },
+    categoryExtensions: {
+      ...mcpOptions.categoryExtensions,
+      default: true,
+    },
+    experimentalStructuredContent: {
+      ...mcpOptions.experimentalStructuredContent,
+      default: true,
+    },
+    isolated: {
+      ...mcpOptions.isolated,
+      description:
+        'If specified, creates a temporary user-data-dir that is automatically cleaned up after the browser is closed. Defaults to true unless userDataDir is provided.',
+    },
+  };
+}
+
 /**
  * Exported only for testing to not trigger process exit.
  */
@@ -384,13 +425,16 @@ export function parser(
   argv = process.argv,
   env = process.env,
 ) {
+  const isViaCli = argv.includes('--viaCli') || argv.includes('--via-cli');
+  const options = isViaCli ? getMcpOptionsForViaCli() : mcpOptions;
+
   const yargsInstance = yargs(hideBin(argv))
     .scriptName('npx chrome-devtools-mcp@latest')
     .parserConfiguration({
       'strip-aliased': true,
       'strip-dashed': true,
     })
-    .options(mcpOptions)
+    .options(options)
     .showHelpOnFail(false, 'Specify --help for available options')
     .middleware(args => {
       // We can't set default in the options else
@@ -411,7 +455,7 @@ export function parser(
       }
 
       const cliOptionsAllowedArgs = [
-        ...Object.keys(mcpOptions),
+        ...Object.keys(options),
         // Yargs populated with positional args
         '_',
         '$0',

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -27,6 +27,8 @@ describe('cli args parsing', () => {
     usageStatistics: true,
     redactNetworkHeaders: false,
     allowUnrestrictedPaths: false,
+    memoryDebugging: false,
+    experimentalStructuredContent: false,
   };
 
   it('parses with default args', async () => {
@@ -38,6 +40,15 @@ describe('cli args parsing', () => {
       $0: 'npx chrome-devtools-mcp@latest',
       channel: 'stable',
     });
+  });
+
+  it('parses with viaCli args', async () => {
+    const args = parseArguments(['--viaCli']);
+    assert.strictEqual(args.headless, true);
+    assert.strictEqual(args.memoryDebugging, true);
+    assert.strictEqual(args.categoryExtensions, true);
+    assert.strictEqual(args.experimentalStructuredContent, true);
+    assert.strictEqual(args.viaCli, true);
   });
 
   it('parses with browser url', async () => {


### PR DESCRIPTION
Currently tools that require --memoryDebugging cannot directly be invoked from the CLI. The server needs to be start explicitly with the --memoryDebugging flag first. This PR makes --memoryDebugging a default for the CLI.