### PR TITLE
feat: support configurable filesystem roots

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,8 +12,8 @@ chrome-devtools status # check if install worked.
 ```
 
 The CLI enables unrestricted filesystem access by default. Use `--workspace`
-to limit file tools to specific directories (the OS temp directory stays
-allowed). Repeat the flag for more than one directory.
+to limit file tools to specific directories. Repeat the flag for more than one
+directory.
 `--allow-unrestricted-paths` still works on its own for compatibility, but it
 cannot be combined with `--workspace`.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,9 +11,11 @@ npm i chrome-devtools-mcp@latest -g
 chrome-devtools status # check if install worked.
 ```
 
-Use `--workspace` when starting the CLI to allow file tools to access a
-directory outside the OS temp directory. Repeat the flag to allow more than one
-directory.
+The CLI enables unrestricted filesystem access by default. Use `--workspace`
+to limit file tools to specific directories (the OS temp directory stays
+allowed). Repeat the flag for more than one directory.
+`--allow-unrestricted-paths` still works on its own for compatibility, but it
+cannot be combined with `--workspace`.
 
 ```sh
 chrome-devtools start --workspace=/path/to/project --workspace=/path/to/output

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,6 +11,14 @@ npm i chrome-devtools-mcp@latest -g
 chrome-devtools status # check if install worked.
 ```
 
+Use `--workspace` when starting the CLI to allow file tools to access a
+directory outside the OS temp directory. Repeat the flag to allow more than one
+directory.
+
+```sh
+chrome-devtools start --workspace=/path/to/project --workspace=/path/to/output
+```
+
 ## How it works
 
 The CLI acts as a client to a background `chrome-devtools-mcp` daemon (uses Unix sockets on Linux/Mac and named pipes on Windows).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ The Chrome DevTools MCP server supports the following configuration option:
   - **Type:** boolean
   - **Default:** `false`
 
-- **`--memoryDebugging`/ `--memory-debugging`, `-experimentalMemory`**
+- **`--memoryDebugging`/ `--memory-debugging`, `--experimentalMemory`**
   Whether to enable memory debugging tools.
   - **Type:** boolean
   - **Default:** `false`
@@ -220,6 +220,11 @@ The Chrome DevTools MCP server supports the following configuration option:
   If set, disables the default path restriction that applies when the MCP client does not negotiate the roots capability. By default, file-writing tools are restricted to the OS temp directory when no roots are configured. Use this only when connecting a trusted local client that does not implement MCP roots and requires access to paths outside the temp directory.
   - **Type:** boolean
   - **Default:** `false`
+
+- **`--filesystemRoot`/ `--filesystem-root`, `--workspace`**
+  A directory that filesystem tools are allowed to access. May be specified more than once.
+  - **Type:** array
+  - **Default:** `OS temp directory`
 
 <!-- END AUTO GENERATED OPTIONS -->
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -139,7 +139,9 @@ function generateConfigOptionsMarkdown(): string {
       continue;
     }
 
-    const aliasText = optionConfig.alias ? `, \`-${optionConfig.alias}\`` : '';
+    const aliasText = optionConfig.alias
+      ? `, \`${optionConfig.alias.length === 1 ? '-' : '--'}${optionConfig.alias}\``
+      : '';
     const description = optionConfig.description || optionConfig.describe || '';
 
     // Convert camelCase to dash-case

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -166,7 +166,7 @@ function generateConfigOptionsMarkdown(): string {
     }
 
     // Add default if available
-    markdown += `  - **Default:** \`${optionConfig.default ?? 'false'}\`\n`;
+    markdown += `  - **Default:** \`${optionConfig.defaultDescription ?? optionConfig.default ?? 'false'}\`\n`;
 
     markdown += '\n';
   }

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -35,7 +35,6 @@ import {
   mcpOptions,
   parseArguments,
   getMcpOptionsForViaCli,
-  applyCliFilesystemAccess,
 } from '../config/mcp-options.js';
 
 await checkForUpdates(
@@ -156,7 +155,6 @@ y.command(
     ) {
       argv.headless = true;
     }
-    applyCliFilesystemAccess(argv, hideBin(process.argv));
     const args = serializeArgs(mcpOptions, argv);
     await start(args, argv.sessionId);
     process.exit(0);

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -35,6 +35,7 @@ import {
   mcpOptions,
   parseArguments,
   getMcpOptionsForViaCli,
+  applyFilesystemRootOverrides,
   checkFilesystemRootConflict,
 } from '../config/mcp-options.js';
 
@@ -161,6 +162,13 @@ y.command(
       !argv.wsEndpoint
     ) {
       argv.headless = true;
+    }
+    applyFilesystemRootOverrides(argv, hideBin(process.argv));
+    // CLI defaults unrestricted paths on. Clear the yargs filesystemRoot default
+    // so it is not serialized onto the daemon as an explicit flag that would
+    // then conflict with --allow-unrestricted-paths.
+    if (argv.allowUnrestrictedPaths === true) {
+      argv.filesystemRoot = undefined;
     }
     const args = serializeArgs(mcpOptions, argv);
     await start(args, argv.sessionId);

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -35,6 +35,7 @@ import {
   mcpOptions,
   parseArguments,
   getMcpOptionsForViaCli,
+  checkFilesystemRootConflict,
 } from '../config/mcp-options.js';
 
 await checkForUpdates(
@@ -128,6 +129,12 @@ y.command(
   y =>
     y
       .options(getCliOptions())
+      .check(argv => {
+        return checkFilesystemRootConflict(
+          argv.allowUnrestrictedPaths,
+          hideBin(process.argv),
+        );
+      })
       .example(
         '$0 start --browserUrl http://localhost:9222',
         'Start the server connecting to an existing browser',

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -35,8 +35,7 @@ import {
   mcpOptions,
   parseArguments,
   getMcpOptionsForViaCli,
-  applyFilesystemRootOverrides,
-  checkFilesystemRootConflict,
+  applyCliFilesystemAccess,
 } from '../config/mcp-options.js';
 
 await checkForUpdates(
@@ -130,12 +129,6 @@ y.command(
   y =>
     y
       .options(getCliOptions())
-      .check(argv => {
-        return checkFilesystemRootConflict(
-          argv.allowUnrestrictedPaths,
-          hideBin(process.argv),
-        );
-      })
       .example(
         '$0 start --browserUrl http://localhost:9222',
         'Start the server connecting to an existing browser',
@@ -163,13 +156,7 @@ y.command(
     ) {
       argv.headless = true;
     }
-    applyFilesystemRootOverrides(argv, hideBin(process.argv));
-    // CLI defaults unrestricted paths on. Clear the yargs filesystemRoot default
-    // so it is not serialized onto the daemon as an explicit flag that would
-    // then conflict with --allow-unrestricted-paths.
-    if (argv.allowUnrestrictedPaths === true) {
-      argv.filesystemRoot = undefined;
-    }
+    applyCliFilesystemAccess(argv, hideBin(process.argv));
     const args = serializeArgs(mcpOptions, argv);
     await start(args, argv.sessionId);
     process.exit(0);

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -406,8 +406,7 @@ export const mcpOptions = {
     default: [os.tmpdir()],
     defaultDescription: 'OS temp directory',
     describe:
-      'A directory that filesystem tools are allowed to access. May be specified more than once. ' +
-      'The OS temp directory is always allowed.',
+      'A directory that filesystem tools are allowed to access. May be specified more than once.',
   },
 } satisfies Record<string, YargsOptions>;
 

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -6,6 +6,7 @@
 
 import type {YargsOptions} from '../third_party/index.js';
 import {yargs, hideBin} from '../third_party/index.js';
+import os from 'node:os';
 
 export const mcpOptions = {
   autoConnect: {
@@ -392,6 +393,7 @@ export const mcpOptions = {
   allowUnrestrictedPaths: {
     type: 'boolean',
     default: false,
+    deprecated: 'Use --workspace=/ instead.',
     describe:
       'If set, disables the default path restriction that applies when the MCP client does not negotiate ' +
       'the roots capability. By default, file-writing tools are restricted to the OS temp directory when ' +
@@ -401,6 +403,8 @@ export const mcpOptions = {
   filesystemRoot: {
     type: 'array',
     alias: 'workspace',
+    default: [os.tmpdir()],
+    defaultDescription: 'OS temp directory',
     describe:
       'A directory that filesystem tools are allowed to access. May be specified more than once. ' +
       'The OS temp directory is always allowed.',
@@ -408,6 +412,29 @@ export const mcpOptions = {
 } satisfies Record<string, YargsOptions>;
 
 export type ParsedArguments = ReturnType<typeof parseArguments>;
+
+export function checkFilesystemRootConflict(
+  allowUnrestrictedPaths: unknown,
+  argv: readonly string[],
+): boolean {
+  if (allowUnrestrictedPaths !== true) {
+    return true;
+  }
+
+  const hasExplicitFilesystemRoot = argv.some(arg => {
+    return ['--filesystem-root', '--filesystemRoot', '--workspace'].some(
+      option => arg === option || arg.startsWith(`${option}=`),
+    );
+  });
+
+  if (hasExplicitFilesystemRoot) {
+    throw new Error(
+      'Arguments filesystemRoot and allowUnrestrictedPaths are mutually exclusive',
+    );
+  }
+
+  return true;
+}
 
 export function getMcpOptionsForViaCli(): typeof mcpOptions {
   if (!('default' in mcpOptions.headless)) {
@@ -475,6 +502,12 @@ export function parser(
       'strip-dashed': true,
     })
     .options(options)
+    .check(args => {
+      return checkFilesystemRootConflict(
+        args.allowUnrestrictedPaths,
+        hideBin(argv),
+      );
+    })
     .showHelpOnFail(false, 'Specify --help for available options')
     .middleware(args => {
       // We can't set default in the options else

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -413,21 +413,67 @@ export const mcpOptions = {
 
 export type ParsedArguments = ReturnType<typeof parseArguments>;
 
+const FILESYSTEM_ROOT_FLAGS = [
+  '--filesystem-root',
+  '--filesystemRoot',
+  '--workspace',
+] as const;
+
+const UNRESTRICTED_PATHS_FLAGS = [
+  '--allow-unrestricted-paths',
+  '--allowUnrestrictedPaths',
+] as const;
+
+export interface FilesystemAccessFlags {
+  allowUnrestrictedPaths?: unknown;
+  filesystemRoot?: unknown;
+}
+
+function hasExplicitArg(
+  argv: readonly string[],
+  names: readonly string[],
+): boolean {
+  return argv.some(arg =>
+    names.some(name => arg === name || arg.startsWith(`${name}=`)),
+  );
+}
+
+/**
+ * CLI defaults `--allow-unrestricted-paths` to true. An explicit `--workspace`
+ * / `--filesystem-root` should restrict access to those directories instead of
+ * conflicting with that default. Passing both flags explicitly is still an
+ * error.
+ */
+export function applyFilesystemRootOverrides(
+  args: FilesystemAccessFlags,
+  argv: readonly string[],
+): void {
+  const hasExplicitRoot = hasExplicitArg(argv, FILESYSTEM_ROOT_FLAGS);
+  const hasExplicitUnrestricted = hasExplicitArg(
+    argv,
+    UNRESTRICTED_PATHS_FLAGS,
+  );
+
+  if (hasExplicitRoot && !hasExplicitUnrestricted) {
+    args.allowUnrestrictedPaths = false;
+  }
+}
+
 export function checkFilesystemRootConflict(
   allowUnrestrictedPaths: unknown,
   argv: readonly string[],
 ): boolean {
-  if (allowUnrestrictedPaths !== true) {
-    return true;
-  }
+  const hasExplicitFilesystemRoot = hasExplicitArg(argv, FILESYSTEM_ROOT_FLAGS);
+  const hasExplicitUnrestricted = hasExplicitArg(
+    argv,
+    UNRESTRICTED_PATHS_FLAGS,
+  );
 
-  const hasExplicitFilesystemRoot = argv.some(arg => {
-    return ['--filesystem-root', '--filesystemRoot', '--workspace'].some(
-      option => arg === option || arg.startsWith(`${option}=`),
-    );
-  });
-
-  if (hasExplicitFilesystemRoot) {
+  if (
+    allowUnrestrictedPaths === true &&
+    hasExplicitFilesystemRoot &&
+    hasExplicitUnrestricted
+  ) {
     throw new Error(
       'Arguments filesystemRoot and allowUnrestrictedPaths are mutually exclusive',
     );
@@ -510,6 +556,7 @@ export function parser(
     })
     .showHelpOnFail(false, 'Specify --help for available options')
     .middleware(args => {
+      applyFilesystemRootOverrides(args, hideBin(argv));
       // We can't set default in the options else
       // Yargs will complain
       if (

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -398,6 +398,13 @@ export const mcpOptions = {
       'no roots are configured. Use this only when connecting a trusted local client that does not implement ' +
       'MCP roots and requires access to paths outside the temp directory.',
   },
+  filesystemRoot: {
+    type: 'array',
+    alias: 'workspace',
+    describe:
+      'A directory that filesystem tools are allowed to access. May be specified more than once. ' +
+      'The OS temp directory is always allowed.',
+  },
 } satisfies Record<string, YargsOptions>;
 
 export type ParsedArguments = ReturnType<typeof parseArguments>;

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -474,8 +474,12 @@ export function parser(
     .showHelpOnFail(false, 'Specify --help for available options')
     .middleware(args => {
       if (isViaCli && args.filesystemRoot === DEFAULT_FILESYSTEM_ROOT) {
-        args.allowUnrestrictedPaths = true;
-        args.filesystemRoot = undefined;
+        const cliFilesystemArgs: {
+          allowUnrestrictedPaths?: boolean;
+          filesystemRoot?: unknown;
+        } = args;
+        cliFilesystemArgs.allowUnrestrictedPaths = true;
+        cliFilesystemArgs.filesystemRoot = undefined;
       }
       // We can't set default in the options else
       // Yargs will complain

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -8,6 +8,8 @@ import type {YargsOptions} from '../third_party/index.js';
 import {yargs, hideBin} from '../third_party/index.js';
 import os from 'node:os';
 
+export const DEFAULT_FILESYSTEM_ROOT = [os.tmpdir()];
+
 export const mcpOptions = {
   autoConnect: {
     type: 'boolean',
@@ -403,7 +405,7 @@ export const mcpOptions = {
   filesystemRoot: {
     type: 'array',
     alias: 'workspace',
-    default: [os.tmpdir()],
+    default: DEFAULT_FILESYSTEM_ROOT,
     defaultDescription: 'OS temp directory',
     describe:
       'A directory that filesystem tools are allowed to access. May be specified more than once.',
@@ -411,44 +413,6 @@ export const mcpOptions = {
 } satisfies Record<string, YargsOptions>;
 
 export type ParsedArguments = ReturnType<typeof parseArguments>;
-
-const FILESYSTEM_ROOT_FLAGS = [
-  '--filesystem-root',
-  '--filesystemRoot',
-  '--workspace',
-] as const;
-
-export interface FilesystemAccessFlags {
-  allowUnrestrictedPaths?: unknown;
-  filesystemRoot?: unknown;
-}
-
-function hasExplicitArg(
-  argv: readonly string[],
-  names: readonly string[],
-): boolean {
-  return argv.some(arg =>
-    names.some(name => arg === name || arg.startsWith(`${name}=`)),
-  );
-}
-
-/**
- * CLI filesystem access. `--allow-unrestricted-paths` is not given a CLI yargs
- * default; middleware enables it when the user did not pass `--workspace` /
- * `--filesystem-root`. Explicit workspace flags are detected separately from
- * the yargs tmpdir default so that default is not treated as a user workspace.
- */
-export function applyCliFilesystemAccess(
-  args: FilesystemAccessFlags,
-  argv: readonly string[],
-): void {
-  if (hasExplicitArg(argv, FILESYSTEM_ROOT_FLAGS)) {
-    args.allowUnrestrictedPaths = false;
-    return;
-  }
-  args.allowUnrestrictedPaths = true;
-  args.filesystemRoot = undefined;
-}
 
 export function getMcpOptionsForViaCli(): typeof mcpOptions {
   if (!('default' in mcpOptions.headless)) {
@@ -509,8 +473,9 @@ export function parser(
     .options(options)
     .showHelpOnFail(false, 'Specify --help for available options')
     .middleware(args => {
-      if (isViaCli) {
-        applyCliFilesystemAccess(args, hideBin(argv));
+      if (isViaCli && args.filesystemRoot === DEFAULT_FILESYSTEM_ROOT) {
+        args.allowUnrestrictedPaths = true;
+        args.filesystemRoot = undefined;
       }
       // We can't set default in the options else
       // Yargs will complain

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -418,11 +418,6 @@ const FILESYSTEM_ROOT_FLAGS = [
   '--workspace',
 ] as const;
 
-const UNRESTRICTED_PATHS_FLAGS = [
-  '--allow-unrestricted-paths',
-  '--allowUnrestrictedPaths',
-] as const;
-
 export interface FilesystemAccessFlags {
   allowUnrestrictedPaths?: unknown;
   filesystemRoot?: unknown;
@@ -438,57 +433,26 @@ function hasExplicitArg(
 }
 
 /**
- * CLI defaults `--allow-unrestricted-paths` to true. An explicit `--workspace`
- * / `--filesystem-root` should restrict access to those directories instead of
- * conflicting with that default. Passing both flags explicitly is still an
- * error.
+ * CLI filesystem access. `--allow-unrestricted-paths` is not given a CLI yargs
+ * default; middleware enables it when the user did not pass `--workspace` /
+ * `--filesystem-root`. Explicit workspace flags are detected separately from
+ * the yargs tmpdir default so that default is not treated as a user workspace.
  */
-export function applyFilesystemRootOverrides(
+export function applyCliFilesystemAccess(
   args: FilesystemAccessFlags,
   argv: readonly string[],
 ): void {
-  const hasExplicitRoot = hasExplicitArg(argv, FILESYSTEM_ROOT_FLAGS);
-  const hasExplicitUnrestricted = hasExplicitArg(
-    argv,
-    UNRESTRICTED_PATHS_FLAGS,
-  );
-
-  if (hasExplicitRoot && !hasExplicitUnrestricted) {
+  if (hasExplicitArg(argv, FILESYSTEM_ROOT_FLAGS)) {
     args.allowUnrestrictedPaths = false;
+    return;
   }
-}
-
-export function checkFilesystemRootConflict(
-  allowUnrestrictedPaths: unknown,
-  argv: readonly string[],
-): boolean {
-  const hasExplicitFilesystemRoot = hasExplicitArg(argv, FILESYSTEM_ROOT_FLAGS);
-  const hasExplicitUnrestricted = hasExplicitArg(
-    argv,
-    UNRESTRICTED_PATHS_FLAGS,
-  );
-
-  if (
-    allowUnrestrictedPaths === true &&
-    hasExplicitFilesystemRoot &&
-    hasExplicitUnrestricted
-  ) {
-    throw new Error(
-      'Arguments filesystemRoot and allowUnrestrictedPaths are mutually exclusive',
-    );
-  }
-
-  return true;
+  args.allowUnrestrictedPaths = true;
+  args.filesystemRoot = undefined;
 }
 
 export function getMcpOptionsForViaCli(): typeof mcpOptions {
   if (!('default' in mcpOptions.headless)) {
     throw new Error('headless cli option unexpectedly does not have a default');
-  }
-  if (!('default' in mcpOptions.allowUnrestrictedPaths)) {
-    throw new Error(
-      'allowUnrestrictedPaths cli option unexpectedly does not have a default',
-    );
   }
   if (!('default' in mcpOptions.experimentalStructuredContent)) {
     throw new Error(
@@ -501,10 +465,6 @@ export function getMcpOptionsForViaCli(): typeof mcpOptions {
 
   return {
     ...mcpOptions,
-    allowUnrestrictedPaths: {
-      ...mcpOptions.allowUnrestrictedPaths,
-      default: true,
-    },
     headless: {
       ...mcpOptions.headless,
       default: true,
@@ -547,15 +507,11 @@ export function parser(
       'strip-dashed': true,
     })
     .options(options)
-    .check(args => {
-      return checkFilesystemRootConflict(
-        args.allowUnrestrictedPaths,
-        hideBin(argv),
-      );
-    })
     .showHelpOnFail(false, 'Specify --help for available options')
     .middleware(args => {
-      applyFilesystemRootOverrides(args, hideBin(argv));
+      if (isViaCli) {
+        applyCliFilesystemAccess(args, hideBin(argv));
+      }
       // We can't set default in the options else
       // Yargs will complain
       if (

--- a/src/daemon/utils.ts
+++ b/src/daemon/utils.ts
@@ -132,6 +132,12 @@ export function serializeArgs(
       continue;
     }
     const value = argv[key];
+    const option = options[key];
+    // Yargs reuses the option `default` object; skip it so the daemon parser
+    // still sees the original default (needed for filesystemRoot identity).
+    if (option !== undefined && value === option.default) {
+      continue;
+    }
     const kebabKey = key.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`);
 
     if (typeof value === 'boolean') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,12 +55,11 @@ export class McpServer {
   #serverArgs: ParsedArguments;
   #options: McpServerOptions;
   #context?: McpContext;
-  #configuredRoots: Root[];
 
   /**
    * Client roots stay valid across browser reconnects and only the client can
-   * invalidate them through a `roots/list_changed` notification. Explicitly
-   * configured roots are process state and are always included.
+   * invalidate them through a `roots/list_changed` notification. CLI-configured
+   * roots are read from `#serverArgs` when combining roots.
    */
   #lastClientRoots?: Root[];
   #toolMutex = new Mutex();
@@ -71,15 +70,6 @@ export class McpServer {
   ) {
     this.#serverArgs = serverArgs;
     this.#options = options;
-    this.#configuredRoots = (
-      serverArgs.allowUnrestrictedPaths ? [] : (serverArgs.filesystemRoot ?? [])
-    ).map(root => {
-      const rootPath = path.resolve(String(root));
-      return {
-        uri: pathToFileURL(rootPath).href,
-        name: path.basename(rootPath) || rootPath,
-      };
-    });
 
     if (this.#serverArgs.usageStatistics) {
       ClearcutLogger.initialize({
@@ -121,7 +111,7 @@ export class McpServer {
         );
       } else if (
         !this.#serverArgs.allowUnrestrictedPaths &&
-        this.#configuredRoots.length === 0
+        (this.#serverArgs.filesystemRoot ?? []).length === 0
       ) {
         console.warn(
           '[chrome-devtools-mcp] The connecting client did not negotiate the MCP roots ' +
@@ -174,13 +164,21 @@ export class McpServer {
   }
 
   #combinedRoots(): Root[] | undefined {
-    if (
-      this.#configuredRoots.length === 0 &&
-      this.#lastClientRoots === undefined
-    ) {
+    const configuredRoots = (
+      this.#serverArgs.allowUnrestrictedPaths
+        ? []
+        : (this.#serverArgs.filesystemRoot ?? [])
+    ).map(root => {
+      const rootPath = path.resolve(String(root));
+      return {
+        uri: pathToFileURL(rootPath).href,
+        name: path.basename(rootPath) || rootPath,
+      };
+    });
+    if (configuredRoots.length === 0 && this.#lastClientRoots === undefined) {
       return undefined;
     }
-    return [...this.#configuredRoots, ...(this.#lastClientRoots ?? [])];
+    return [...configuredRoots, ...(this.#lastClientRoots ?? [])];
   }
 
   /**
@@ -279,9 +277,6 @@ export class McpServer {
         // never pays for a client round-trip
         void this.#updateRoots();
       }
-    }
-    if (this.#context === undefined) {
-      throw new Error('MCP context was not initialized');
     }
     return this.#context;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@
  */
 
 import type fs from 'node:fs';
+import path from 'node:path';
+import {pathToFileURL} from 'node:url';
 
 import type {Channel} from './browser.js';
 import {ensureBrowserConnected, ensureBrowserLaunched} from './browser.js';
@@ -53,13 +55,14 @@ export class McpServer {
   #serverArgs: ParsedArguments;
   #options: McpServerOptions;
   #context?: McpContext;
+  #configuredRoots: Root[];
 
   /**
-   * Roots are client state rather than browser state, so the last listing stays
-   * valid across browser reconnects and only the client can invalidate it, via
-   * the `roots/list_changed` notification handled below
+   * Client roots stay valid across browser reconnects and only the client can
+   * invalidate them through a `roots/list_changed` notification. Explicitly
+   * configured roots are process state and are always included.
    */
-  #lastRoots?: Root[];
+  #lastClientRoots?: Root[];
   #toolMutex = new Mutex();
 
   private constructor(
@@ -68,6 +71,13 @@ export class McpServer {
   ) {
     this.#serverArgs = serverArgs;
     this.#options = options;
+    this.#configuredRoots = (serverArgs.filesystemRoot ?? []).map(root => {
+      const rootPath = path.resolve(String(root));
+      return {
+        uri: pathToFileURL(rootPath).href,
+        name: path.basename(rootPath) || rootPath,
+      };
+    });
 
     if (this.#serverArgs.usageStatistics) {
       ClearcutLogger.initialize({
@@ -107,7 +117,10 @@ export class McpServer {
             void this.#updateRoots();
           },
         );
-      } else if (!this.#serverArgs.allowUnrestrictedPaths) {
+      } else if (
+        !this.#serverArgs.allowUnrestrictedPaths &&
+        this.#configuredRoots.length === 0
+      ) {
         console.warn(
           '[chrome-devtools-mcp] The connecting client did not negotiate the MCP roots ' +
             'capability. File-writing tools will be restricted to the OS temp directory. ' +
@@ -158,6 +171,16 @@ export class McpServer {
     await loadIssueDescriptions();
   }
 
+  #combinedRoots(): Root[] | undefined {
+    if (
+      this.#configuredRoots.length === 0 &&
+      this.#lastClientRoots === undefined
+    ) {
+      return undefined;
+    }
+    return [...this.#configuredRoots, ...(this.#lastClientRoots ?? [])];
+  }
+
   /**
    * `timeout` is only passed where a tool call is waiting on the result – the
    * background refreshes below block nobody, so bounding them would just discard
@@ -173,8 +196,8 @@ export class McpServer {
         ListRootsResultSchema,
         timeout === undefined ? undefined : {timeout},
       );
-      this.#lastRoots = roots.roots;
-      this.#context?.setRoots(this.#lastRoots);
+      this.#lastClientRoots = roots.roots;
+      this.#context?.setRoots(this.#combinedRoots());
     } catch (e) {
       logger?.('Failed to list roots', e);
     }
@@ -244,16 +267,19 @@ export class McpServer {
         // Surfaces a one-time note in the next response after a reconnect.
         reconnected: this.#context !== undefined,
       });
-      if (this.#lastRoots === undefined) {
+      this.#context.setRoots(this.#combinedRoots());
+      if (this.#lastClientRoots === undefined) {
         // Nothing listed yet, so this call has to wait – bounded, since it is
         // holding the tool mutex, and a later background refresh still lands
         await this.#updateRoots(ROOTS_REQUEST_TIMEOUT);
       } else {
         // Carry the known roots over and refresh out of band, so a reconnect
         // never pays for a client round-trip
-        this.#context.setRoots(this.#lastRoots);
         void this.#updateRoots();
       }
+    }
+    if (this.#context === undefined) {
+      throw new Error('MCP context was not initialized');
     }
     return this.#context;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,9 @@ export class McpServer {
   ) {
     this.#serverArgs = serverArgs;
     this.#options = options;
-    this.#configuredRoots = (serverArgs.filesystemRoot ?? []).map(root => {
+    this.#configuredRoots = (
+      serverArgs.allowUnrestrictedPaths ? [] : (serverArgs.filesystemRoot ?? [])
+    ).map(root => {
       const rootPath = path.resolve(String(root));
       return {
         uri: pathToFileURL(rootPath).href,

--- a/src/telemetry/flag_usage_metrics.json
+++ b/src/telemetry/flag_usage_metrics.json
@@ -401,5 +401,9 @@
   {
     "name": "experimental_screencast_fps_present",
     "flagType": "boolean"
+  },
+  {
+    "name": "filesystem_root_present",
+    "flagType": "boolean"
   }
 ]

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,6 +5,7 @@
  */
 
 import assert from 'node:assert';
+import os from 'node:os';
 import {describe, it} from 'node:test';
 
 import {mcpOptions, parser} from '../src/config/mcp-options.js';
@@ -28,6 +29,7 @@ describe('cli args parsing', () => {
     javascriptEvaluation: true,
     redactNetworkHeaders: false,
     allowUnrestrictedPaths: false,
+    filesystemRoot: [os.tmpdir()],
     memoryDebugging: false,
     experimentalStructuredContent: false,
     pageIdRouting: true,
@@ -164,6 +166,17 @@ describe('cli args parsing', () => {
       '--workspace=/tmp/two',
     ]);
     assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one', '/tmp/two']);
+  });
+
+  it('rejects filesystem roots with unrestricted paths', async () => {
+    assert.throws(() => {
+      parseArguments(['--workspace=/', '--allow-unrestricted-paths']);
+    }, /filesystemRoot and allowUnrestrictedPaths are mutually exclusive/);
+  });
+
+  it('still accepts unrestricted paths without an explicit root', async () => {
+    const args = parseArguments(['--allow-unrestricted-paths']);
+    assert.strictEqual(args.allowUnrestrictedPaths, true);
   });
 
   it('parses ignore chrome args', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -152,42 +152,49 @@ describe('cli args parsing', () => {
     });
   });
 
-  it('parses filesystem roots', async () => {
-    const args = parseArguments([
-      '--filesystem-root=/tmp/one',
-      '--filesystem-root=/tmp/two',
-    ]);
-    assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one', '/tmp/two']);
-  });
+  describe('filesystem roots', () => {
+    it('parses filesystem roots', async () => {
+      const args = parseArguments([
+        '--filesystem-root=/tmp/one',
+        '--filesystem-root=/tmp/two',
+      ]);
+      assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one', '/tmp/two']);
+    });
 
-  it('parses workspace as an alias for filesystem roots', async () => {
-    const args = parseArguments([
-      '--workspace=/tmp/one',
-      '--workspace=/tmp/two',
-    ]);
-    assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one', '/tmp/two']);
-  });
+    it('parses workspace as an alias for filesystem roots', async () => {
+      const args = parseArguments([
+        '--workspace=/tmp/one',
+        '--workspace=/tmp/two',
+      ]);
+      assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one', '/tmp/two']);
+    });
 
-  it('rejects filesystem roots with unrestricted paths', async () => {
-    assert.throws(() => {
-      parseArguments(['--workspace=/', '--allow-unrestricted-paths']);
-    }, /filesystemRoot and allowUnrestrictedPaths are mutually exclusive/);
-  });
+    it('still accepts unrestricted paths without an explicit root', async () => {
+      const args = parseArguments(['--allow-unrestricted-paths']);
+      assert.strictEqual(args.allowUnrestrictedPaths, true);
+    });
 
-  it('still accepts unrestricted paths without an explicit root', async () => {
-    const args = parseArguments(['--allow-unrestricted-paths']);
-    assert.strictEqual(args.allowUnrestrictedPaths, true);
-  });
+    it('lets an explicit workspace override the CLI unrestricted default', async () => {
+      const args = parseArguments(['--viaCli', '--workspace=/tmp/one']);
+      assert.strictEqual(args.allowUnrestrictedPaths, false);
+      assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one']);
+    });
 
-  it('lets an explicit workspace override the CLI unrestricted default', async () => {
-    const args = parseArguments(['--viaCli', '--workspace=/tmp/one']);
-    assert.strictEqual(args.allowUnrestrictedPaths, false);
-    assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one']);
-  });
+    it('keeps the CLI unrestricted default when no workspace is set', async () => {
+      const args = parseArguments(['--viaCli']);
+      assert.strictEqual(args.allowUnrestrictedPaths, true);
+      assert.strictEqual(args.filesystemRoot, undefined);
+    });
 
-  it('keeps the CLI unrestricted default when no workspace is set', async () => {
-    const args = parseArguments(['--viaCli']);
-    assert.strictEqual(args.allowUnrestrictedPaths, true);
+    it('passes explicit workspace roots along when unrestricted is also set', async () => {
+      const args = parseArguments([
+        '--viaCli',
+        '--workspace=/tmp/one',
+        '--allow-unrestricted-paths',
+      ]);
+      assert.strictEqual(args.allowUnrestrictedPaths, false);
+      assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one']);
+    });
   });
 
   it('parses ignore chrome args', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -179,6 +179,17 @@ describe('cli args parsing', () => {
     assert.strictEqual(args.allowUnrestrictedPaths, true);
   });
 
+  it('lets an explicit workspace override the CLI unrestricted default', async () => {
+    const args = parseArguments(['--viaCli', '--workspace=/tmp/one']);
+    assert.strictEqual(args.allowUnrestrictedPaths, false);
+    assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one']);
+  });
+
+  it('keeps the CLI unrestricted default when no workspace is set', async () => {
+    const args = parseArguments(['--viaCli']);
+    assert.strictEqual(args.allowUnrestrictedPaths, true);
+  });
+
   it('parses ignore chrome args', async () => {
     const args = parseArguments([
       `--ignore-default-chrome-arg='--disable-extensions'`,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -150,6 +150,22 @@ describe('cli args parsing', () => {
     });
   });
 
+  it('parses filesystem roots', async () => {
+    const args = parseArguments([
+      '--filesystem-root=/tmp/one',
+      '--filesystem-root=/tmp/two',
+    ]);
+    assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one', '/tmp/two']);
+  });
+
+  it('parses workspace as an alias for filesystem roots', async () => {
+    const args = parseArguments([
+      '--workspace=/tmp/one',
+      '--workspace=/tmp/two',
+    ]);
+    assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one', '/tmp/two']);
+  });
+
   it('parses ignore chrome args', async () => {
     const args = parseArguments([
       `--ignore-default-chrome-arg='--disable-extensions'`,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,10 +5,13 @@
  */
 
 import assert from 'node:assert';
-import os from 'node:os';
 import {describe, it} from 'node:test';
 
-import {mcpOptions, parser} from '../src/config/mcp-options.js';
+import {
+  DEFAULT_FILESYSTEM_ROOT,
+  mcpOptions,
+  parser,
+} from '../src/config/mcp-options.js';
 
 function parseArguments(argv: string[], env: NodeJS.ProcessEnv = {}) {
   return parser('0.0.0', ['node', 'main.js', ...argv], env)
@@ -29,7 +32,7 @@ describe('cli args parsing', () => {
     javascriptEvaluation: true,
     redactNetworkHeaders: false,
     allowUnrestrictedPaths: false,
-    filesystemRoot: [os.tmpdir()],
+    filesystemRoot: DEFAULT_FILESYSTEM_ROOT,
     memoryDebugging: false,
     experimentalStructuredContent: false,
     pageIdRouting: true,
@@ -186,14 +189,9 @@ describe('cli args parsing', () => {
       assert.strictEqual(args.filesystemRoot, undefined);
     });
 
-    it('passes explicit workspace roots along when unrestricted is also set', async () => {
-      const args = parseArguments([
-        '--viaCli',
-        '--workspace=/tmp/one',
-        '--allow-unrestricted-paths',
-      ]);
-      assert.strictEqual(args.allowUnrestrictedPaths, false);
-      assert.deepStrictEqual(args.filesystemRoot, ['/tmp/one']);
+    it('uses yargs default identity to detect an unset CLI workspace', async () => {
+      const args = parseArguments([]);
+      assert.strictEqual(args.filesystemRoot, DEFAULT_FILESYSTEM_ROOT);
     });
   });
 

--- a/tests/e2e/chrome-devtools-start-stop.test.ts
+++ b/tests/e2e/chrome-devtools-start-stop.test.ts
@@ -98,7 +98,8 @@ describe('chrome-devtools', () => {
       const statusResult = await runCli(['status'], sessionId);
       assert.strictEqual(statusResult.status, 0);
       assert.ok(
-        statusResult.stdout.includes(`--filesystem-root=${workspace}`),
+        statusResult.stdout.includes('--filesystem-root=') &&
+          statusResult.stdout.includes(path.basename(workspace)),
         `workspace was not forwarded: ${statusResult.stdout}`,
       );
     } finally {

--- a/tests/e2e/chrome-devtools-start-stop.test.ts
+++ b/tests/e2e/chrome-devtools-start-stop.test.ts
@@ -78,4 +78,31 @@ describe('chrome-devtools', () => {
 
     await assertDaemonIsRunning(sessionId);
   });
+
+  it('can start the daemon with a workspace', async () => {
+    const workspace = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chrome-devtools-workspace-'),
+    );
+
+    try {
+      const startResult = await runCli(
+        ['start', '--workspace', workspace],
+        sessionId,
+      );
+      assert.strictEqual(
+        startResult.status,
+        0,
+        `start command failed: ${startResult.stderr}`,
+      );
+
+      const statusResult = await runCli(['status'], sessionId);
+      assert.strictEqual(statusResult.status, 0);
+      assert.ok(
+        statusResult.stdout.includes(`--filesystem-root=${workspace}`),
+        `workspace was not forwarded: ${statusResult.stdout}`,
+      );
+    } finally {
+      fs.rmSync(workspace, {recursive: true, force: true});
+    }
+  });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -246,6 +246,51 @@ describe('e2e', () => {
     );
   });
 
+  it('combines configured filesystem roots with client roots', async () => {
+    const configuredRoot = await fs.promises.mkdtemp(
+      path.join(os.homedir(), '.configured-root-'),
+    );
+    const clientRoot = await fs.promises.mkdtemp(
+      path.join(os.homedir(), '.client-root-'),
+    );
+
+    try {
+      await withClient(
+        async client => {
+          client.setRequestHandler(ListRootsRequestSchema, () => {
+            return {
+              roots: [
+                {uri: pathToFileURL(clientRoot).href, name: 'client-root'},
+              ],
+            };
+          });
+
+          for (const outputPath of [
+            path.join(configuredRoot, 'configured.png'),
+            path.join(clientRoot, 'client.png'),
+          ]) {
+            const result = await client.callTool({
+              name: 'take_screenshot',
+              arguments: {pageId: 1, filePath: outputPath},
+            });
+            assert.strictEqual(result.isError, undefined);
+            const content = result.content as TextContent[];
+            assert.match(content[0].text, /Saved screenshot to/);
+          }
+        },
+        [`--filesystem-root=${configuredRoot}`],
+        {
+          capabilities: {
+            roots: {listChanged: true},
+          },
+        },
+      );
+    } finally {
+      await fs.promises.rm(configuredRoot, {recursive: true, force: true});
+      await fs.promises.rm(clientRoot, {recursive: true, force: true});
+    }
+  });
+
   it('denies file access if roots list is empty', async () => {
     await withClient(
       async client => {


### PR DESCRIPTION
Fixes #2598

This lets people set filesystem roots through the MCP server or the Chrome DevTools CLI. Multiple roots work together with any roots sent by the MCP client, and temp directory access stays the same.

I added tests for the flags and root handling.