### PR TITLE
feat(screenshot): add omitBackground parameter to take_screenshot

### DIFF
--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -173,6 +173,12 @@ export const screenshot = definePageTool(args => {
         .describe(
           'The absolute path, or a path relative to the current working directory, to save the screenshot to instead of attaching it to the response.',
         ),
+      omitBackground: zod
+        .boolean()
+        .optional()
+        .describe(
+          'Hides the default white background and allows capturing transparent backgrounds or CSS backgrounds behind transparent elements.',
+        ),
     },
     blockedByDialog: true,
     verifyFilesSchema: {
@@ -194,6 +200,7 @@ export const screenshot = definePageTool(args => {
           ? undefined
           : (request.params.quality ?? screenshotQuality);
       const fullPage = request.params.fullPage ?? false;
+      const omitBackground = request.params.omitBackground;
 
       // `getElementByUid` mints a fresh ElementHandle per call, so dispose it
       // once the capture is done to avoid leaking a remote object for the life
@@ -229,12 +236,14 @@ export const screenshot = definePageTool(args => {
           quality,
           optimizeForSpeed: true,
           clip,
+          omitBackground,
         });
       } else if (element) {
         screenshot = await element.screenshot({
           type: format,
           quality,
           optimizeForSpeed: true,
+          omitBackground,
         });
       } else {
         screenshot = await page.screenshot({
@@ -242,6 +251,7 @@ export const screenshot = definePageTool(args => {
           fullPage,
           quality,
           optimizeForSpeed: true,
+          omitBackground,
         });
       }
 

--- a/tests/tools/screenshot.test.ts
+++ b/tests/tools/screenshot.test.ts
@@ -60,6 +60,28 @@ describe('screenshot', () => {
         );
       });
     });
+    it('with omitBackground option', async () => {
+      await withMcpContext(async (response, context) => {
+        const fixture = screenshots.basic;
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(fixture.html);
+        await screenshotTool.handler(
+          {
+            params: {format: 'png', omitBackground: true},
+            page: context.getSelectedMcpPage(),
+          },
+          response,
+          context,
+        );
+
+        assert.equal(response.images.length, 1);
+        assert.equal(response.images[0].mimeType, 'image/png');
+        assert.equal(
+          response.responseLines.at(0),
+          "Took a screenshot of the current page's viewport.",
+        );
+      });
+    });
     it('ignores quality', async () => {
       await withMcpContext(async (response, context) => {
         const fixture = screenshots.basic;


### PR DESCRIPTION
Fixes #806

Adds an optional `omitBackground` boolean parameter to `take_screenshot`. When `true`, hides the default white background so CSS backgrounds behind transparent canvas elements (Cytoscape.js, Chart.js, Three.js, etc.) render correctly in screenshots.
