### PR TITLE
fix: new flags for page id routing moved to the end of metrics json

### DIFF
--- a/src/telemetry/flag_usage_metrics.json
+++ b/src/telemetry/flag_usage_metrics.json
@@ -303,14 +303,6 @@
     "flagType": "boolean"
   },
   {
-    "name": "page_id_routing_present",
-    "flagType": "boolean"
-  },
-  {
-    "name": "page_id_routing",
-    "flagType": "boolean"
-  },
-  {
     "name": "memory_debugging_present",
     "flagType": "boolean"
   },
@@ -388,6 +380,14 @@
   },
   {
     "name": "category_pwa",
+    "flagType": "boolean"
+  },
+  {
+    "name": "page_id_routing_present",
+    "flagType": "boolean"
+  },
+  {
+    "name": "page_id_routing",
     "flagType": "boolean"
   }
 ]


### PR DESCRIPTION
Follow up #1777 

The flags for page id routing were added to the middle of flag_usage_metrics.json. This change moves them to the end