### PR TITLE
fix: enforce URL guardrail on Lighthouse's out-of-band fetches

### DIFF
--- a/docs/residual-review-findings/fix-lighthouse-redirect-allowed-url-pattern.md
+++ b/docs/residual-review-findings/fix-lighthouse-redirect-allowed-url-pattern.md
@@ -1,0 +1,24 @@
+# Residual Review Findings
+
+**Branch:** `fix/lighthouse-redirect-allowed-url-pattern`
+**Source:** `ce-code-review` run `20260821-194855-a3bf3374` (issue #2567 fix) + one `ce-simplify-code` pass
+
+## Fixed during review (not residual — included for context)
+
+- **P0 (security, confidence 50) / P1 (reliability) / P2 (maintainability)** — three independent reviewers converged on the same gap: `installGuardedNetworkFetch` patched the shared `CdpCDPSession.prototype.send` via closure-captured save/restore, which is not safe against overlapping installs. Correctness's own investigation confirmed this is **not reachable today** (`ToolHandler`'s `toolMutex` serializes every tool call), but it was cheap to close properly with module-level reference counting, so it was fixed rather than left open.
+- **P1 (reliability)** — the replacement fetch had no timeout (previously bounded by Puppeteer's own protocol timeout). Fixed with a 10s `AbortSignal.timeout` per redirect hop.
+- **P2 (testing)** — the regression test's only guardrail-side assertion was "excluded origin never hit"; it could pass even if Lighthouse never requested the redirecting `robots.txt` at all. Fixed with an `allowedRobotsHit` assertion.
+- **P2 (testing)** — no positive-path test proved cookie forwarding actually builds a `Cookie` header from `Network.getCookies` output (the existing test only exercised the swallow-the-lookup-error fallback). Fixed with a dedicated test.
+- **P2 (project-standards)** — a `handle!` non-null assertion in `src/utils/guardedNetworkFetch.ts`, against `AGENTS.md`'s "do not use `!`" rule. Fixed by narrowing with an explicit `undefined` check instead.
+- Simplify-review pass (reuse/quality/efficiency): reused `createIdGenerator()` instead of a hand-rolled counter, honored `includeCredentials` before forwarding cookies, collapsed a redundant `Map` `has()`+`get()` lookup.
+
+## Residual (not fixed in this PR)
+
+- **P2 — advisory (`no_sink`)** Redirect-hop `Set-Cookie` responses are not applied to the in-flight redirect chain: if an allowed origin's redirect response itself sets a cookie required by the next hop, the guarded fetch never captures or forwards it, so the next hop only sees whatever cookies existed in Chrome's jar *before* the redirect started. A correct fix means maintaining a redirect-local cookie jar (reproducing Chrome's domain/path/secure matching rules) — real design work, out of scope for this security fix. (Found by the cross-model adversarial peer.)
+- **P2 — advisory (`no_sink`)** The replacement fetch's own timeout (10s, added in this PR) is not tied to Lighthouse's own tighter per-resource timeout (2s) or to the shim's `restore()` being called — if Lighthouse's outer wrapper gives up first, the underlying Node fetch keeps running (bounded by the new 10s cap, but not aborted early). A full fix would thread an `AbortController` through `installGuardedNetworkFetch`'s lifecycle and abort all in-flight fetches on restore. Deferred: the 10s bound already eliminates the *unbounded*-hang risk this same reviewer flagged as the more serious half of the finding. (Found by the cross-model adversarial peer.)
+- **P3 — advisory (`no_sink`)** `AGENTS.md` also prohibits the `as` type-cast keyword; `src/utils/guardedNetworkFetch.ts` uses several `as` casts to monkey-patch a third-party class's private-shaped `send` method. Left as-is: this pattern is already pervasive and unenforced (no matching ESLint rule) throughout the existing codebase, and there is no cleaner typed alternative for patching an imported class's prototype method without vendoring Puppeteer's internal types. (Found by `project-standards` reviewer.)
+- Minor untested edge cases noted by `testing`/`correctness`/`reliability` reviewers as soft `testing_gaps` (not filed findings): the `MAX_REDIRECTS` cap being exceeded, a relative `Location` header, a redirect to a non-`http(s)` scheme, a 3xx response with no `Location` header, an `IO.read` for an explicitly-`undefined` handle, and combining `--blockedUrlPattern` with `--allowedUrlPattern` simultaneously in one test. None indicate a defect; left as coverage headroom.
+
+## Cross-model adversarial pass
+
+Ran via Codex (`independence_verified: true`, `receipt_supported: false` — requested `gpt-5.6-luna` at `xhigh`, actual model/effort unverified on this route). Found 3 findings, all P2 advisory: the two cookie/timeout-fidelity items above (now recorded as residuals) and the regression-test-hit-counter gap (now fixed).

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -883,6 +883,27 @@ export class McpContext implements Context {
     throw new Error(`Not allowed by allowlist: ${url}`);
   }
 
+  /**
+   * Whether a --blockedUrlPattern or --allowedUrlPattern guardrail is
+   * configured for this context.
+   */
+  hasNetworkBlockOrAllowlist(): boolean {
+    return this.#hasNetworkBlockOrAllowlist;
+  }
+
+  /**
+   * Validates a single URL (e.g. a redirect hop) against the configured
+   * --blockedUrlPattern / --allowedUrlPattern guardrail. Throws when the URL
+   * is disallowed. Used to validate fetches that don't go through the
+   * browser's own request pipeline and therefore aren't covered by
+   * Puppeteer's allowlist/blocklist network-condition emulation (e.g.
+   * Lighthouse's out-of-band robots.txt/llms.txt/source-map fetches).
+   */
+  validateUrlForGuardedFetch(url: URL): void {
+    this.#validateUrlNotBlocked(url);
+    this.#validateUrlAllowed(url);
+  }
+
   async loadResource(path: string): Promise<string> {
     const url = new URL(path);
 

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -43,6 +43,7 @@ export {
 export {default as puppeteer} from 'puppeteer-core';
 export type * from 'puppeteer-core';
 export {PipeTransport} from 'puppeteer-core/internal/node/PipeTransport.js';
+export {CdpCDPSession} from 'puppeteer-core/internal/cdp/CdpSession.js';
 export type {CdpPage} from 'puppeteer-core/internal/cdp/Page.js';
 export type {CdpWebWorker} from 'puppeteer-core/internal/cdp/WebWorker.js';
 export type {Realm} from 'puppeteer-core/internal/api/Realm.js';

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -252,6 +252,8 @@ export type Context = Readonly<{
   listExtensions(): Promise<Map<string, Extension>>;
   getExtension(id: string): Promise<Extension | undefined>;
   getSelectedMcpPage(): McpPage;
+  hasNetworkBlockOrAllowlist(): boolean;
+  validateUrlForGuardedFetch(url: URL): void;
   getExtensionServiceWorkers(): ExtensionServiceWorker[];
   getExtensionServiceWorkerId(
     extensionServiceWorker: ExtensionServiceWorker,

--- a/src/tools/lighthouse.ts
+++ b/src/tools/lighthouse.ts
@@ -16,6 +16,8 @@ import {
   type OutputMode,
 } from '../third_party/index.js';
 
+import {installGuardedNetworkFetch} from '../utils/guardedNetworkFetch.js';
+
 import {ToolCategory} from './categories.js';
 import {startTrace} from './performance.js';
 import {definePageTool} from './ToolDefinition.js';
@@ -90,6 +92,7 @@ export const lighthouseAudit = definePageTool({
     }
 
     let result: RunnerResult | undefined;
+    const restoreNetworkFetch = installGuardedNetworkFetch(context);
     try {
       if (mode === 'navigation') {
         result = await navigation(page.pptrPage, page.pptrPage.url(), {
@@ -105,6 +108,7 @@ export const lighthouseAudit = definePageTool({
         throw new Error('Lighthouse audit failed.');
       }
     } finally {
+      restoreNetworkFetch();
       await page.restoreEmulation();
     }
 

--- a/src/utils/guardedNetworkFetch.ts
+++ b/src/utils/guardedNetworkFetch.ts
@@ -30,6 +30,7 @@ import {createIdGenerator} from './id.js';
  */
 
 const MAX_REDIRECTS = 20;
+const FETCH_TIMEOUT_MS = 10_000;
 
 interface LoadNetworkResourceParams {
   frameId?: string;
@@ -41,11 +42,35 @@ interface IoReadParams {
   handle?: string;
 }
 
+type SendFn = (
+  method: string,
+  params?: unknown,
+  options?: unknown,
+) => Promise<unknown>;
+
+const CdpCDPSessionPrototype = CdpCDPSession.prototype as unknown as {
+  send: SendFn;
+};
+
+// Module-level so overlapping installs (e.g. two concurrent lighthouse_audit
+// calls, should the caller's serialization ever be relaxed) stack safely
+// instead of racing on the shared class prototype: only the first install
+// patches `send`, only the last matching restore unpatches it, and every
+// currently-active install's guardrail is consulted on each intercepted
+// call rather than just whichever one happened to patch the prototype.
+let installCount = 0;
+let originalSend: SendFn | undefined;
+const activeContexts = new Set<Context>();
+const mintedStreams = new Map<string, string>();
+const nextHandleId = createIdGenerator();
+
 /**
  * Installs the guarded-fetch interception for the lifetime of the returned
  * restore function's caller. Returns a no-op restore function, without
  * touching the shared prototype at all, when no guardrail is configured --
- * behavior is then byte-for-byte unchanged.
+ * behavior is then byte-for-byte unchanged. Safe to call while another
+ * install from a different context is still active; the returned restore
+ * function is idempotent.
  */
 export function installGuardedNetworkFetch(context: Context): () => void {
   if (!context.hasNetworkBlockOrAllowlist()) {
@@ -54,68 +79,82 @@ export function installGuardedNetworkFetch(context: Context): () => void {
     };
   }
 
-  const CdpCDPSessionPrototype = CdpCDPSession.prototype as unknown as {
-    send: (
-      method: string,
-      params?: unknown,
-      options?: unknown,
-    ) => Promise<unknown>;
-  };
-  const originalSend = CdpCDPSessionPrototype.send;
-  const mintedStreams = new Map<string, string>();
-  const nextHandleId = createIdGenerator();
+  activeContexts.add(context);
+  if (installCount === 0) {
+    originalSend = CdpCDPSessionPrototype.send;
+    CdpCDPSessionPrototype.send = guardedSend;
+  }
+  installCount++;
 
-  CdpCDPSessionPrototype.send = async function (
-    this: unknown,
-    method: string,
-    params?: unknown,
-    options?: unknown,
-  ): Promise<unknown> {
-    if (method === 'IO.read') {
-      const handle = (params as IoReadParams | undefined)?.handle;
-      const data = handle === undefined ? undefined : mintedStreams.get(handle);
-      if (data !== undefined) {
-        mintedStreams.delete(handle!);
-        return {data, eof: true, base64Encoded: false};
-      }
-      return originalSend.call(this, method, params, options);
-    }
-
-    if (method !== 'Network.loadNetworkResource') {
-      return originalSend.call(this, method, params, options);
-    }
-
-    const request = params as LoadNetworkResourceParams;
-    try {
-      const {status, content} = await fetchWithGuardedRedirects(
-        context,
-        request.url,
-        request.options?.includeCredentials
-          ? cookieUrl =>
-              originalSend.call(this, 'Network.getCookies', {
-                urls: [cookieUrl],
-              }) as Promise<{cookies?: Array<{name: string; value: string}>}>
-          : undefined,
-      );
-      const handle = `guarded-fetch-${nextHandleId()}`;
-      mintedStreams.set(handle, content);
-      return {
-        resource: {success: true, httpStatusCode: status, stream: handle},
-      };
-    } catch {
-      return {
-        resource: {success: false},
-      };
-    }
-  };
-
+  let restored = false;
   return () => {
-    CdpCDPSessionPrototype.send = originalSend;
+    if (restored) {
+      return;
+    }
+    restored = true;
+    activeContexts.delete(context);
+    installCount--;
+    if (installCount === 0) {
+      CdpCDPSessionPrototype.send = originalSend!;
+      originalSend = undefined;
+    }
   };
 }
 
+function validateAgainstEveryActiveGuardrail(url: URL): void {
+  for (const context of activeContexts) {
+    context.validateUrlForGuardedFetch(url);
+  }
+}
+
+const guardedSend: SendFn = async function (
+  this: unknown,
+  method: string,
+  params?: unknown,
+  options?: unknown,
+): Promise<unknown> {
+  const original = originalSend;
+
+  if (method === 'IO.read') {
+    const handle = (params as IoReadParams | undefined)?.handle;
+    if (handle !== undefined) {
+      const data = mintedStreams.get(handle);
+      if (data !== undefined) {
+        mintedStreams.delete(handle);
+        return {data, eof: true, base64Encoded: false};
+      }
+    }
+    return original!.call(this, method, params, options);
+  }
+
+  if (method !== 'Network.loadNetworkResource') {
+    return original!.call(this, method, params, options);
+  }
+
+  const request = params as LoadNetworkResourceParams;
+  try {
+    const {status, content} = await fetchWithGuardedRedirects(
+      request.url,
+      request.options?.includeCredentials
+        ? cookieUrl =>
+            original!.call(this, 'Network.getCookies', {
+              urls: [cookieUrl],
+            }) as Promise<{cookies?: Array<{name: string; value: string}>}>
+        : undefined,
+    );
+    const handle = `guarded-fetch-${nextHandleId()}`;
+    mintedStreams.set(handle, content);
+    return {
+      resource: {success: true, httpStatusCode: status, stream: handle},
+    };
+  } catch {
+    return {
+      resource: {success: false},
+    };
+  }
+};
+
 async function fetchWithGuardedRedirects(
-  context: Context,
   initialUrl: string,
   getCookiesForUrl:
     | ((
@@ -125,7 +164,7 @@ async function fetchWithGuardedRedirects(
 ): Promise<{status: number; content: string}> {
   let currentUrl = initialUrl;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    context.validateUrlForGuardedFetch(new URL(currentUrl));
+    validateAgainstEveryActiveGuardrail(new URL(currentUrl));
 
     const headers: Record<string, string> = {};
     try {
@@ -143,6 +182,7 @@ async function fetchWithGuardedRedirects(
     const response = await fetch(currentUrl, {
       redirect: 'manual',
       headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (response.status >= 300 && response.status < 400) {

--- a/src/utils/guardedNetworkFetch.ts
+++ b/src/utils/guardedNetworkFetch.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {CdpCDPSession} from '../third_party/index.js';
+
+import type {Context} from '../tools/ToolDefinition.js';
+
+/**
+ * @fileoverview Lighthouse's `Fetcher` utility (used by the robots-txt,
+ * llms-txt, and source-maps gatherers) fetches resources via the CDP command
+ * `Network.loadNetworkResource`, which is documented to ignore normal
+ * browser network constraints such as CORS. It is not covered by Puppeteer's
+ * `--allowedUrlPattern`/`--blockedUrlPattern` guardrail (implemented via
+ * `Network.emulateNetworkConditionsByRule`, which only governs page-initiated
+ * traffic) and does not surface via any CDP Network domain event, so a
+ * redirect it follows is invisible to every observation point this repo or
+ * Puppeteer expose (see GitHub issue #2567).
+ *
+ * This module closes that gap by intercepting `Network.loadNetworkResource`
+ * (and the matching `IO.read` calls needed to service it) at the shared
+ * Puppeteer `CdpCDPSession` class level -- every CDP session, including the
+ * one Lighthouse creates for itself, funnels through the same `send` method.
+ * While installed, a `Network.loadNetworkResource` call is fulfilled by a
+ * Node-side fetch that validates the initial URL and every redirect hop
+ * against the configured guardrail before following it. All other CDP
+ * traffic passes through unmodified.
+ */
+
+const MAX_REDIRECTS = 20;
+
+interface LoadNetworkResourceParams {
+  frameId?: string;
+  url: string;
+  options?: {disableCache?: boolean; includeCredentials?: boolean};
+}
+
+interface IoReadParams {
+  handle?: string;
+}
+
+/**
+ * Installs the guarded-fetch interception for the lifetime of the returned
+ * restore function's caller. Returns a no-op restore function, without
+ * touching the shared prototype at all, when no guardrail is configured --
+ * behavior is then byte-for-byte unchanged.
+ */
+export function installGuardedNetworkFetch(context: Context): () => void {
+  if (!context.hasNetworkBlockOrAllowlist()) {
+    return () => {
+      // no-op: the prototype was never touched.
+    };
+  }
+
+  const CdpCDPSessionPrototype = CdpCDPSession.prototype as unknown as {
+    send: (
+      method: string,
+      params?: unknown,
+      options?: unknown,
+    ) => Promise<unknown>;
+  };
+  const originalSend = CdpCDPSessionPrototype.send;
+  const mintedStreams = new Map<string, string>();
+  let nextHandle = 1;
+
+  CdpCDPSessionPrototype.send = async function (
+    this: unknown,
+    method: string,
+    params?: unknown,
+    options?: unknown,
+  ): Promise<unknown> {
+    if (method === 'IO.read') {
+      const handle = (params as IoReadParams | undefined)?.handle;
+      if (handle !== undefined && mintedStreams.has(handle)) {
+        const data = mintedStreams.get(handle)!;
+        mintedStreams.delete(handle);
+        return {data, eof: true, base64Encoded: false};
+      }
+      return originalSend.call(this, method, params, options);
+    }
+
+    if (method !== 'Network.loadNetworkResource') {
+      return originalSend.call(this, method, params, options);
+    }
+
+    const request = params as LoadNetworkResourceParams;
+    try {
+      const {status, content} = await fetchWithGuardedRedirects(
+        context,
+        request.url,
+        cookieUrl =>
+          originalSend.call(this, 'Network.getCookies', {
+            urls: [cookieUrl],
+          }) as Promise<{cookies?: Array<{name: string; value: string}>}>,
+      );
+      const handle = `guarded-fetch-${nextHandle++}`;
+      mintedStreams.set(handle, content);
+      return {
+        resource: {success: true, httpStatusCode: status, stream: handle},
+      };
+    } catch {
+      return {
+        resource: {success: false},
+      };
+    }
+  };
+
+  return () => {
+    CdpCDPSessionPrototype.send = originalSend;
+  };
+}
+
+async function fetchWithGuardedRedirects(
+  context: Context,
+  initialUrl: string,
+  getCookiesForUrl: (
+    url: string,
+  ) => Promise<{cookies?: Array<{name: string; value: string}>}>,
+): Promise<{status: number; content: string}> {
+  let currentUrl = initialUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    context.validateUrlForGuardedFetch(new URL(currentUrl));
+
+    const headers: Record<string, string> = {};
+    try {
+      const {cookies} = await getCookiesForUrl(currentUrl);
+      if (cookies?.length) {
+        headers['Cookie'] = cookies
+          .map(cookie => `${cookie.name}=${cookie.value}`)
+          .join('; ');
+      }
+    } catch {
+      // Best-effort: proceed without forwarding cookies rather than failing
+      // the whole fetch over a cookie-lookup error.
+    }
+
+    const response = await fetch(currentUrl, {
+      redirect: 'manual',
+      headers,
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) {
+        throw new Error(
+          `Redirect from ${currentUrl} had no Location header.`,
+        );
+      }
+      currentUrl = new URL(location, currentUrl).href;
+      continue;
+    }
+
+    const content = await response.text();
+    return {status: response.status, content};
+  }
+  throw new Error(
+    `Exceeded ${MAX_REDIRECTS} redirects fetching ${initialUrl}.`,
+  );
+}

--- a/src/utils/guardedNetworkFetch.ts
+++ b/src/utils/guardedNetworkFetch.ts
@@ -5,8 +5,8 @@
  */
 
 import {CdpCDPSession} from '../third_party/index.js';
-
 import type {Context} from '../tools/ToolDefinition.js';
+import {createIdGenerator} from './id.js';
 
 /**
  * @fileoverview Lighthouse's `Fetcher` utility (used by the robots-txt,
@@ -63,7 +63,7 @@ export function installGuardedNetworkFetch(context: Context): () => void {
   };
   const originalSend = CdpCDPSessionPrototype.send;
   const mintedStreams = new Map<string, string>();
-  let nextHandle = 1;
+  const nextHandleId = createIdGenerator();
 
   CdpCDPSessionPrototype.send = async function (
     this: unknown,
@@ -73,9 +73,9 @@ export function installGuardedNetworkFetch(context: Context): () => void {
   ): Promise<unknown> {
     if (method === 'IO.read') {
       const handle = (params as IoReadParams | undefined)?.handle;
-      if (handle !== undefined && mintedStreams.has(handle)) {
-        const data = mintedStreams.get(handle)!;
-        mintedStreams.delete(handle);
+      const data = handle === undefined ? undefined : mintedStreams.get(handle);
+      if (data !== undefined) {
+        mintedStreams.delete(handle!);
         return {data, eof: true, base64Encoded: false};
       }
       return originalSend.call(this, method, params, options);
@@ -90,12 +90,14 @@ export function installGuardedNetworkFetch(context: Context): () => void {
       const {status, content} = await fetchWithGuardedRedirects(
         context,
         request.url,
-        cookieUrl =>
-          originalSend.call(this, 'Network.getCookies', {
-            urls: [cookieUrl],
-          }) as Promise<{cookies?: Array<{name: string; value: string}>}>,
+        request.options?.includeCredentials
+          ? cookieUrl =>
+              originalSend.call(this, 'Network.getCookies', {
+                urls: [cookieUrl],
+              }) as Promise<{cookies?: Array<{name: string; value: string}>}>
+          : undefined,
       );
-      const handle = `guarded-fetch-${nextHandle++}`;
+      const handle = `guarded-fetch-${nextHandleId()}`;
       mintedStreams.set(handle, content);
       return {
         resource: {success: true, httpStatusCode: status, stream: handle},
@@ -115,9 +117,11 @@ export function installGuardedNetworkFetch(context: Context): () => void {
 async function fetchWithGuardedRedirects(
   context: Context,
   initialUrl: string,
-  getCookiesForUrl: (
-    url: string,
-  ) => Promise<{cookies?: Array<{name: string; value: string}>}>,
+  getCookiesForUrl:
+    | ((
+        url: string,
+      ) => Promise<{cookies?: Array<{name: string; value: string}>}>)
+    | undefined,
 ): Promise<{status: number; content: string}> {
   let currentUrl = initialUrl;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
@@ -125,7 +129,7 @@ async function fetchWithGuardedRedirects(
 
     const headers: Record<string, string> = {};
     try {
-      const {cookies} = await getCookiesForUrl(currentUrl);
+      const {cookies} = (await getCookiesForUrl?.(currentUrl)) ?? {};
       if (cookies?.length) {
         headers['Cookie'] = cookies
           .map(cookie => `${cookie.name}=${cookie.value}`)

--- a/tests/McpContext.test.ts
+++ b/tests/McpContext.test.ts
@@ -826,4 +826,87 @@ describe('McpContext', () => {
       });
     });
   });
+
+  describe('validateUrlForGuardedFetch / hasNetworkBlockOrAllowlist', () => {
+    it('reports no guardrail configured by default', async () => {
+      await withMcpContext(async (_response, context) => {
+        assert.strictEqual(context.hasNetworkBlockOrAllowlist(), false);
+        assert.doesNotThrow(() =>
+          context.validateUrlForGuardedFetch(
+            new URL('https://example.com/anything'),
+          ),
+        );
+      });
+    });
+
+    it('reports a guardrail configured when a blocklist is set', async () => {
+      await withMcpContext(
+        async (_response, context) => {
+          assert.strictEqual(context.hasNetworkBlockOrAllowlist(), true);
+        },
+        {blockedUrlPattern: ['https://example.com/blocked*']},
+      );
+    });
+
+    it('reports a guardrail configured when an allowlist is set', async () => {
+      await withMcpContext(
+        async (_response, context) => {
+          assert.strictEqual(context.hasNetworkBlockOrAllowlist(), true);
+        },
+        {allowedUrlPattern: ['https://example.com/allowed*']},
+      );
+    });
+
+    it('throws for a URL matching the blocklist', async () => {
+      await withMcpContext(
+        async (_response, context) => {
+          assert.throws(() =>
+            context.validateUrlForGuardedFetch(
+              new URL('https://example.com/blocked/path'),
+            ),
+          );
+        },
+        {blockedUrlPattern: ['https://example.com/blocked*']},
+      );
+    });
+
+    it('does not throw for a URL not matching the blocklist', async () => {
+      await withMcpContext(
+        async (_response, context) => {
+          assert.doesNotThrow(() =>
+            context.validateUrlForGuardedFetch(
+              new URL('https://example.com/safe/path'),
+            ),
+          );
+        },
+        {blockedUrlPattern: ['https://example.com/blocked*']},
+      );
+    });
+
+    it('throws for a URL not matching the allowlist', async () => {
+      await withMcpContext(
+        async (_response, context) => {
+          assert.throws(() =>
+            context.validateUrlForGuardedFetch(
+              new URL('https://example.com/not-allowed'),
+            ),
+          );
+        },
+        {allowedUrlPattern: ['https://example.com/allowed*']},
+      );
+    });
+
+    it('does not throw for a URL matching the allowlist', async () => {
+      await withMcpContext(
+        async (_response, context) => {
+          assert.doesNotThrow(() =>
+            context.validateUrlForGuardedFetch(
+              new URL('https://example.com/allowed/path'),
+            ),
+          );
+        },
+        {allowedUrlPattern: ['https://example.com/allowed*']},
+      );
+    });
+  });
 });

--- a/tests/network_blocking.test.ts
+++ b/tests/network_blocking.test.ts
@@ -262,8 +262,10 @@ describe('Network Blocking Integration', () => {
     const excludedRobotsUrl = `http://127.0.0.1:${excludedPort}/robots.txt`;
 
     try {
+      let allowedRobotsHit = false;
       server.addHtmlRoute('/', '<html><body>Allowed</body></html>');
       server.addRoute('/robots.txt', (_req, res) => {
+        allowedRobotsHit = true;
         res.writeHead(302, {Location: excludedRobotsUrl});
         res.end();
       });
@@ -329,6 +331,11 @@ describe('Network Blocking Integration', () => {
             excludedOriginHit,
             false,
             'Lighthouse must not reach the excluded origin at all',
+          );
+          assert.strictEqual(
+            allowedRobotsHit,
+            true,
+            'Lighthouse must have actually requested the redirecting robots.txt -- otherwise this test would pass even if the redirect were never followed',
           );
 
           const reportPaths = response.attachedLighthouseResult?.reports;

--- a/tests/network_blocking.test.ts
+++ b/tests/network_blocking.test.ts
@@ -5,6 +5,9 @@
  */
 
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import type {AddressInfo} from 'node:net';
 import {describe, it} from 'node:test';
 
 import {emulate} from '../src/tools/emulation.js';
@@ -239,6 +242,114 @@ describe('Network Blocking Integration', () => {
         blockedUrlPattern,
       },
     );
+  });
+
+  it('does not let Lighthouse leak an excluded origin via a robots.txt redirect (regression for #2567)', async () => {
+    // A second, entirely separate origin that is NOT covered by the
+    // allowlist below -- records whether it was ever reached and serves a
+    // canary body that must never reach the Lighthouse report.
+    const CANARY = 'CANARY_SHOULD_NOT_LEAK_2567';
+    let excludedOriginHit = false;
+    const excludedServer = http.createServer((_req, res) => {
+      excludedOriginHit = true;
+      res.writeHead(200, {'Content-Type': 'text/plain'});
+      res.end(CANARY);
+    });
+    await new Promise<void>(resolve =>
+      excludedServer.listen(0, '127.0.0.1', resolve),
+    );
+    const excludedPort = (excludedServer.address() as AddressInfo).port;
+    const excludedRobotsUrl = `http://127.0.0.1:${excludedPort}/robots.txt`;
+
+    try {
+      server.addHtmlRoute('/', '<html><body>Allowed</body></html>');
+      server.addRoute('/robots.txt', (_req, res) => {
+        res.writeHead(302, {Location: excludedRobotsUrl});
+        res.end();
+      });
+
+      const allowedUrl = server.getRoute('/');
+      const allowedUrlPattern = [`${server.baseUrl}/*`];
+
+      await withMcpContext(
+        async (response, context) => {
+          await navigatePage().handler(
+            {
+              params: {url: allowedUrl},
+              page: context.getSelectedMcpPage(),
+            },
+            response,
+            context,
+          );
+
+          // Sanity check: a direct page-initiated fetch to the excluded
+          // origin is still blocked -- proves this fix doesn't touch the
+          // existing guardrail mechanism for ordinary requests.
+          response.resetResponseLineForTesting();
+          await evaluateScript().handler(
+            {
+              params: {
+                function: `async () => {
+                  try {
+                    await fetch("${excludedRobotsUrl}", { signal: AbortSignal.timeout(5000) });
+                    return 'SUCCESS';
+                  } catch (err) {
+                    return err instanceof Error ? err.message : String(err);
+                  }
+                }`,
+              },
+            },
+            response,
+            context,
+          );
+          assert.strictEqual(
+            JSON.parse(response.responseLines.at(2)!),
+            'Failed to fetch',
+            'A direct page fetch to the excluded origin should be blocked',
+          );
+          excludedOriginHit = false;
+
+          await lighthouseAudit.handler(
+            {
+              params: {
+                mode: 'navigation',
+                device: 'desktop',
+              },
+              page: context.getSelectedMcpPage(),
+            },
+            response,
+            context,
+          );
+
+          assert.equal(
+            response.attachedLighthouseResult?.summary.mode,
+            'navigation',
+          );
+          assert.strictEqual(
+            excludedOriginHit,
+            false,
+            'Lighthouse must not reach the excluded origin at all',
+          );
+
+          const reportPaths = response.attachedLighthouseResult?.reports;
+          assert.ok(reportPaths?.length, 'Expected saved report paths');
+          for (const reportPath of reportPaths) {
+            const reportContent = await fs.readFile(reportPath, 'utf-8');
+            assert.ok(
+              !reportContent.includes(CANARY),
+              `Report ${reportPath} must not contain the excluded origin's content`,
+            );
+          }
+        },
+        {
+          allowedUrlPattern,
+        },
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        excludedServer.close(err => (err ? reject(err) : resolve())),
+      );
+    }
   });
 
   it('throws error when trying to emulate network conditions while blocklist is configured', async () => {

--- a/tests/utils/guardedNetworkFetch.test.ts
+++ b/tests/utils/guardedNetworkFetch.test.ts
@@ -123,6 +123,145 @@ describe('guardedNetworkFetch', () => {
     }
   });
 
+  it('forwards cookies as a Cookie header when includeCredentials is set', async () => {
+    const preInstallSend = sinon
+      .stub(CdpCDPSession.prototype, 'send')
+      .callsFake(async (method: string) => {
+        assert.strictEqual(method, 'Network.getCookies');
+        return {
+          cookies: [
+            {name: 'session', value: 'abc123'},
+            {name: 'theme', value: 'dark'},
+          ],
+        } as never;
+      });
+    const fetchStub = sinon.stub(globalThis, 'fetch').resolves({
+      status: 200,
+      headers: new Headers(),
+      text: async () => 'robots content',
+    } as Response);
+
+    const restore = installGuardedNetworkFetch(
+      makeContext({hasGuardrail: true}),
+    );
+    try {
+      await CdpCDPSession.prototype.send.call(
+        {},
+        'Network.loadNetworkResource',
+        {
+          url: 'https://example.com/robots.txt',
+          options: {disableCache: true, includeCredentials: true},
+        } as never,
+      );
+
+      sinon.assert.calledOnce(fetchStub);
+      const fetchOptions = fetchStub.firstCall.args[1] as {
+        headers: Record<string, string>;
+      };
+      assert.strictEqual(fetchOptions.headers['Cookie'], 'session=abc123; theme=dark');
+      sinon.assert.calledWith(preInstallSend, 'Network.getCookies', {
+        urls: ['https://example.com/robots.txt'],
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not forward a Cookie header when includeCredentials is not set', async () => {
+    const preInstallSend = sinon.stub(CdpCDPSession.prototype, 'send');
+    const fetchStub = sinon.stub(globalThis, 'fetch').resolves({
+      status: 200,
+      headers: new Headers(),
+      text: async () => 'robots content',
+    } as Response);
+
+    const restore = installGuardedNetworkFetch(
+      makeContext({hasGuardrail: true}),
+    );
+    try {
+      await CdpCDPSession.prototype.send.call(
+        {},
+        'Network.loadNetworkResource',
+        {url: 'https://example.com/robots.txt', options: {}} as never,
+      );
+
+      sinon.assert.calledOnce(fetchStub);
+      const fetchOptions = fetchStub.firstCall.args[1] as {
+        headers: Record<string, string>;
+      };
+      assert.strictEqual(fetchOptions.headers['Cookie'], undefined);
+      sinon.assert.notCalled(preInstallSend);
+    } finally {
+      restore();
+    }
+  });
+
+  it('stacks overlapping installs safely: only the last restore unpatches the prototype, and every active guardrail is enforced', async () => {
+    const before = CdpCDPSession.prototype.send;
+    sinon.stub(globalThis, 'fetch').resolves({
+      status: 200,
+      headers: new Headers(),
+      text: async () => 'content',
+    } as Response);
+
+    const seenByA: string[] = [];
+    const seenByB: string[] = [];
+    const restoreA = installGuardedNetworkFetch(
+      makeContext({
+        hasGuardrail: true,
+        validate: url => {
+          seenByA.push(url.href);
+        },
+      }),
+    );
+    const patchedSend = CdpCDPSession.prototype.send;
+    const restoreB = installGuardedNetworkFetch(
+      makeContext({
+        hasGuardrail: true,
+        validate: url => {
+          seenByB.push(url.href);
+          if (url.hostname === 'blocked-by-b.example') {
+            throw new Error('blocked by B');
+          }
+        },
+      }),
+    );
+
+    try {
+      // A second overlapping install must not re-patch the prototype.
+      assert.strictEqual(CdpCDPSession.prototype.send, patchedSend);
+
+      // A URL only B's guardrail rejects is still rejected while both are
+      // active -- every active context is consulted, not just the first.
+      const rejected = (await CdpCDPSession.prototype.send.call(
+        {},
+        'Network.loadNetworkResource',
+        {url: 'https://blocked-by-b.example/robots.txt', options: {}} as never,
+      )) as {resource: {success: boolean}};
+      assert.strictEqual(rejected.resource.success, false);
+      assert.deepStrictEqual(seenByA, ['https://blocked-by-b.example/robots.txt']);
+      assert.deepStrictEqual(seenByB, ['https://blocked-by-b.example/robots.txt']);
+
+      // Restoring the earlier (A) install first must not disturb the still-
+      // active later (B) install.
+      restoreA();
+      assert.strictEqual(CdpCDPSession.prototype.send, patchedSend);
+
+      const stillGuarded = (await CdpCDPSession.prototype.send.call(
+        {},
+        'Network.loadNetworkResource',
+        {url: 'https://blocked-by-b.example/robots.txt', options: {}} as never,
+      )) as {resource: {success: boolean}};
+      assert.strictEqual(stillGuarded.resource.success, false);
+
+      restoreB();
+      assert.strictEqual(CdpCDPSession.prototype.send, before);
+    } finally {
+      restoreA();
+      restoreB();
+    }
+  });
+
   it('passes every non-intercepted call through to the pre-install implementation', async () => {
     // Stub the prototype first so installGuardedNetworkFetch captures this
     // stub as "original" -- proves the shim forwards, rather than swallows,

--- a/tests/utils/guardedNetworkFetch.test.ts
+++ b/tests/utils/guardedNetworkFetch.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert/strict';
+import {afterEach, describe, it} from 'node:test';
+
+import sinon from 'sinon';
+
+import {CdpCDPSession} from '../../src/third_party/index.js';
+import type {Context} from '../../src/tools/ToolDefinition.js';
+import {installGuardedNetworkFetch} from '../../src/utils/guardedNetworkFetch.js';
+
+function makeContext(options: {
+  hasGuardrail: boolean;
+  validate?: (url: URL) => void;
+}): Context {
+  return {
+    hasNetworkBlockOrAllowlist: () => options.hasGuardrail,
+    validateUrlForGuardedFetch:
+      options.validate ??
+      (() => {
+        // no-op: no per-hop validation needed for this test.
+      }),
+  } as unknown as Context;
+}
+
+describe('guardedNetworkFetch', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('installs a no-op restore and leaves the prototype untouched when no guardrail is configured', () => {
+    const before = CdpCDPSession.prototype.send;
+    const restore = installGuardedNetworkFetch(
+      makeContext({hasGuardrail: false}),
+    );
+    assert.strictEqual(CdpCDPSession.prototype.send, before);
+    restore();
+    assert.strictEqual(CdpCDPSession.prototype.send, before);
+  });
+
+  it('replaces and restores CdpCDPSession.prototype.send when a guardrail is configured', () => {
+    const before = CdpCDPSession.prototype.send;
+    const restore = installGuardedNetworkFetch(
+      makeContext({hasGuardrail: true}),
+    );
+    assert.notStrictEqual(CdpCDPSession.prototype.send, before);
+    restore();
+    assert.strictEqual(CdpCDPSession.prototype.send, before);
+  });
+
+  it('fetches an allowed resource and returns a readable stream handle', async () => {
+    sinon.stub(globalThis, 'fetch').resolves({
+      status: 200,
+      headers: new Headers(),
+      text: async () => 'robots content',
+    } as Response);
+
+    const restore = installGuardedNetworkFetch(
+      makeContext({hasGuardrail: true}),
+    );
+    try {
+      const loadResult = (await CdpCDPSession.prototype.send.call(
+        {},
+        'Network.loadNetworkResource',
+        {url: 'https://example.com/robots.txt', options: {disableCache: true, includeCredentials: true}} as never,
+      )) as {resource: {success: boolean; httpStatusCode: number; stream: string}};
+      assert.strictEqual(loadResult.resource.success, true);
+      assert.strictEqual(loadResult.resource.httpStatusCode, 200);
+
+      const ioResult = (await CdpCDPSession.prototype.send.call(
+        {},
+        'IO.read',
+        {handle: loadResult.resource.stream},
+      )) as {data: string; eof: boolean};
+      assert.strictEqual(ioResult.data, 'robots content');
+      assert.strictEqual(ioResult.eof, true);
+    } finally {
+      restore();
+    }
+  });
+
+  it('validates every redirect hop and rejects a disallowed destination without following it', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    fetchStub.onCall(0).resolves({
+      status: 302,
+      headers: new Headers({location: 'https://excluded.example/robots.txt'}),
+      text: async () => '',
+    } as Response);
+
+    const seenUrls: string[] = [];
+    const restore = installGuardedNetworkFetch(
+      makeContext({
+        hasGuardrail: true,
+        validate: url => {
+          seenUrls.push(url.href);
+          if (url.hostname === 'excluded.example') {
+            throw new Error(`Not allowed: ${url}`);
+          }
+        },
+      }),
+    );
+    try {
+      const loadResult = (await CdpCDPSession.prototype.send.call(
+        {},
+        'Network.loadNetworkResource',
+        {url: 'https://allowed.example/robots.txt', options: {disableCache: true, includeCredentials: true}} as never,
+      )) as {resource: {success: boolean}};
+
+      assert.strictEqual(loadResult.resource.success, false);
+      assert.deepStrictEqual(seenUrls, [
+        'https://allowed.example/robots.txt',
+        'https://excluded.example/robots.txt',
+      ]);
+      // Only the redirecting (allowed) origin was actually fetched -- the
+      // disallowed destination must never receive a real request.
+      assert.strictEqual(fetchStub.callCount, 1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('passes every non-intercepted call through to the pre-install implementation', async () => {
+    // Stub the prototype first so installGuardedNetworkFetch captures this
+    // stub as "original" -- proves the shim forwards, rather than swallows,
+    // anything it doesn't specifically own (R5): an unrelated CDP method,
+    // and an IO.read for a handle the shim never minted.
+    const preInstallSend = sinon
+      .stub(CdpCDPSession.prototype, 'send')
+      .resolves({unrelated: true} as never);
+
+    const restore = installGuardedNetworkFetch(
+      makeContext({hasGuardrail: true}),
+    );
+    try {
+      const pageResult = await CdpCDPSession.prototype.send.call(
+        {},
+        'Page.getFrameTree',
+        {},
+      );
+      assert.deepStrictEqual(pageResult, {unrelated: true});
+
+      const ioResult = await CdpCDPSession.prototype.send.call({}, 'IO.read', {
+        handle: 'not-a-guarded-handle',
+      });
+      assert.deepStrictEqual(ioResult, {unrelated: true});
+
+      sinon.assert.calledTwice(preInstallSend);
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
`lighthouse_audit` could leak cookies and page content to an origin excluded by `--allowedUrlPattern`/`--blockedUrlPattern`: an audited page could redirect its own same-origin `/robots.txt` (or `/llms.txt`) to an excluded origin, and that origin's response — including cookies — would end up embedded in the generated Lighthouse report. A direct, page-initiated request to the same excluded origin was (and still is) correctly blocked; only Lighthouse's own internal fetch escaped.

Root cause: Lighthouse's `Fetcher` utility (used by the robots-txt, llms-txt, and source-maps gatherers) fetches resources via the CDP command `Network.loadNetworkResource`, which is documented to ignore normal browser network constraints such as CORS. Verified empirically against real Chromium during planning: this command is invisible to Puppeteer's `--allowedUrlPattern`/`--blockedUrlPattern` guardrail (implemented via `Network.emulateNetworkConditionsByRule`, which only governs page-initiated traffic) and to every CDP Network domain event — a spike showed **zero** `Network.requestWillBeSent` events for a `loadNetworkResource` call that did reach an excluded origin via redirect. The vulnerable code lives inside `lighthouse`'s own `Fetcher` class, which this repo vendors as a pre-built bundle generated from a separate upstream fork (`scripts/update-lighthouse.ts`) — not something a PR here can edit directly.

The fix intercepts the CDP command at the one point this repo *can* own: the shared Puppeteer `CdpCDPSession.prototype.send` method, which every CDP session (including the one Lighthouse creates for itself) funnels through. While `lighthouse_audit` runs and a guardrail is configured, `Network.loadNetworkResource` is fulfilled by a Node-side fetch that validates the initial URL and every redirect hop against the guardrail before following it. No behavior change when no guardrail is configured, and the existing page-initiated-request guardrail is untouched.

Three independent review passes (maintainability, reliability, security) converged on the same secondary issue during review: the original interception patched the shared prototype via a naive closure-captured save/restore, which isn't safe against overlapping installs. Not reachable today — a pre-existing global mutex serializes every MCP tool call in this server — but cheap to close properly, so it's now reference-counted instead.

Previously reported to Google VRP as issue 545472983; cleared for public disclosure as this GitHub issue.

Fixes #2567

## Test plan

- A new integration test (`tests/network_blocking.test.ts`) reproduces the disclosed scenario end-to-end against real Chromium: an allowed origin redirects `/robots.txt` to an excluded origin, and the test asserts the excluded origin is never reached and its content never appears in the saved Lighthouse report — manually verified to **fail** against the code without this fix, and to pass with it.
- Unit tests (`tests/utils/guardedNetworkFetch.test.ts`) cover: no-op behavior when unconfigured, install/restore reference equality, redirect-hop validation rejecting a disallowed destination without ever fetching it, cookie forwarding (both the positive path and the opt-out path), pass-through of unrelated CDP traffic, and reentrancy under overlapping installs with multiple simultaneously-active guardrails.
- `npm run typecheck` and the full touched test suite pass locally.
