### PR TITLE
fix: treat timeout 0 as the default wait, not unlimited

### DIFF
--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -466,7 +466,7 @@ export const timeoutSchema = {
       `Maximum wait time in milliseconds. If set to 0, the default timeout will be used.`,
     )
     .transform(value => {
-      return value && value <= 0 ? undefined : value;
+      return value === undefined || value <= 0 ? undefined : value;
     }),
 };
 

--- a/tests/tools/timeoutSchema.test.ts
+++ b/tests/tools/timeoutSchema.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {describe, it} from 'node:test';
+
+import {zod} from '../../src/third_party/index.js';
+import {timeoutSchema} from '../../src/tools/ToolDefinition.js';
+
+const schema = zod.object(timeoutSchema);
+
+describe('timeoutSchema', () => {
+  it('treats 0 as "use the default timeout"', () => {
+    assert.deepStrictEqual(schema.parse({timeout: 0}), {timeout: undefined});
+  });
+
+  it('treats a negative timeout as "use the default timeout"', () => {
+    assert.deepStrictEqual(schema.parse({timeout: -1}), {timeout: undefined});
+  });
+
+  it('keeps a positive timeout in milliseconds', () => {
+    assert.deepStrictEqual(schema.parse({timeout: 500}), {timeout: 500});
+  });
+
+  it('leaves an omitted timeout undefined', () => {
+    assert.deepStrictEqual(schema.parse({}), {});
+  });
+});


### PR DESCRIPTION
## Summary
`timeoutSchema` documents that `timeout: 0` uses the default wait. The transform used `value && value <= 0`, which is falsy for `0`, so the number `0` was passed through to Puppeteer. In Puppeteer, `timeout: 0` means wait forever.

Agents that pass `0` expecting the normal default can hang `navigate_page` / `new_page` on a stuck load.

## Test plan
- [x] `timeout: 0` and `-1` parse to `undefined`
- [x] `timeout: 500` stays `500`
- [x] omitted timeout stays omitted
