### PR TITLE
feat(performance): set default trace buffer size to match DevTools (1.2gb)

### DIFF
--- a/src/tools/performance.ts
+++ b/src/tools/performance.ts
@@ -81,6 +81,7 @@ export const startTrace = definePageTool({
       ];
       await page.pptrPage.tracing.start({
         categories,
+        bufferSize: 1200 * 1000,
       });
 
       if (request.params.reload) {

--- a/tests/tools/performance.test.ts
+++ b/tests/tools/performance.test.ts
@@ -67,6 +67,7 @@ describe('performance', () => {
             ...DevTools.TracingOptionalCategories.JsSampling,
             ...DevTools.TracingOptionalCategories.Screenshot,
           ],
+          bufferSize: 1200 * 1000,
         });
         assert.ok(context.isRunningPerformanceTrace());
         assert.ok(


### PR DESCRIPTION
Align the trace buffer size configured during performance trace recording with the 1.2 GB (1,200,000 KB) buffer size used by DevTools TracingManager. This prevents traces from overflowing the default 200 MB buffer during longer recordings.