### PR TITLE
fix: honor background when new_page uses isolatedContext

### DIFF
--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -344,7 +344,7 @@ export class McpContext implements Context {
         ctx = await this.browser.createBrowserContext();
         this.#isolatedContexts.set(isolatedContextName, ctx);
       }
-      page = await ctx.newPage();
+      page = await ctx.newPage({background});
     } else {
       page = await this.browser.newPage({background});
     }

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -430,6 +430,38 @@ describe('pages', () => {
       });
     });
 
+    it('keeps focus when background is true with isolatedContext', async () => {
+      await withMcpContext(async (response, context) => {
+        const originalPage = context.getPageById(1);
+        assert.strictEqual(originalPage, context.getSelectedMcpPage());
+        // Ensure original page has focus
+        await originalPage.pptrPage.bringToFront();
+        assert.strictEqual(
+          await originalPage.pptrPage.evaluate(() => document.hasFocus()),
+          true,
+        );
+        await newPage().handler(
+          {
+            params: {
+              url: 'data:text/html,<html></html>',
+              background: true,
+              isolatedContext: 'session-a',
+            },
+          },
+          response,
+          context,
+        );
+        // New page should be selected but original should retain focus
+        const mcpPage = context.getSelectedMcpPage();
+        assert.strictEqual(mcpPage.isolatedContextName, 'session-a');
+        assert.strictEqual(
+          await originalPage.pptrPage.evaluate(() => document.hasFocus()),
+          true,
+        );
+        assert.ok(response.includePages);
+      });
+    });
+
     it('reuses the same context for the same isolatedContext name', async () => {
       await withMcpContext(async (response, context) => {
         await newPage().handler(


### PR DESCRIPTION
Fixes #2657

## Summary

- `BrowserContext.newPage()` in Puppeteer 25.9 supports the `background` option, so pass it through in the isolated-context branch of `McpContext.newPage()` instead of dropping it.
- Add a real-browser regression test asserting the original page keeps focus when `new_page` is called with both `background: true` and `isolatedContext`.

## Testing

- `npm run typecheck`
- `npm run test:no-build tests/tools/pages.test.ts`
- prettier + eslint pass
