### PR TITLE
feat(cli): persist startup defaults from XDG config

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,27 @@ chrome-devtools take_screenshot 1 --filePath screenshot.png
 chrome-devtools stop
 ```
 
+## Startup defaults
+
+You can persist options used to start the daemon in an XDG-compatible configuration file at `$XDG_CONFIG_HOME/chrome-devtools/config.json`, or `~/.config/chrome-devtools/config.json` when `XDG_CONFIG_HOME` is not set.
+
+The file contains a JSON object whose keys match the options accepted by `chrome-devtools start`. Run `chrome-devtools start --help` for the supported options.
+
+```json
+{
+  "executablePath": "/usr/bin/chromium",
+  "headless": false
+}
+```
+
+These defaults apply both when a tool command automatically starts the daemon and when `chrome-devtools start` is invoked explicitly. Precedence is:
+
+```text
+explicit command-line options > configuration file > built-in defaults
+```
+
+`chrome-devtools status` reports the effective daemon arguments after this merge.
+
 ## Command Usage
 
 The CLI only supports tools available in the MCP server without additional arguments (see [Tool reference](./tool-reference.md)).

--- a/skills/chrome-devtools-cli/SKILL.md
+++ b/skills/chrome-devtools-cli/SKILL.md
@@ -190,3 +190,5 @@ chrome-devtools start --headless=false # Start with visible browser window
 chrome-devtools status  # Checks if chrome-devtools-mcp is running
 chrome-devtools stop    # Stop chrome-devtools-mcp if any
 ```
+
+Persist daemon startup defaults in `$XDG_CONFIG_HOME/chrome-devtools/config.json` (or `~/.config/chrome-devtools/config.json`). Keys match `chrome-devtools start` options. Command-line flags override the file; the file overrides built-in defaults. The same file is used when a tool command auto-starts the daemon.

--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -30,12 +30,14 @@ import {hideBin, yargs, type CallToolResult} from '../third_party/index.js';
 import {checkForUpdates} from '../utils/check-for-updates.js';
 import {VERSION} from '../version.js';
 
-import {commands} from '../config/cli-options.js';
 import {
-  mcpOptions,
-  parseArguments,
-  getMcpOptionsForViaCli,
-} from '../config/mcp-options.js';
+  applyCliStartDefaults,
+  getCliStartOptions,
+  readCliConfig,
+  resolveCliStartArgs,
+} from '../config/cli-config.js';
+import {commands} from '../config/cli-options.js';
+import {mcpOptions, parseArguments} from '../config/mcp-options.js';
 
 await checkForUpdates(
   'Run `npm install -g chrome-devtools-mcp@latest` and `chrome-devtools start` to update and restart the daemon.',
@@ -47,21 +49,6 @@ async function start(args: string[], sessionId: string) {
   const combinedArgs = [...DEFAULT_CLI_ARGS, ...args];
   await startDaemon(combinedArgs, sessionId);
   logDisclaimers(parseArguments(VERSION, combinedArgs));
-}
-
-function getCliOptions() {
-  const options: Partial<typeof mcpOptions> = {
-    ...getMcpOptionsForViaCli(),
-  };
-
-  // Missing CLI serialization.
-  delete options.viewport;
-
-  // Change the defaults for the CLI.
-  delete options.experimentalStructuredContent;
-  delete options.experimentalInteropTools;
-
-  return options;
 }
 
 const y = yargs(hideBin(process.argv))
@@ -127,7 +114,8 @@ y.command(
   'Start or restart chrome-devtools-mcp',
   y =>
     y
-      .options(getCliOptions())
+      .options(getCliStartOptions())
+      .config(readCliConfig())
       .example(
         '$0 start --browserUrl http://localhost:9222',
         'Start the server connecting to an existing browser',
@@ -137,24 +125,7 @@ y.command(
     if (isDaemonRunning(argv.sessionId)) {
       await stopDaemon(argv.sessionId);
     }
-    // Defaults but we do not want to affect the yargs conflict resolution.
-    if (
-      argv.isolated === undefined &&
-      argv.userDataDir === undefined &&
-      !argv.autoConnect &&
-      !argv.browserUrl &&
-      !argv.wsEndpoint
-    ) {
-      argv.isolated = true;
-    }
-    if (
-      argv.headless === undefined &&
-      !argv.autoConnect &&
-      !argv.browserUrl &&
-      !argv.wsEndpoint
-    ) {
-      argv.headless = true;
-    }
+    applyCliStartDefaults(argv);
     const args = serializeArgs(mcpOptions, argv);
     await start(args, argv.sessionId);
     process.exit(0);
@@ -282,7 +253,7 @@ for (const [commandName, commandDef] of Object.entries(commands)) {
           : Promise.resolve(undefined);
 
         if (!isDaemonRunning(sessionId)) {
-          await start(serializeArgs(mcpOptions, argv), sessionId);
+          await start(resolveCliStartArgs([], readCliConfig()), sessionId);
         }
 
         const commandArgs: Record<string, unknown> = {};

--- a/src/config/cli-config.ts
+++ b/src/config/cli-config.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import {serializeArgs} from '../daemon/utils.js';
+import {yargs} from '../third_party/index.js';
+
+import {getMcpOptionsForViaCli, mcpOptions} from './mcp-options.js';
+
+export function getCliConfigPath(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDirectory = os.homedir(),
+): string {
+  const configHome =
+    env['XDG_CONFIG_HOME'] || path.join(homeDirectory, '.config');
+  return path.join(configHome, 'chrome-devtools', 'config.json');
+}
+
+export function readCliConfig(
+  configPath = getCliConfigPath(),
+): Record<string, unknown> {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(configPath, 'utf8');
+  } catch (error) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return {};
+    }
+    throw new Error(
+      `Failed to read Chrome DevTools CLI config at ${configPath}: ${getErrorMessage(error)}`,
+      {cause: error},
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse Chrome DevTools CLI config at ${configPath}: ${getErrorMessage(error)}`,
+      {cause: error},
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(
+      `Chrome DevTools CLI config at ${configPath} must contain a JSON object`,
+    );
+  }
+  return parsed;
+}
+
+export function getCliStartOptions(): Partial<typeof mcpOptions> {
+  const options: Partial<typeof mcpOptions> = {
+    ...getMcpOptionsForViaCli(),
+  };
+
+  // Missing CLI serialization.
+  delete options.viewport;
+
+  // Change the defaults for the CLI.
+  delete options.experimentalStructuredContent;
+  delete options.experimentalInteropTools;
+
+  return options;
+}
+
+export function applyCliStartDefaults(argv: {
+  isolated?: unknown;
+  userDataDir?: unknown;
+  autoConnect?: unknown;
+  browserUrl?: unknown;
+  wsEndpoint?: unknown;
+  headless?: unknown;
+}): void {
+  // Defaults but we do not want to affect the yargs conflict resolution.
+  if (
+    argv.isolated === undefined &&
+    argv.userDataDir === undefined &&
+    !argv.autoConnect &&
+    !argv.browserUrl &&
+    !argv.wsEndpoint
+  ) {
+    argv.isolated = true;
+  }
+  if (
+    argv.headless === undefined &&
+    !argv.autoConnect &&
+    !argv.browserUrl &&
+    !argv.wsEndpoint
+  ) {
+    argv.headless = true;
+  }
+}
+
+export function parseCliStartArgv(
+  argv: string[] = [],
+  config: Record<string, unknown> = {},
+) {
+  const parsed = yargs(argv)
+    .locale('en')
+    .scriptName('chrome-devtools')
+    .options(getCliStartOptions())
+    .config(config)
+    .strict()
+    .exitProcess(false)
+    .fail((message, error) => {
+      throw error ?? new Error(message);
+    })
+    .parseSync();
+  applyCliStartDefaults(parsed);
+  return parsed;
+}
+
+export function resolveCliStartArgs(
+  argv: string[] = [],
+  config: Record<string, unknown> = {},
+): string[] {
+  return serializeArgs(mcpOptions, parseCliStartArgv(argv, config));
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/tests/cli-config.test.ts
+++ b/tests/cli-config.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, describe, it} from 'node:test';
+
+import {
+  getCliConfigPath,
+  readCliConfig,
+  resolveCliStartArgs,
+} from '../src/config/cli-config.js';
+
+describe('Chrome DevTools CLI config', () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories) {
+      fs.rmSync(directory, {recursive: true, force: true});
+    }
+    temporaryDirectories.length = 0;
+  });
+
+  function createTemporaryDirectory(): string {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chrome-devtools-cli-config-test-'),
+    );
+    temporaryDirectories.push(directory);
+    return directory;
+  }
+
+  it('uses XDG_CONFIG_HOME when set', () => {
+    assert.strictEqual(
+      getCliConfigPath(
+        {XDG_CONFIG_HOME: '/tmp/xdg-config'},
+        '/tmp/home-directory',
+      ),
+      path.join('/tmp/xdg-config', 'chrome-devtools', 'config.json'),
+    );
+  });
+
+  it('falls back to the home config directory', () => {
+    assert.strictEqual(
+      getCliConfigPath({}, '/tmp/home-directory'),
+      path.join(
+        '/tmp/home-directory',
+        '.config',
+        'chrome-devtools',
+        'config.json',
+      ),
+    );
+  });
+
+  it('falls back to the home config directory when XDG_CONFIG_HOME is empty', () => {
+    assert.strictEqual(
+      getCliConfigPath({XDG_CONFIG_HOME: ''}, '/tmp/home-directory'),
+      path.join(
+        '/tmp/home-directory',
+        '.config',
+        'chrome-devtools',
+        'config.json',
+      ),
+    );
+  });
+
+  it('returns an empty config when the file does not exist', () => {
+    const configPath = path.join(createTemporaryDirectory(), 'config.json');
+    assert.deepStrictEqual(readCliConfig(configPath), {});
+  });
+
+  it('reads a JSON config object', () => {
+    const configPath = path.join(createTemporaryDirectory(), 'config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({executablePath: '/usr/bin/chromium', headless: false}),
+    );
+
+    assert.deepStrictEqual(readCliConfig(configPath), {
+      executablePath: '/usr/bin/chromium',
+      headless: false,
+    });
+  });
+
+  it('rejects invalid JSON', () => {
+    const configPath = path.join(createTemporaryDirectory(), 'config.json');
+    fs.writeFileSync(configPath, '{');
+
+    assert.throws(
+      () => readCliConfig(configPath),
+      /Failed to parse Chrome DevTools CLI config/,
+    );
+  });
+
+  it('rejects a non-object config', () => {
+    const configPath = path.join(createTemporaryDirectory(), 'config.json');
+    fs.writeFileSync(configPath, '[]');
+
+    assert.throws(
+      () => readCliConfig(configPath),
+      /must contain a JSON object/,
+    );
+  });
+
+  it('rejects unknown start options in the config', () => {
+    assert.throws(
+      () => resolveCliStartArgs([], {notAStartOption: true}),
+      /Unknown argument/,
+    );
+  });
+
+  it('reuses start option validation for config values', () => {
+    assert.throws(
+      () => resolveCliStartArgs([], {browserUrl: 'not-a-url'}),
+      /not valid URL/,
+    );
+  });
+});
+
+describe('Chrome DevTools CLI start arg precedence', () => {
+  it('serializes configured start options for automatic daemon startup', () => {
+    const args = resolveCliStartArgs([], {
+      executablePath: '/usr/bin/chromium',
+      headless: false,
+    });
+
+    assert.ok(args.includes('--executable-path=/usr/bin/chromium'));
+    assert.ok(args.includes('--no-headless'));
+    assert.ok(!args.includes('--headless'));
+  });
+
+  it('lets command-line options override configuration values', () => {
+    const args = resolveCliStartArgs(['--headless=true'], {headless: false});
+
+    assert.ok(args.includes('--headless'));
+    assert.ok(!args.includes('--no-headless'));
+  });
+
+  it('lets configuration values override built-in defaults', () => {
+    const defaultArgs = resolveCliStartArgs([]);
+    assert.ok(defaultArgs.includes('--headless'));
+    assert.ok(defaultArgs.includes('--isolated'));
+
+    const configuredArgs = resolveCliStartArgs([], {
+      headless: false,
+      isolated: false,
+    });
+    assert.ok(configuredArgs.includes('--no-headless'));
+    assert.ok(configuredArgs.includes('--no-isolated'));
+    assert.ok(!configuredArgs.includes('--headless'));
+    assert.ok(!configuredArgs.includes('--isolated'));
+  });
+
+  it('does not enable isolated when userDataDir is configured', () => {
+    const args = resolveCliStartArgs([], {userDataDir: '/tmp/chrome-profile'});
+
+    assert.ok(args.includes('--user-data-dir=/tmp/chrome-profile'));
+    assert.ok(!args.includes('--isolated'));
+  });
+});

--- a/tests/e2e/chrome-devtools-commands.test.ts
+++ b/tests/e2e/chrome-devtools-commands.test.ts
@@ -6,6 +6,10 @@
 
 import assert from 'node:assert';
 import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
 import {describe, it, afterEach, beforeEach} from 'node:test';
 
 import {
@@ -50,6 +54,38 @@ describe('chrome-devtools', () => {
     );
 
     await assertDaemonIsRunning(sessionId);
+  });
+
+  it('uses config defaults when automatically starting the daemon', async () => {
+    const configHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chrome-devtools-cli-config-test-'),
+    );
+    const configDirectory = path.join(configHome, 'chrome-devtools');
+    const userDataDir = path.join(configHome, 'chrome-profile');
+    fs.mkdirSync(configDirectory);
+    fs.mkdirSync(userDataDir);
+    fs.writeFileSync(
+      path.join(configDirectory, 'config.json'),
+      JSON.stringify({userDataDir, categoryNetwork: false}),
+    );
+    const env = {...process.env, XDG_CONFIG_HOME: configHome};
+
+    try {
+      const listPagesResult = await runCli(['list_pages'], sessionId, env);
+      assert.strictEqual(
+        listPagesResult.status,
+        0,
+        `list_pages command failed: ${listPagesResult.stderr}`,
+      );
+
+      const statusResult = await runCli(['status'], sessionId, env);
+      assert.ok(
+        statusResult.stdout.includes(`"--user-data-dir=${userDataDir}"`),
+      );
+      assert.match(statusResult.stdout, /"--no-category-network"/);
+    } finally {
+      fs.rmSync(configHome, {recursive: true, force: true});
+    }
   });
 
   it('can take screenshot', async () => {

--- a/tests/e2e/chrome-devtools-start-stop.test.ts
+++ b/tests/e2e/chrome-devtools-start-stop.test.ts
@@ -9,6 +9,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 import {describe, it, afterEach, beforeEach} from 'node:test';
 
 import {
@@ -77,5 +78,66 @@ describe('chrome-devtools', () => {
     );
 
     await assertDaemonIsRunning(sessionId);
+  });
+
+  it('uses config defaults when starting the daemon explicitly', async () => {
+    const configHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chrome-devtools-cli-config-test-'),
+    );
+    const configDirectory = path.join(configHome, 'chrome-devtools');
+    fs.mkdirSync(configDirectory);
+    fs.writeFileSync(
+      path.join(configDirectory, 'config.json'),
+      JSON.stringify({categoryNetwork: false}),
+    );
+    const env = {...process.env, XDG_CONFIG_HOME: configHome};
+
+    try {
+      const startResult = await runCli(['start'], sessionId, env);
+      assert.strictEqual(
+        startResult.status,
+        0,
+        `start command failed: ${startResult.stderr}`,
+      );
+
+      const statusResult = await runCli(['status'], sessionId, env);
+      assert.match(statusResult.stdout, /"--no-category-network"/);
+    } finally {
+      fs.rmSync(configHome, {recursive: true, force: true});
+    }
+  });
+
+  it('lets command-line options override config defaults', async () => {
+    const configHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chrome-devtools-cli-config-test-'),
+    );
+    const configDirectory = path.join(configHome, 'chrome-devtools');
+    fs.mkdirSync(configDirectory);
+    fs.writeFileSync(
+      path.join(configDirectory, 'config.json'),
+      JSON.stringify({categoryNetwork: false, headless: false}),
+    );
+    const env = {...process.env, XDG_CONFIG_HOME: configHome};
+
+    try {
+      const startResult = await runCli(
+        ['start', '--categoryNetwork=true', '--headless=true'],
+        sessionId,
+        env,
+      );
+      assert.strictEqual(
+        startResult.status,
+        0,
+        `start command failed: ${startResult.stderr}`,
+      );
+
+      const statusResult = await runCli(['status'], sessionId, env);
+      assert.match(statusResult.stdout, /"--category-network"/);
+      assert.doesNotMatch(statusResult.stdout, /"--no-category-network"/);
+      assert.match(statusResult.stdout, /"--headless"/);
+      assert.doesNotMatch(statusResult.stdout, /"--no-headless"/);
+    } finally {
+      fs.rmSync(configHome, {recursive: true, force: true});
+    }
   });
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -435,6 +435,7 @@ export const CLI_PATH = path.resolve('build/src/bin/chrome-devtools.js');
 export async function runCli(
   args: string[],
   sessionId?: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<{status: number | null; stdout: string; stderr: string}> {
   return new Promise((resolve, reject) => {
     const finalArgs = [...args];
@@ -442,7 +443,7 @@ export async function runCli(
       finalArgs.push('--sessionId', sessionId);
     }
     const child = spawn('node', [CLI_PATH, ...finalArgs], {
-      env: process.env,
+      env,
     });
     let stdout = '';
     let stderr = '';


### PR DESCRIPTION
## Summary

The standalone `chrome-devtools` CLI auto-starts its daemon when the first tool command runs, but that path had no way to reuse user-specific startup options (`executablePath`, `headless`, `userDataDir`, and other `start` flags). After a reboot, crash, or `stop`, the next command launched the daemon with built-in defaults.

This adds an XDG-compatible config file:

```text
$XDG_CONFIG_HOME/chrome-devtools/config.json
```

falling back to `~/.config/chrome-devtools/config.json`. For example:

```json
{
  "executablePath": "/usr/bin/chromium",
  "headless": false
}
```

Precedence is:

```text
explicit command-line options > configuration file > built-in defaults
```

The same file is applied to automatic daemon startup and to explicit `chrome-devtools start` when an option is omitted. Config keys are validated with the existing `start` option parser (including coerce/conflict rules). `chrome-devtools status` continues to report the effective daemon arguments.

Fixes #2388

## Design notes

Implemented against current `main` rather than resurrecting closed PR #2389.

- Config loading lives in `src/config/cli-config.ts` next to the current option modules.
- Auto-start and `start` share `getCliStartOptions()`, `applyCliStartDefaults()`, and yargs `.config()`, so CLI-specific defaults such as `isolated` stay consistent.
- Auto-start no longer serializes the tool command’s argv into daemon flags. Tool commands do not register `start` options, and overlapping keys (for example `viewport` on `emulate`) could leak into the daemon. Persistent defaults belong in the config file; explicit `chrome-devtools start --…` still overrides them.
- Unknown or invalid config keys fail with the same validation as `chrome-devtools start`.

## Testing

- Unit tests for config path resolution, missing/invalid files, option validation, and CLI > config > built-in precedence (`tests/cli-config.test.ts`)
- E2E: automatic `list_pages` startup uses config values and `status` shows them
- E2E: explicit `start` uses config when flags are omitted
- E2E: command-line flags override config

Locally: `npm run format`, `npx tsc --noEmit`, `npm run test tests/cli-config.test.ts`, and the chrome-devtools start/commands e2e files.