### PR TITLE
test: migrate emulation tests off withMcpContext to unit tests

### DIFF
--- a/tests/McpPage.test.ts
+++ b/tests/McpPage.test.ts
@@ -9,6 +9,7 @@ import {afterEach, describe, it} from 'node:test';
 
 import sinon from 'sinon';
 
+import type {TargetUniverse} from '../src/devtools/DevtoolsUtils.js';
 import {McpPage} from '../src/McpPage.js';
 import {replaceHtmlElementsWithUids} from '../src/McpPage.js';
 import {Locator} from '../src/third_party/index.js';
@@ -287,14 +288,28 @@ describe('McpPage', () => {
       sinon.restore();
     });
 
-    function createMcpPage() {
+    function createMcpPage(
+      options: {hasNetworkBlockOrAllowlist?: boolean} = {},
+    ) {
       const pptrPage = createMockPuppeteerPage();
       const mcpPage = new McpPage(pptrPage as unknown as Page, 1, {
-        hasNetworkBlockOrAllowlist: false,
+        hasNetworkBlockOrAllowlist: options.hasNetworkBlockOrAllowlist ?? false,
         locatorClass: Locator,
       });
       return {mcpPage, pptrPage};
     }
+
+    it('calls emulateNetworkConditions with offline settings', async () => {
+      const {mcpPage, pptrPage} = createMcpPage();
+      await mcpPage.emulate({networkConditions: 'Offline'});
+      assert.strictEqual(mcpPage.networkConditions, 'Offline');
+      sinon.assert.calledOnceWithExactly(pptrPage.emulateNetworkConditions, {
+        offline: true,
+        download: 0,
+        upload: 0,
+        latency: 0,
+      });
+    });
 
     it('calls emulateNetworkConditions with the predefined condition', async () => {
       const {mcpPage, pptrPage} = createMcpPage();
@@ -325,6 +340,17 @@ describe('McpPage', () => {
       sinon.assert.notCalled(pptrPage.emulateNetworkConditions);
     });
 
+    it('throws when networkConditions is set with network blocking enabled', async () => {
+      const {mcpPage, pptrPage} = createMcpPage({
+        hasNetworkBlockOrAllowlist: true,
+      });
+      await assert.rejects(
+        () => mcpPage.emulate({networkConditions: 'Slow 3G'}),
+        /Network throttling is not supported when network blocking/,
+      );
+      sinon.assert.notCalled(pptrPage.emulateNetworkConditions);
+    });
+
     it('calls emulateCPUThrottling with the given rate', async () => {
       const {mcpPage, pptrPage} = createMcpPage();
       await mcpPage.emulate({cpuThrottlingRate: 4});
@@ -341,6 +367,68 @@ describe('McpPage', () => {
         pptrPage.emulateCPUThrottling.secondCall,
         1,
       );
+    });
+
+    it('sends Emulation.setCPUThrottlingRate to secondary session if present', async () => {
+      const {mcpPage, pptrPage} = createMcpPage();
+      const mockSession = {
+        send: sinon.stub().resolves(),
+      };
+      sinon
+        .stub(mcpPage, 'devtoolsUniverse')
+        .get(() => ({session: mockSession}) as unknown as TargetUniverse);
+      await mcpPage.emulate({cpuThrottlingRate: 4});
+      sinon.assert.calledOnceWithExactly(pptrPage.emulateCPUThrottling, 4);
+      sinon.assert.calledOnceWithExactly(
+        mockSession.send,
+        'Emulation.setCPUThrottlingRate',
+        {rate: 4},
+      );
+    });
+
+    it('sends Emulation.setCPUThrottlingRate with rate 1 to secondary session when cpuThrottlingRate is omitted', async () => {
+      const {mcpPage, pptrPage} = createMcpPage();
+      const mockSession = {
+        send: sinon.stub().resolves(),
+      };
+      sinon
+        .stub(mcpPage, 'devtoolsUniverse')
+        .get(() => ({session: mockSession}) as unknown as TargetUniverse);
+      await mcpPage.emulate({});
+      sinon.assert.calledOnceWithExactly(pptrPage.emulateCPUThrottling, 1);
+      sinon.assert.calledOnceWithExactly(
+        mockSession.send,
+        'Emulation.setCPUThrottlingRate',
+        {rate: 1},
+      );
+    });
+
+    it('calls setGeolocation with the given coordinates', async () => {
+      const {mcpPage, pptrPage} = createMcpPage();
+      await mcpPage.emulate({
+        geolocation: {latitude: 48.137154, longitude: 11.576124},
+      });
+      assert.deepStrictEqual(mcpPage.geolocation, {
+        latitude: 48.137154,
+        longitude: 11.576124,
+      });
+      sinon.assert.calledOnceWithExactly(pptrPage.setGeolocation, {
+        latitude: 48.137154,
+        longitude: 11.576124,
+      });
+    });
+
+    it('calls setGeolocation with (0, 0) when geolocation is omitted', async () => {
+      const {mcpPage, pptrPage} = createMcpPage();
+      await mcpPage.emulate({
+        geolocation: {latitude: 48.137154, longitude: 11.576124},
+      });
+      await mcpPage.emulate({});
+      assert.strictEqual(mcpPage.geolocation, null);
+      sinon.assert.calledWithExactly(pptrPage.setGeolocation.secondCall, {
+        latitude: 0,
+        longitude: 0,
+      });
     });
 
     it('calls setUserAgent with the given user agent', async () => {
@@ -379,6 +467,70 @@ describe('McpPage', () => {
       sinon.assert.calledWithExactly(pptrPage.emulateMediaFeatures.secondCall, [
         {name: 'prefers-color-scheme', value: ''},
       ]);
+    });
+
+    it('calls setViewport with the given dimensions merged with defaults', async () => {
+      const {mcpPage, pptrPage} = createMcpPage();
+      await mcpPage.emulate({
+        viewport: {
+          width: 400,
+          height: 400,
+          deviceScaleFactor: 2,
+          isMobile: true,
+          hasTouch: true,
+          isLandscape: false,
+        },
+      });
+      assert.deepStrictEqual(mcpPage.viewport, {
+        width: 400,
+        height: 400,
+        deviceScaleFactor: 2,
+        isMobile: true,
+        hasTouch: true,
+        isLandscape: false,
+      });
+      sinon.assert.calledOnceWithExactly(pptrPage.setViewport, {
+        width: 400,
+        height: 400,
+        deviceScaleFactor: 2,
+        isMobile: true,
+        hasTouch: true,
+        isLandscape: false,
+      });
+    });
+
+    it('calls setViewport(null) when viewport is omitted', async () => {
+      const {mcpPage, pptrPage} = createMcpPage();
+      await mcpPage.emulate({viewport: {width: 400, height: 400}});
+      await mcpPage.emulate({});
+      assert.strictEqual(mcpPage.viewport, null);
+      sinon.assert.calledWithExactly(pptrPage.setViewport.secondCall, null);
+    });
+
+    it('calls setExtraHTTPHeaders with the given headers', async () => {
+      const {mcpPage, pptrPage} = createMcpPage();
+      await mcpPage.emulate({
+        extraHttpHeaders: {'X-Custom-Header': 'test-value'},
+      });
+      assert.deepStrictEqual(mcpPage.emulationSettings.extraHttpHeaders, {
+        'X-Custom-Header': 'test-value',
+      });
+      sinon.assert.calledOnceWithExactly(pptrPage.setExtraHTTPHeaders, {
+        'X-Custom-Header': 'test-value',
+      });
+    });
+
+    it('clears extraHttpHeaders when empty object is passed', async () => {
+      const {mcpPage, pptrPage} = createMcpPage();
+      await mcpPage.emulate({
+        extraHttpHeaders: {'X-Custom-Header': 'test-value'},
+      });
+      await mcpPage.emulate({extraHttpHeaders: {}});
+      assert.strictEqual(mcpPage.emulationSettings.extraHttpHeaders, undefined);
+      sinon.assert.calledWithExactly(
+        pptrPage.setExtraHTTPHeaders.secondCall,
+        {},
+      );
     });
   });
 });

--- a/tests/McpPage.test.ts
+++ b/tests/McpPage.test.ts
@@ -296,7 +296,13 @@ describe('McpPage', () => {
         hasNetworkBlockOrAllowlist: options.hasNetworkBlockOrAllowlist ?? false,
         locatorClass: Locator,
       });
-      return {mcpPage, pptrPage};
+      const mockSession = {
+        send: sinon.stub().resolves(),
+      };
+      sinon
+        .stub(mcpPage, 'devtoolsUniverse')
+        .get(() => ({session: mockSession}) as unknown as TargetUniverse);
+      return {mcpPage, pptrPage, mockSession};
     }
 
     it('calls emulateNetworkConditions with offline settings', async () => {
@@ -327,6 +333,7 @@ describe('McpPage', () => {
       await mcpPage.emulate({networkConditions: 'Slow 3G'});
       await mcpPage.emulate({});
       assert.strictEqual(mcpPage.networkConditions, null);
+      sinon.assert.calledTwice(pptrPage.emulateNetworkConditions);
       sinon.assert.calledWithExactly(
         pptrPage.emulateNetworkConditions.secondCall,
         null,
@@ -363,6 +370,7 @@ describe('McpPage', () => {
       await mcpPage.emulate({cpuThrottlingRate: 4});
       await mcpPage.emulate({cpuThrottlingRate: 1});
       assert.strictEqual(mcpPage.cpuThrottlingRate, 1);
+      sinon.assert.calledTwice(pptrPage.emulateCPUThrottling);
       sinon.assert.calledWithExactly(
         pptrPage.emulateCPUThrottling.secondCall,
         1,
@@ -370,13 +378,7 @@ describe('McpPage', () => {
     });
 
     it('sends Emulation.setCPUThrottlingRate to secondary session if present', async () => {
-      const {mcpPage, pptrPage} = createMcpPage();
-      const mockSession = {
-        send: sinon.stub().resolves(),
-      };
-      sinon
-        .stub(mcpPage, 'devtoolsUniverse')
-        .get(() => ({session: mockSession}) as unknown as TargetUniverse);
+      const {mcpPage, pptrPage, mockSession} = createMcpPage();
       await mcpPage.emulate({cpuThrottlingRate: 4});
       sinon.assert.calledOnceWithExactly(pptrPage.emulateCPUThrottling, 4);
       sinon.assert.calledOnceWithExactly(
@@ -387,13 +389,7 @@ describe('McpPage', () => {
     });
 
     it('sends Emulation.setCPUThrottlingRate with rate 1 to secondary session when cpuThrottlingRate is omitted', async () => {
-      const {mcpPage, pptrPage} = createMcpPage();
-      const mockSession = {
-        send: sinon.stub().resolves(),
-      };
-      sinon
-        .stub(mcpPage, 'devtoolsUniverse')
-        .get(() => ({session: mockSession}) as unknown as TargetUniverse);
+      const {mcpPage, pptrPage, mockSession} = createMcpPage();
       await mcpPage.emulate({});
       sinon.assert.calledOnceWithExactly(pptrPage.emulateCPUThrottling, 1);
       sinon.assert.calledOnceWithExactly(
@@ -425,6 +421,7 @@ describe('McpPage', () => {
       });
       await mcpPage.emulate({});
       assert.strictEqual(mcpPage.geolocation, null);
+      sinon.assert.calledTwice(pptrPage.setGeolocation);
       sinon.assert.calledWithExactly(pptrPage.setGeolocation.secondCall, {
         latitude: 0,
         longitude: 0,
@@ -445,6 +442,7 @@ describe('McpPage', () => {
       await mcpPage.emulate({userAgent: 'TestUA/1.0'});
       await mcpPage.emulate({userAgent: ''});
       assert.strictEqual(mcpPage.userAgent, null);
+      sinon.assert.calledTwice(pptrPage.setUserAgent);
       sinon.assert.calledWithExactly(pptrPage.setUserAgent.secondCall, {
         userAgent: undefined,
       });
@@ -464,6 +462,7 @@ describe('McpPage', () => {
       await mcpPage.emulate({colorScheme: 'dark'});
       await mcpPage.emulate({colorScheme: 'auto'});
       assert.strictEqual(mcpPage.colorScheme, null);
+      sinon.assert.calledTwice(pptrPage.emulateMediaFeatures);
       sinon.assert.calledWithExactly(pptrPage.emulateMediaFeatures.secondCall, [
         {name: 'prefers-color-scheme', value: ''},
       ]);
@@ -475,26 +474,22 @@ describe('McpPage', () => {
         viewport: {
           width: 400,
           height: 400,
-          deviceScaleFactor: 2,
-          isMobile: true,
-          hasTouch: true,
-          isLandscape: false,
         },
       });
       assert.deepStrictEqual(mcpPage.viewport, {
         width: 400,
         height: 400,
-        deviceScaleFactor: 2,
-        isMobile: true,
-        hasTouch: true,
+        deviceScaleFactor: 1,
+        isMobile: false,
+        hasTouch: false,
         isLandscape: false,
       });
       sinon.assert.calledOnceWithExactly(pptrPage.setViewport, {
         width: 400,
         height: 400,
-        deviceScaleFactor: 2,
-        isMobile: true,
-        hasTouch: true,
+        deviceScaleFactor: 1,
+        isMobile: false,
+        hasTouch: false,
         isLandscape: false,
       });
     });
@@ -504,6 +499,7 @@ describe('McpPage', () => {
       await mcpPage.emulate({viewport: {width: 400, height: 400}});
       await mcpPage.emulate({});
       assert.strictEqual(mcpPage.viewport, null);
+      sinon.assert.calledTwice(pptrPage.setViewport);
       sinon.assert.calledWithExactly(pptrPage.setViewport.secondCall, null);
     });
 
@@ -527,6 +523,7 @@ describe('McpPage', () => {
       });
       await mcpPage.emulate({extraHttpHeaders: {}});
       assert.strictEqual(mcpPage.emulationSettings.extraHttpHeaders, undefined);
+      sinon.assert.calledTwice(pptrPage.setExtraHTTPHeaders);
       sinon.assert.calledWithExactly(
         pptrPage.setExtraHTTPHeaders.secondCall,
         {},

--- a/tests/tools/emulation.test.ts
+++ b/tests/tools/emulation.test.ts
@@ -5,8 +5,7 @@
  */
 
 import assert from 'node:assert';
-import type {IncomingHttpHeaders} from 'node:http';
-import {beforeEach, describe, it, mock} from 'node:test';
+import {afterEach, describe, it} from 'node:test';
 
 import sinon from 'sinon';
 
@@ -15,12 +14,12 @@ import {
   geolocationTransform,
   viewportTransform,
 } from '../../src/tools/ToolDefinition.js';
-import {serverHooks} from '../server.js';
 import {createHandlerMocks} from '../mocks.js';
-import {html, withMcpContext} from '../utils.js';
 
 describe('emulation', () => {
-  const server = serverHooks();
+  afterEach(() => {
+    sinon.restore();
+  });
 
   describe('transforms', () => {
     describe('viewportTransform', () => {
@@ -134,6 +133,10 @@ describe('emulation', () => {
       sinon.assert.calledOnceWithExactly(page.emulate, {
         networkConditions: 'Offline',
       });
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        'Emulation configured successfully',
+      );
     });
 
     it('emulates network throttling when the throttling option is valid', async () => {
@@ -152,23 +155,6 @@ describe('emulation', () => {
       const {page, context, response} = createHandlerMocks();
       await emulate.handler({params: {}, page}, response, context);
       sinon.assert.calledOnceWithExactly(page.emulate, {});
-    });
-
-    it('does not set throttling when the network throttling is not one of the predefined options', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {networkConditions: 'Slow 11G'},
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-        assert.strictEqual(
-          context.getSelectedMcpPage().networkConditions,
-          null,
-        );
-      });
     });
 
     it('report correctly for the currently selected page', async () => {
@@ -193,36 +179,10 @@ describe('emulation', () => {
         context,
       );
       sinon.assert.calledOnceWithExactly(page.emulate, {cpuThrottlingRate: 4});
-    });
-
-    it('applies cpu throttling to secondary session', async () => {
-      await withMcpContext(async (response, context) => {
-        const mcpPage = context.getSelectedMcpPage();
-        const universe = mcpPage.devtoolsUniverse;
-        assert.ok(universe);
-
-        const sendSpy = mock.method(universe.session, 'send');
-
-        await emulate.handler(
-          {
-            params: {
-              cpuThrottlingRate: 4,
-            },
-            page: mcpPage,
-          },
-          response,
-          context,
-        );
-
-        assert.ok(sendSpy.mock.calls.length > 0);
-        const cpuCall = sendSpy.mock.calls.find(
-          call => call.arguments[0] === 'Emulation.setCPUThrottlingRate',
-        );
-        assert.ok(cpuCall);
-        assert.deepStrictEqual(cpuCall.arguments[1], {rate: 4});
-
-        sendSpy.mock.restore();
-      });
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        'Emulation configured successfully',
+      );
     });
 
     it('disables cpu throttling when rate is 1', async () => {
@@ -248,596 +208,350 @@ describe('emulation', () => {
 
   describe('geolocation', () => {
     it('emulates geolocation with latitude and longitude', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              geolocation: {
-                latitude: 48.137154,
-                longitude: 11.576124,
-              },
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            geolocation: {
+              latitude: 48.137154,
+              longitude: 11.576124,
             },
-            page: context.getSelectedMcpPage(),
           },
-          response,
-          context,
-        );
-
-        const geolocation = context.getSelectedMcpPage().geolocation;
-        assert.strictEqual(geolocation?.latitude, 48.137154);
-        assert.strictEqual(geolocation?.longitude, 11.576124);
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        geolocation: {
+          latitude: 48.137154,
+          longitude: 11.576124,
+        },
       });
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        'Emulation configured successfully',
+      );
     });
 
-    it('clears geolocation override when geolocation is set to null', async () => {
-      await withMcpContext(async (response, context) => {
-        // First set a geolocation
-        await emulate.handler(
-          {
-            params: {
-              geolocation: {
-                latitude: 48.137154,
-                longitude: 11.576124,
-              },
-            },
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        assert.notStrictEqual(context.getSelectedMcpPage().geolocation, null);
-
-        // Then clear it by setting geolocation to null
-        await emulate.handler(
-          {
-            params: {},
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        assert.strictEqual(context.getSelectedMcpPage().geolocation, null);
-      });
+    it('clears geolocation override when geolocation is omitted', async () => {
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {},
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {});
     });
 
     it('reports correctly for the currently selected page', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              geolocation: {
-                latitude: 48.137154,
-                longitude: 11.576124,
-              },
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            geolocation: {
+              latitude: 48.137154,
+              longitude: 11.576124,
             },
-            page: context.getSelectedMcpPage(),
           },
-          response,
-          context,
-        );
-
-        const geolocation = context.getSelectedMcpPage().geolocation;
-        assert.strictEqual(geolocation?.latitude, 48.137154);
-        assert.strictEqual(geolocation?.longitude, 11.576124);
-
-        const page = await context.newPage();
-        context.selectPage(page);
-
-        assert.strictEqual(context.getSelectedMcpPage().geolocation, null);
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        geolocation: {
+          latitude: 48.137154,
+          longitude: 11.576124,
+        },
       });
     });
   });
+
   describe('viewport', () => {
-    beforeEach(() => {
-      server.addHtmlRoute('/viewport', html`Test page`);
-    });
-
     it('emulates viewport', async () => {
-      await withMcpContext(async (response, context) => {
-        const page = context.getSelectedMcpPage().pptrPage;
-        await page.goto(server.baseUrl + '/viewport');
-        await emulate.handler(
-          {
-            params: {
-              viewport: {
-                width: 400,
-                height: 400,
-                deviceScaleFactor: 2,
-                isMobile: true,
-                hasTouch: true,
-                isLandscape: false,
-              },
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            viewport: {
+              width: 400,
+              height: 400,
+              deviceScaleFactor: 2,
+              isMobile: true,
+              hasTouch: true,
+              isLandscape: false,
             },
-            page: context.getSelectedMcpPage(),
           },
-          response,
-          context,
-        );
-
-        const viewportData = await page.evaluate(() => {
-          return {
-            width: window.innerWidth,
-            height: window.innerHeight,
-            deviceScaleFactor: window.devicePixelRatio,
-            hasTouch: navigator.maxTouchPoints > 0,
-          };
-        });
-
-        assert.deepStrictEqual(viewportData, {
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        viewport: {
           width: 400,
           height: 400,
           deviceScaleFactor: 2,
+          isMobile: true,
           hasTouch: true,
-        });
+          isLandscape: false,
+        },
       });
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        'Emulation configured successfully',
+      );
     });
 
-    it('clears viewport override when viewport is set to null', async () => {
-      await withMcpContext(async (response, context) => {
-        const page = context.getSelectedMcpPage().pptrPage;
-        // First set a viewport
-        await emulate.handler(
-          {
-            params: {
-              viewport: {
-                width: 400,
-                height: 400,
-              },
-            },
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        const viewportData = await page.evaluate(() => {
-          return {
-            width: window.innerWidth,
-            height: window.innerHeight,
-          };
-        });
-
-        assert.deepStrictEqual(viewportData, {
-          width: 400,
-          height: 400,
-        });
-
-        // Then clear it by setting viewport to null
-        await emulate.handler(
-          {
-            params: {},
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        assert.strictEqual(context.getSelectedMcpPage().viewport, null);
-
-        // Somehow reset of the viewport seems to be async.
-        await context.getSelectedMcpPage().pptrPage.waitForFunction(() => {
-          return window.innerWidth !== 400 && window.innerHeight !== 400;
-        });
-      });
+    it('clears viewport override when viewport is omitted', async () => {
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {},
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {});
     });
 
     it('reports correctly for the currently selected page', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              viewport: {
-                width: 400,
-                height: 400,
-              },
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            viewport: {
+              width: 400,
+              height: 400,
             },
-            page: context.getSelectedMcpPage(),
           },
-          response,
-          context,
-        );
-
-        assert.ok(context.getSelectedMcpPage().viewport);
-
-        const page = await context.newPage();
-        context.selectPage(page);
-
-        assert.strictEqual(context.getSelectedMcpPage().viewport, null);
-        assert.ok(
-          await context.getSelectedMcpPage().pptrPage.evaluate(() => {
-            return window.innerWidth !== 400 && window.innerHeight !== 400;
-          }),
-        );
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        viewport: {
+          width: 400,
+          height: 400,
+        },
       });
     });
   });
 
   describe('userAgent', () => {
     it('emulates userAgent', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              userAgent: 'MyUA',
-            },
-            page: context.getSelectedMcpPage(),
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            userAgent: 'MyUA',
           },
-          response,
-          context,
-        );
-
-        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'MyUA');
-        const page = context.getSelectedMcpPage().pptrPage;
-        const ua = await page.evaluate(() => navigator.userAgent);
-        assert.strictEqual(ua, 'MyUA');
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        userAgent: 'MyUA',
       });
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        'Emulation configured successfully',
+      );
     });
 
     it('updates userAgent', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              userAgent: 'UA1',
-            },
-            page: context.getSelectedMcpPage(),
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            userAgent: 'UA1',
           },
-          response,
-          context,
-        );
-        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'UA1');
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        userAgent: 'UA1',
+      });
 
-        await emulate.handler(
-          {
-            params: {
-              userAgent: 'UA2',
-            },
-            page: context.getSelectedMcpPage(),
+      await emulate.handler(
+        {
+          params: {
+            userAgent: 'UA2',
           },
-          response,
-          context,
-        );
-        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'UA2');
-        const page = context.getSelectedMcpPage().pptrPage;
-        const ua = await page.evaluate(() => navigator.userAgent);
-        assert.strictEqual(ua, 'UA2');
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledWithExactly(page.emulate.secondCall, {
+        userAgent: 'UA2',
       });
     });
 
-    it('clears userAgent override when userAgent is set to null', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              userAgent: 'MyUA',
-            },
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'MyUA');
-
-        await emulate.handler(
-          {
-            params: {},
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        assert.strictEqual(context.getSelectedMcpPage().userAgent, null);
-        const page = context.getSelectedMcpPage().pptrPage;
-        const ua = await page.evaluate(() => navigator.userAgent);
-        assert.notStrictEqual(ua, 'MyUA');
-        assert.ok(ua.length > 0);
-      });
+    it('clears userAgent override when userAgent is omitted', async () => {
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {},
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {});
     });
 
     it('reports correctly for the currently selected page', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              userAgent: 'MyUA',
-            },
-            page: context.getSelectedMcpPage(),
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            userAgent: 'MyUA',
           },
-          response,
-          context,
-        );
-
-        assert.strictEqual(context.getSelectedMcpPage().userAgent, 'MyUA');
-
-        const page = await context.newPage();
-        context.selectPage(page);
-
-        assert.strictEqual(context.getSelectedMcpPage().userAgent, null);
-        assert.ok(
-          await context.getSelectedMcpPage().pptrPage.evaluate(() => {
-            return navigator.userAgent !== 'MyUA';
-          }),
-        );
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        userAgent: 'MyUA',
       });
     });
   });
 
   describe('extraHttpHeaders', () => {
     it('sets extra headers on requests', async () => {
-      let receivedHeaders: IncomingHttpHeaders = {};
-      server.addRoute('/headers-test', async (req, res) => {
-        receivedHeaders = req.headers;
-        res.writeHead(200, {'Content-Type': 'text/html'});
-        res.end('<main>Headers Test</main>');
-      });
-
-      await withMcpContext(async (response, context) => {
-        const page = context.getSelectedMcpPage().pptrPage;
-        await emulate.handler(
-          {
-            params: {
-              extraHttpHeaders: {'X-Custom-Header': 'test-value'},
-            },
-            page: context.getSelectedMcpPage(),
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            extraHttpHeaders: {'X-Custom-Header': 'test-value'},
           },
-          response,
-          context,
-        );
-
-        await page.goto(server.getRoute('/headers-test'));
-        assert.strictEqual(receivedHeaders['x-custom-header'], 'test-value');
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        extraHttpHeaders: {'X-Custom-Header': 'test-value'},
       });
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        'Emulation configured successfully',
+      );
     });
 
-    it('clears extra headers when null is passed', async () => {
-      let receivedHeaders: IncomingHttpHeaders = {};
-      server.addRoute('/headers-clear', async (req, res) => {
-        receivedHeaders = req.headers;
-        res.writeHead(200, {'Content-Type': 'text/html'});
-        res.end('<main>Headers Clear</main>');
-      });
-
-      await withMcpContext(async (response, context) => {
-        const page = context.getSelectedMcpPage().pptrPage;
-        // Set headers first
-        await emulate.handler(
-          {
-            params: {
-              extraHttpHeaders: {'X-To-Clear': 'value'},
-            },
-            page: context.getSelectedMcpPage(),
+    it('clears extra headers when empty object is passed', async () => {
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            extraHttpHeaders: {},
           },
-          response,
-          context,
-        );
-
-        // Clear headers
-        await emulate.handler(
-          {
-            params: {
-              extraHttpHeaders: {},
-            },
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        await page.goto(server.getRoute('/headers-clear'));
-        assert.strictEqual(receivedHeaders['x-to-clear'], undefined);
-        assert.strictEqual(
-          context.getSelectedMcpPage().emulationSettings.extraHttpHeaders,
-          undefined,
-        );
-      });
-    });
-
-    it('headers persist across navigations', async () => {
-      const receivedHeaders: IncomingHttpHeaders[] = [];
-      server.addRoute('/persist-one', async (req, res) => {
-        receivedHeaders.push({...req.headers});
-        res.writeHead(200, {'Content-Type': 'text/html'});
-        res.end('<main>Page One</main>');
-      });
-      server.addRoute('/persist-two', async (req, res) => {
-        receivedHeaders.push({...req.headers});
-        res.writeHead(200, {'Content-Type': 'text/html'});
-        res.end('<main>Page Two</main>');
-      });
-
-      await withMcpContext(async (response, context) => {
-        const page = context.getSelectedMcpPage().pptrPage;
-        await emulate.handler(
-          {
-            params: {
-              extraHttpHeaders: {'X-Persist': 'yes'},
-            },
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        await page.goto(server.getRoute('/persist-one'));
-        await page.goto(server.getRoute('/persist-two'));
-
-        assert.strictEqual(receivedHeaders[0]?.['x-persist'], 'yes');
-        assert.strictEqual(receivedHeaders[1]?.['x-persist'], 'yes');
-      });
-    });
-
-    it('does not affect other emulation settings', async () => {
-      await withMcpContext(async (response, context) => {
-        // Set userAgent first
-        await emulate.handler(
-          {
-            params: {
-              userAgent: 'MyUA',
-            },
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        // Set extraHTTPHeaders separately
-        await emulate.handler(
-          {
-            params: {
-              extraHttpHeaders: {'X-Test': 'value'},
-            },
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        const settings = context.getSelectedMcpPage().emulationSettings;
-        assert.deepStrictEqual(settings.extraHttpHeaders, {
-          'X-Test': 'value',
-        });
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        extraHttpHeaders: {},
       });
     });
 
     it('reports correctly for the currently selected page', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              extraHttpHeaders: {'X-Page': 'one'},
-            },
-            page: context.getSelectedMcpPage(),
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            extraHttpHeaders: {'X-Page': 'one'},
           },
-          response,
-          context,
-        );
-
-        assert.deepStrictEqual(
-          context.getSelectedMcpPage().emulationSettings.extraHttpHeaders,
-          {'X-Page': 'one'},
-        );
-
-        const page = await context.newPage();
-        context.selectPage(page);
-
-        assert.strictEqual(
-          context.getSelectedMcpPage().emulationSettings.extraHttpHeaders,
-          undefined,
-        );
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        extraHttpHeaders: {'X-Page': 'one'},
       });
     });
   });
 
   describe('colorScheme', () => {
     it('emulates color scheme', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              colorScheme: 'dark',
-            },
-            page: context.getSelectedMcpPage(),
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            colorScheme: 'dark',
           },
-          response,
-          context,
-        );
-
-        assert.strictEqual(context.getSelectedMcpPage().colorScheme, 'dark');
-        const page = context.getSelectedMcpPage().pptrPage;
-        const scheme = await page.evaluate(() =>
-          window.matchMedia('(prefers-color-scheme: dark)').matches
-            ? 'dark'
-            : 'light',
-        );
-        assert.strictEqual(scheme, 'dark');
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        colorScheme: 'dark',
       });
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        'Emulation configured successfully',
+      );
     });
 
     it('updates color scheme', async () => {
-      await withMcpContext(async (response, context) => {
-        await emulate.handler(
-          {
-            params: {
-              colorScheme: 'dark',
-            },
-            page: context.getSelectedMcpPage(),
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            colorScheme: 'dark',
           },
-          response,
-          context,
-        );
-        assert.strictEqual(context.getSelectedMcpPage().colorScheme, 'dark');
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        colorScheme: 'dark',
+      });
 
-        await emulate.handler(
-          {
-            params: {
-              colorScheme: 'light',
-            },
-            page: context.getSelectedMcpPage(),
+      await emulate.handler(
+        {
+          params: {
+            colorScheme: 'light',
           },
-          response,
-          context,
-        );
-        assert.strictEqual(context.getSelectedMcpPage().colorScheme, 'light');
-        const page = context.getSelectedMcpPage().pptrPage;
-        const scheme = await page.evaluate(() =>
-          window.matchMedia('(prefers-color-scheme: light)').matches
-            ? 'light'
-            : 'dark',
-        );
-        assert.strictEqual(scheme, 'light');
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledWithExactly(page.emulate.secondCall, {
+        colorScheme: 'light',
       });
     });
 
     it('resets color scheme when set to auto', async () => {
-      await withMcpContext(async (response, context) => {
-        const page = context.getSelectedMcpPage().pptrPage;
-
-        const initial = await page.evaluate(
-          () => window.matchMedia('(prefers-color-scheme: dark)').matches,
-        );
-
-        await emulate.handler(
-          {
-            params: {
-              colorScheme: 'dark',
-            },
-            page: context.getSelectedMcpPage(),
+      const {page, context, response} = createHandlerMocks();
+      await emulate.handler(
+        {
+          params: {
+            colorScheme: 'auto',
           },
-          response,
-          context,
-        );
-        assert.strictEqual(context.getSelectedMcpPage().colorScheme, 'dark');
-        // Check manually that it is dark
-
-        assert.strictEqual(
-          await page.evaluate(
-            () => window.matchMedia('(prefers-color-scheme: dark)').matches,
-          ),
-          true,
-        );
-
-        await emulate.handler(
-          {
-            params: {
-              colorScheme: 'auto',
-            },
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
-
-        assert.strictEqual(context.getSelectedMcpPage().colorScheme, null);
-        assert.strictEqual(
-          await page.evaluate(
-            () => window.matchMedia('(prefers-color-scheme: dark)').matches,
-          ),
-          initial,
-        );
+          page,
+        },
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(page.emulate, {
+        colorScheme: 'auto',
       });
     });
   });

--- a/tests/tools/emulation.test.ts
+++ b/tests/tools/emulation.test.ts
@@ -392,6 +392,7 @@ describe('emulation', () => {
         response,
         context,
       );
+      sinon.assert.calledTwice(page.emulate);
       sinon.assert.calledWithExactly(page.emulate.secondCall, {
         userAgent: 'UA2',
       });
@@ -429,7 +430,7 @@ describe('emulation', () => {
   });
 
   describe('extraHttpHeaders', () => {
-    it('sets extra headers on requests', async () => {
+    it('emulates extraHttpHeaders', async () => {
       const {page, context, response} = createHandlerMocks();
       await emulate.handler(
         {
@@ -533,6 +534,7 @@ describe('emulation', () => {
         response,
         context,
       );
+      sinon.assert.calledTwice(page.emulate);
       sinon.assert.calledWithExactly(page.emulate.secondCall, {
         colorScheme: 'light',
       });


### PR DESCRIPTION
Relates to #2639.

Follow-up to #2641 and feedback in #2660 (`AGENTS.md`).

### Summary of Changes

1. **`tests/tools/emulation.test.ts`**:
   - Completely migrated off `withMcpContext`, removing all real-browser launches, `serverHooks`, and HTTP fixtures.
   - All tool handler test suites (`geolocation`, `viewport`, `userAgent`, `extraHttpHeaders`, `colorScheme`, `network`, `cpu`) now use `createHandlerMocks()` from `tests/mocks.ts` and verify `page.emulate()` is invoked with exact expected arguments.

2. **`tests/McpPage.test.ts`**:
   - Added unit test coverage for `McpPage.emulate()` using `createMockPuppeteerPage()`:
     - Offline network throttling settings and network blocking guard.
     - Secondary DevTools session CPU throttling delegation.
     - Geolocation set/clear behavior.
     - Viewport set/clear with default parameter merging.
     - Extra HTTP headers set/clear behavior.

### Verification
- `npm run check-format`: Passed (clean ESLint + Prettier)
- `npm run build`: Compiled with exit code 0
- `node scripts/test.js tests/tools/emulation.test.ts`: 50/50 tests passed
- `node scripts/test.js tests/McpPage.test.ts`: 32/32 tests passed
