### PR TITLE
test: stabilize delayed navigation timing

### DIFF
--- a/tests/utils/WaitForHelper.test.ts
+++ b/tests/utils/WaitForHelper.test.ts
@@ -60,13 +60,20 @@ describe('WaitForHelper', () => {
       const result = await mcpPage.waitForEventsAfterAction(
         async () => {
           // Simulate an action that takes longer than expectNavigationIn (300ms)
-          // before triggering the navigation.
+          // before scheduling the navigation. Scheduling it after evaluate
+          // returns avoids racing the execution-context teardown on Windows.
           await new Promise(resolve => setTimeout(resolve, 600));
           await mcpPage.pptrPage.evaluate(targetUrl => {
-            location.href = targetUrl;
+            setTimeout(() => {
+              location.href = targetUrl;
+            }, 50);
           }, url);
         },
-        {waitForStableDom: false, expectNavigationIn: 300},
+        {
+          waitForStableDom: false,
+          expectNavigationIn: 300,
+          timeout: 10_000,
+        },
       );
 
       assert.strictEqual(result.navigatedToUrl, url);


### PR DESCRIPTION
## Summary

- schedule the delayed navigation after `evaluate` returns
- give navigation completion a test-specific timeout

## Why

The regression test raced execution-context teardown on Windows Node 26 and failed twice in #2623. The change keeps the original scenario: the action still takes longer than `expectNavigationIn`, then navigation starts within the expected window. Production code is unchanged.

## Verification

- `npm run test -- tests/utils/WaitForHelper.test.ts`
- 20 consecutive focused repetitions passed on the exact branch head