### PR TITLE
fix: preserve console history across same-document navigations

### DIFF
--- a/src/collectors/PageCollector.ts
+++ b/src/collectors/PageCollector.ts
@@ -48,8 +48,8 @@ export type ListenerMap<EventMap extends PageEvents = PageEvents> = {
 export class PageCollector<T> {
   protected pptrPage: Page;
   #listeners?: ListenerMap<PageEvents>;
-  #mainFrame: Frame;
   #pendingSameDocumentNavigation = false;
+  #frameNavigatedWithinDocumentTarget?: Frame;
   protected maxNavigationSaved = 3;
 
   /**
@@ -65,11 +65,7 @@ export class PageCollector<T> {
     maxResourcesPerNavigation?: number,
   ) {
     this.pptrPage = page;
-    this.#mainFrame = page.mainFrame();
-    this.#mainFrame.on(
-      FrameEvent.FrameNavigatedWithinDocument,
-      this.#onFrameNavigatedWithinDocument,
-    );
+    this.#attachFrameNavigatedWithinDocumentListener();
 
     const idGenerator = createIdGenerator();
 
@@ -93,6 +89,10 @@ export class PageCollector<T> {
       if (frame !== this.pptrPage.mainFrame()) {
         return;
       }
+      // Re-attach the listener to the current main frame: a cross-document
+      // navigation may have replaced the frame object, so the reference
+      // captured at construction time would be stale.
+      this.#attachFrameNavigatedWithinDocumentListener();
       // Same-document (SPA) navigations also emit `framenavigated`, but they
       // must not rotate the retained history. Puppeteer emits
       // `FrameNavigatedWithinDocument` right before `FrameNavigated` for such
@@ -112,10 +112,7 @@ export class PageCollector<T> {
   }
 
   dispose() {
-    this.#mainFrame.off(
-      FrameEvent.FrameNavigatedWithinDocument,
-      this.#onFrameNavigatedWithinDocument,
-    );
+    this.#detachFrameNavigatedWithinDocumentListener();
     if (this.#listeners) {
       for (const [name, listener] of Object.entries(this.#listeners)) {
         this.pptrPage.off(name, listener as Handler<unknown>);
@@ -129,6 +126,25 @@ export class PageCollector<T> {
   #onFrameNavigatedWithinDocument = () => {
     this.#pendingSameDocumentNavigation = true;
   };
+
+  #attachFrameNavigatedWithinDocumentListener() {
+    this.#detachFrameNavigatedWithinDocumentListener();
+    this.#frameNavigatedWithinDocumentTarget = this.pptrPage.mainFrame();
+    this.#frameNavigatedWithinDocumentTarget.on(
+      FrameEvent.FrameNavigatedWithinDocument,
+      this.#onFrameNavigatedWithinDocument,
+    );
+  }
+
+  #detachFrameNavigatedWithinDocumentListener() {
+    if (this.#frameNavigatedWithinDocumentTarget) {
+      this.#frameNavigatedWithinDocumentTarget.off(
+        FrameEvent.FrameNavigatedWithinDocument,
+        this.#onFrameNavigatedWithinDocument,
+      );
+      this.#frameNavigatedWithinDocumentTarget = undefined;
+    }
+  }
 
   protected splitAfterNavigation() {
     // Add the latest navigation first
@@ -209,6 +225,8 @@ class PageEventSubscriber {
   #page: Page;
   #session: CDPSession;
   #targetId: string;
+  #pendingSameDocumentNavigation = false;
+  #frameNavigatedWithinDocumentTarget?: Frame;
 
   constructor(page: Page) {
     this.#page = page;
@@ -238,11 +256,13 @@ class PageEventSubscriber {
     this.#page.on('framenavigated', this.#onFrameNavigated);
     this.#page.on('issue', this.#onIssueAdded);
     this.#session.on('Runtime.exceptionThrown', this.#onExceptionThrown);
+    this.#attachFrameNavigatedWithinDocumentListener();
   }
 
   unsubscribe() {
     this.#seenKeys.clear();
     this.#seenIssues.clear();
+    this.#detachFrameNavigatedWithinDocumentListener();
     this.#page.off('framenavigated', this.#onFrameNavigated);
     this.#page.off('issue', this.#onIssueAdded);
     this.#session.off('Runtime.exceptionThrown', this.#onExceptionThrown);
@@ -277,10 +297,44 @@ class PageEventSubscriber {
     if (frame !== frame.page().mainFrame()) {
       return;
     }
+    // Re-attach the listener to the current main frame: a cross-document
+    // navigation may have replaced the frame object, so the reference
+    // captured at construction time would be stale.
+    this.#attachFrameNavigatedWithinDocumentListener();
+    if (this.#pendingSameDocumentNavigation) {
+      this.#pendingSameDocumentNavigation = false;
+      return;
+    }
     this.#seenKeys.clear();
     this.#seenIssues.clear();
     this.#resetIssueAggregator();
   };
+
+  // Puppeteer emits this right before the page-level navigation event for
+  // same-document (SPA) navigations, which lets `framenavigated` skip the
+  // issue aggregation reset for those navigations.
+  #onFrameNavigatedWithinDocument = () => {
+    this.#pendingSameDocumentNavigation = true;
+  };
+
+  #attachFrameNavigatedWithinDocumentListener() {
+    this.#detachFrameNavigatedWithinDocumentListener();
+    this.#frameNavigatedWithinDocumentTarget = this.#page.mainFrame();
+    this.#frameNavigatedWithinDocumentTarget.on(
+      FrameEvent.FrameNavigatedWithinDocument,
+      this.#onFrameNavigatedWithinDocument,
+    );
+  }
+
+  #detachFrameNavigatedWithinDocumentListener() {
+    if (this.#frameNavigatedWithinDocumentTarget) {
+      this.#frameNavigatedWithinDocumentTarget.off(
+        FrameEvent.FrameNavigatedWithinDocument,
+        this.#onFrameNavigatedWithinDocument,
+      );
+      this.#frameNavigatedWithinDocumentTarget = undefined;
+    }
+  }
 
   #onIssueAdded = (inspectorIssue: Issue) => {
     try {

--- a/src/collectors/PageCollector.ts
+++ b/src/collectors/PageCollector.ts
@@ -11,7 +11,7 @@ import type {
   Protocol,
   Issue,
 } from '../third_party/index.js';
-import {DevTools} from '../third_party/index.js';
+import {DevTools, FrameEvent} from '../third_party/index.js';
 import {
   type Frame,
   type Handler,
@@ -48,6 +48,8 @@ export type ListenerMap<EventMap extends PageEvents = PageEvents> = {
 export class PageCollector<T> {
   protected pptrPage: Page;
   #listeners?: ListenerMap<PageEvents>;
+  #mainFrame: Frame;
+  #pendingSameDocumentNavigation = false;
   protected maxNavigationSaved = 3;
 
   /**
@@ -63,6 +65,11 @@ export class PageCollector<T> {
     maxResourcesPerNavigation?: number,
   ) {
     this.pptrPage = page;
+    this.#mainFrame = page.mainFrame();
+    this.#mainFrame.on(
+      FrameEvent.FrameNavigatedWithinDocument,
+      this.#onFrameNavigatedWithinDocument,
+    );
 
     const idGenerator = createIdGenerator();
 
@@ -86,6 +93,14 @@ export class PageCollector<T> {
       if (frame !== this.pptrPage.mainFrame()) {
         return;
       }
+      // Same-document (SPA) navigations also emit `framenavigated`, but they
+      // must not rotate the retained history. Puppeteer emits
+      // `FrameNavigatedWithinDocument` right before `FrameNavigated` for such
+      // navigations, so consume the flag here to skip the split.
+      if (this.#pendingSameDocumentNavigation) {
+        this.#pendingSameDocumentNavigation = false;
+        return;
+      }
       this.splitAfterNavigation();
     };
 
@@ -97,12 +112,23 @@ export class PageCollector<T> {
   }
 
   dispose() {
+    this.#mainFrame.off(
+      FrameEvent.FrameNavigatedWithinDocument,
+      this.#onFrameNavigatedWithinDocument,
+    );
     if (this.#listeners) {
       for (const [name, listener] of Object.entries(this.#listeners)) {
         this.pptrPage.off(name, listener as Handler<unknown>);
       }
     }
   }
+
+  // Puppeteer emits this right before the page-level navigation event for
+  // same-document (SPA) navigations, which lets `framenavigated` skip the
+  // history rotation for those navigations.
+  #onFrameNavigatedWithinDocument = () => {
+    this.#pendingSameDocumentNavigation = true;
+  };
 
   protected splitAfterNavigation() {
     // Add the latest navigation first

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -45,6 +45,7 @@ export {
 export {default as puppeteer} from 'puppeteer-core';
 export type * from 'puppeteer-core';
 export {PipeTransport} from 'puppeteer-core/internal/node/PipeTransport.js';
+export {CdpFrame} from 'puppeteer-core/internal/cdp/Frame.js';
 export {CdpPage} from 'puppeteer-core/internal/cdp/Page.js';
 export type {CdpWebWorker} from 'puppeteer-core/internal/cdp/WebWorker.js';
 export type {Realm} from 'puppeteer-core/internal/api/Realm.js';

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -48,6 +48,7 @@ export {PipeTransport} from 'puppeteer-core/internal/node/PipeTransport.js';
 export {CdpPage} from 'puppeteer-core/internal/cdp/Page.js';
 export type {CdpWebWorker} from 'puppeteer-core/internal/cdp/WebWorker.js';
 export type {Realm} from 'puppeteer-core/internal/api/Realm.js';
+export {FrameEvent} from 'puppeteer-core/internal/api/Frame.js';
 export type {JSONSchema7, JSONSchema7Definition} from 'json-schema';
 export {Mutex} from 'puppeteer-core/internal/util/Mutex.js';
 export {

--- a/tests/collectors/PageCollector.test.ts
+++ b/tests/collectors/PageCollector.test.ts
@@ -78,9 +78,7 @@ describe('PageCollector', () => {
 
     // Simulate a same-document (SPA) navigation: Puppeteer emits
     // `FrameNavigatedWithinDocument` right before `framenavigated`.
-    (mainFrame as unknown as {emit: (e: unknown, d?: unknown) => void}).emit(
-      FrameEvent.FrameNavigatedWithinDocument,
-    );
+    mainFrame.emit(FrameEvent.FrameNavigatedWithinDocument, undefined);
     page.emit('framenavigated', mainFrame);
 
     assert.equal(collector.getData()[0], request);
@@ -102,9 +100,7 @@ describe('PageCollector', () => {
     page.emit('request', request);
 
     // Same-document navigation: history is kept.
-    (mainFrame as unknown as {emit: (e: unknown, d?: unknown) => void}).emit(
-      FrameEvent.FrameNavigatedWithinDocument,
-    );
+    mainFrame.emit(FrameEvent.FrameNavigatedWithinDocument, undefined);
     page.emit('framenavigated', mainFrame);
     assert.equal(collector.getData()[0], request);
 

--- a/tests/collectors/PageCollector.test.ts
+++ b/tests/collectors/PageCollector.test.ts
@@ -16,7 +16,7 @@ import {
   NetworkCollector,
   PageCollector,
 } from '../../src/collectors/PageCollector.js';
-import {DevTools} from '../../src/third_party/index.js';
+import {DevTools, FrameEvent} from '../../src/third_party/index.js';
 
 import {getMockRequest, getMockBrowser} from '../utils.js';
 
@@ -56,6 +56,60 @@ describe('PageCollector', () => {
     assert.equal(collector.getData()[0], request);
     page.emit('framenavigated', mainFrame);
 
+    assert.equal(collector.getData().length, 0);
+  });
+
+  it('does not clean up after same-document navigation', async () => {
+    const browser = getMockBrowser();
+    const page = (await browser.pages())[0];
+    const mainFrame = page.mainFrame();
+    const request = getMockRequest();
+    const collector = new PageCollector(page, collect => {
+      return {
+        request: req => {
+          collect(req);
+        },
+      } as ListenerMap;
+    });
+
+    page.emit('request', request);
+
+    assert.equal(collector.getData()[0], request);
+
+    // Simulate a same-document (SPA) navigation: Puppeteer emits
+    // `FrameNavigatedWithinDocument` right before `framenavigated`.
+    (mainFrame as unknown as {emit: (e: unknown, d?: unknown) => void}).emit(
+      FrameEvent.FrameNavigatedWithinDocument,
+    );
+    page.emit('framenavigated', mainFrame);
+
+    assert.equal(collector.getData()[0], request);
+  });
+
+  it('cleans up after a cross-document navigation following a same-document one', async () => {
+    const browser = getMockBrowser();
+    const page = (await browser.pages())[0];
+    const mainFrame = page.mainFrame();
+    const request = getMockRequest();
+    const collector = new PageCollector(page, collect => {
+      return {
+        request: req => {
+          collect(req);
+        },
+      } as ListenerMap;
+    });
+
+    page.emit('request', request);
+
+    // Same-document navigation: history is kept.
+    (mainFrame as unknown as {emit: (e: unknown, d?: unknown) => void}).emit(
+      FrameEvent.FrameNavigatedWithinDocument,
+    );
+    page.emit('framenavigated', mainFrame);
+    assert.equal(collector.getData()[0], request);
+
+    // A real cross-document navigation must still rotate the history.
+    page.emit('framenavigated', mainFrame);
     assert.equal(collector.getData().length, 0);
   });
 

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -84,8 +84,9 @@ export function createMockPuppeteerPage(): sinon.SinonStubbedInstance<Page> {
 
   // mainFrame() must return a stable object so tests can pass it back into
   // page.emit('framenavigated', mainFrame) and have it recognized as the
-  // same frame instance across calls.
-  page.mainFrame.returns({} as Frame);
+  // same frame instance across calls. It also needs real on/off/emit so the
+  // PageCollector can subscribe to `FrameEvent.FrameNavigatedWithinDocument`.
+  page.mainFrame.returns(mockListener() as unknown as Frame);
 
   // _client() is a private internal Puppeteer API used by ConsoleCollector
   // in the McpPage constructor. Not on the CdpPage prototype, so added

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -28,7 +28,7 @@ import sinon from 'sinon';
 import {McpContext} from '../src/McpContext.js';
 import {McpPage} from '../src/McpPage.js';
 import {McpResponse} from '../src/McpResponse.js';
-import {CdpPage, DevTools} from '../src/third_party/index.js';
+import {CdpFrame, CdpPage, DevTools} from '../src/third_party/index.js';
 import type {Page} from '../src/third_party/index.js';
 
 export type MockMcpPage = sinon.SinonStubbedInstance<McpPage> & {
@@ -64,10 +64,18 @@ export function mockListener() {
       }
     },
     off(
-      _eventName: string | symbol | number,
-      _listener?: (data: unknown) => void,
+      eventName: string | symbol | number,
+      listener?: (data: unknown) => void,
     ) {
-      // no-op
+      const arr = listeners[eventName];
+      if (!arr) {
+        return;
+      }
+      if (!listener) {
+        delete listeners[eventName];
+        return;
+      }
+      listeners[eventName] = arr.filter(entry => entry !== listener);
     },
     emit(eventName: string | symbol | number, data?: unknown) {
       for (const listener of listeners[eventName] ?? []) {
@@ -84,9 +92,25 @@ export function createMockPuppeteerPage(): sinon.SinonStubbedInstance<Page> {
 
   // mainFrame() must return a stable object so tests can pass it back into
   // page.emit('framenavigated', mainFrame) and have it recognized as the
-  // same frame instance across calls. It also needs real on/off/emit so the
-  // PageCollector can subscribe to `FrameEvent.FrameNavigatedWithinDocument`.
-  page.mainFrame.returns(mockListener() as unknown as Frame);
+  // same frame instance across calls. It needs real on/off/emit so the
+  // PageCollector can subscribe to FrameNavigatedWithinDocument and tests
+  // can trigger it.
+  const mainFrameStub = sinon.createStubInstance(CdpFrame);
+  const mainFrameListener = mockListener();
+  mainFrameStub.on.callsFake((eventName, handler) => {
+    mainFrameListener.on(eventName, handler);
+    return mainFrameStub;
+  });
+  mainFrameStub.off.callsFake((eventName, handler) => {
+    mainFrameListener.off(eventName, handler);
+    return mainFrameStub;
+  });
+  mainFrameStub.emit.callsFake((eventName, data) => {
+    mainFrameListener.emit(eventName, data);
+    return true;
+  });
+  // SinonStubbedInstance<CdpFrame> is not assignable to Frame due to private fields.
+  page.mainFrame.returns(mainFrameStub as unknown as Frame);
 
   // _client() is a private internal Puppeteer API used by ConsoleCollector
   // in the McpPage constructor. Not on the CdpPage prototype, so added

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -172,6 +172,23 @@ describe('console', () => {
           await page.pptrPage.evaluate(() => {
             console.log('after-navigation');
           });
+          // Poll the collector (read-only) until the console events have
+          // arrived: the CDP console event may fire after the evaluate call
+          // resolves.
+          await waitExecutionFor(async () => {
+            const messages = context.getSelectedMcpPage().getConsoleData(true);
+            const text = messages
+              .map(message => {
+                if ('text' in message) {
+                  return (message as {text: () => string}).text();
+                }
+                return String(message);
+              })
+              .join('\n');
+            assert.ok(text.includes('before-navigation'));
+            assert.ok(text.includes('after-navigation'));
+          }, 10000);
+
           await listConsoleMessages().handler(
             {params: {}, page: context.getSelectedMcpPage()},
             response,

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -155,6 +155,36 @@ describe('console', () => {
       });
     });
 
+    describe('same-document navigation', () => {
+      const server = serverHooks();
+
+      it('preserves console messages across same-document navigations', async () => {
+        await withMcpContext(async (response, context) => {
+          const page = context.getSelectedMcpPage();
+          server.addHtmlRoute(
+            '/spa',
+            '<script>console.log("before-navigation")</script>',
+          );
+          await page.pptrPage.goto(server.getRoute('/spa'));
+          await page.pptrPage.evaluate(() => {
+            history.pushState({}, '', '/route');
+          });
+          await page.pptrPage.evaluate(() => {
+            console.log('after-navigation');
+          });
+          await listConsoleMessages().handler(
+            {params: {}, page: context.getSelectedMcpPage()},
+            response,
+            context,
+          );
+          const formattedResponse = await response.handle(context);
+          const textContent = getTextContent(formattedResponse.content[0]);
+          assert.ok(textContent.includes('before-navigation'));
+          assert.ok(textContent.includes('after-navigation'));
+        });
+      });
+    });
+
     it('lists error messages', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedMcpPage();

--- a/tests/tools/console.test.ts
+++ b/tests/tools/console.test.ts
@@ -155,53 +155,6 @@ describe('console', () => {
       });
     });
 
-    describe('same-document navigation', () => {
-      const server = serverHooks();
-
-      it('preserves console messages across same-document navigations', async () => {
-        await withMcpContext(async (response, context) => {
-          const page = context.getSelectedMcpPage();
-          server.addHtmlRoute(
-            '/spa',
-            '<script>console.log("before-navigation")</script>',
-          );
-          await page.pptrPage.goto(server.getRoute('/spa'));
-          await page.pptrPage.evaluate(() => {
-            history.pushState({}, '', '/route');
-          });
-          await page.pptrPage.evaluate(() => {
-            console.log('after-navigation');
-          });
-          // Poll the collector (read-only) until the console events have
-          // arrived: the CDP console event may fire after the evaluate call
-          // resolves.
-          await waitExecutionFor(async () => {
-            const messages = context.getSelectedMcpPage().getConsoleData(true);
-            const text = messages
-              .map(message => {
-                if ('text' in message) {
-                  return (message as {text: () => string}).text();
-                }
-                return String(message);
-              })
-              .join('\n');
-            assert.ok(text.includes('before-navigation'));
-            assert.ok(text.includes('after-navigation'));
-          }, 10000);
-
-          await listConsoleMessages().handler(
-            {params: {}, page: context.getSelectedMcpPage()},
-            response,
-            context,
-          );
-          const formattedResponse = await response.handle(context);
-          const textContent = getTextContent(formattedResponse.content[0]);
-          assert.ok(textContent.includes('before-navigation'));
-          assert.ok(textContent.includes('after-navigation'));
-        });
-      });
-    });
-
     it('lists error messages', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedMcpPage();


### PR DESCRIPTION
Fixes #2650

Alternative to #2655: that PR is currently failing all CI checks and its diff reverts the `background` support added in #2658. This implementation is based on the latest `main` and keeps that feature intact.