### PR TITLE
fix(memory): expliclity mention the need of a flag

### DIFF
--- a/skills/memory-leak-debugging/SKILL.md
+++ b/skills/memory-leak-debugging/SKILL.md
@@ -7,6 +7,10 @@ description: Diagnoses and resolves memory leaks in JavaScript/Node.js applicati
 
 This skill provides expert guidance and workflows for finding, diagnosing, and fixing memory leaks in JavaScript and Node.js applications using Chrome DevTools MCP tools.
 
+## Prerequisites
+
+Advanced memory debugging tools (`compare_heapsnapshot`, `get_heapsnapshot_details`, etc.) are only available when the server is started with the `--memoryDebugging` flag.
+
 ## Core Principles
 
 - **Prefer MCP memory tools:** Do NOT attempt to read raw `.heapsnapshot` files directly, as they are extremely large and will consume too many tokens. Use the Chrome DevTools MCP heap snapshot tools to summarize, compare, and inspect snapshots.

--- a/skills/memory-leak-debugging/SKILL.md
+++ b/skills/memory-leak-debugging/SKILL.md
@@ -9,7 +9,7 @@ This skill provides expert guidance and workflows for finding, diagnosing, and f
 
 ## Prerequisites
 
-Advanced memory debugging tools (`compare_heapsnapshot`, `get_heapsnapshot_details`, etc.) are only available when the server is started with the `--memoryDebugging` flag.
+Advanced memory debugging tools (`compare_heapsnapshots`, `get_heapsnapshot_details`, etc.) are only available when the server is started with the `--memoryDebugging` flag. First check if these tools are available; if not, try to read the MCP configuration file to check if `--memoryDebugging` is enabled.
 
 ## Core Principles
 


### PR DESCRIPTION
Currently if the generic DevTools SKILL is not in the context the LLM just drop trying to find the tools. 
Giving this hit allows it to prompt the user for a change. This still will require a restart for now.