### PR TITLE
fix: wait for scheduled navigations in slim navigate

### DIFF
--- a/src/tools/slim/tools.ts
+++ b/src/tools/slim/tools.ts
@@ -69,7 +69,12 @@ export const navigate = definePageTool(args => {
       page.pptrPage.on('dialog', dialogHandler);
 
       try {
-        await page.pptrPage.goto(request.params.url, options);
+        await page.waitForEventsAfterAction(
+          async () => {
+            await page.pptrPage.goto(request.params.url, options);
+          },
+          {timeout: options.timeout},
+        );
         response.appendResponseLine(`Navigated to ${page.pptrPage.url()}.`);
       } finally {
         page.pptrPage.off('dialog', dialogHandler);

--- a/tests/tools/slim/tools.test.ts
+++ b/tests/tools/slim/tools.test.ts
@@ -11,10 +11,12 @@ import {describe, it} from 'node:test';
 
 import {parseArguments} from '../../../src/config/mcp-options.js';
 import {evaluate, navigate, screenshot} from '../../../src/tools/slim/tools.js';
+import {serverHooks} from '../../server.js';
 import {screenshots} from '../../snapshot.js';
-import {withMcpContext} from '../../utils.js';
+import {html, withMcpContext} from '../../utils.js';
 
 describe('slim', () => {
+  const server = serverHooks();
   it('evaluates', async t => {
     await withMcpContext(async (response, context) => {
       await evaluate.handler(
@@ -64,6 +66,32 @@ describe('slim', () => {
       );
       assert(!response.includePages);
       t.assert.snapshot(response.responseLines.join('\n'));
+    });
+  });
+
+  it('waits for meta refresh before returning', async () => {
+    server.addHtmlRoute('/final', html`<main id="done">arrived</main>`);
+    server.addHtmlRoute(
+      '/meta',
+      html`<meta http-equiv="refresh" content="0;url=/final" />START`,
+    );
+
+    await withMcpContext(async (response, context) => {
+      await navigate().handler(
+        {
+          params: {url: server.getRoute('/meta')},
+          page: context.getSelectedMcpPage(),
+        },
+        response,
+        context,
+      );
+      const page = context.getSelectedMcpPage().pptrPage;
+      assert.equal(
+        await page.evaluate(() => document.querySelector('#done')?.textContent),
+        'arrived',
+      );
+      assert.ok(page.url().endsWith('/final'));
+      assert.match(response.responseLines.join('\n'), /\/final/);
     });
   });
 


### PR DESCRIPTION
## Problem

`navigate_page` and `new_page` wait for a follow-up navigation (meta refresh, scheduled `location` change) through `waitForEventsAfterAction`. Slim `navigate` only called `page.goto` and returned as soon as the first document loaded.

On a URL that immediately meta-refreshes to another path, slim reported the interstitial URL. Agents using `--slim` then evaluated or screenshotted the wrong page.

## Fix

Wrap slim `navigate`'s `goto` in the same `waitForEventsAfterAction` helper. The existing beforeunload dialog handling and 30s timeout are unchanged. The "Navigated to …" line now uses the settled `page.url()`.

## Testing

- `tests/tools/slim/tools.test.ts`: meta refresh from `/meta` to `/final`; asserts the tool returns after `#done` is present and the reported URL ends with `/final`.
- Existing slim navigate / evaluate / screenshot cases still pass.
