### PR TITLE
feat: report pages opened by input actions

### DIFF
--- a/src/McpResponse.ts
+++ b/src/McpResponse.ts
@@ -675,6 +675,10 @@ export class McpResponse implements Response {
     content: Array<TextContent | ImageContent>;
     structuredContent: object;
   }> {
+    if (this.#attachedWaitForResult?.newPages?.length && !this.#includePages) {
+      await context.createPagesSnapshot();
+    }
+
     const [
       snapshot,
       detailedNetworkRequest,
@@ -784,6 +788,7 @@ export class McpResponse implements Response {
         defaultValue?: string;
       };
       pages?: object[];
+      newPages?: object[];
       pagination?: object;
       heapSnapshot?: {
         stats?: object;
@@ -855,6 +860,29 @@ export class McpResponse implements Response {
         );
         structuredContent.navigatedToUrl =
           this.#attachedWaitForResult.navigatedToUrl;
+      }
+      if (this.#attachedWaitForResult.newPages?.length) {
+        const mcpPagesByPptrPage = new Map(
+          context.getPages().map(mcpPage => [mcpPage.pptrPage, mcpPage]),
+        );
+        const newPages = this.#attachedWaitForResult.newPages.flatMap(page => {
+          const mcpPage = mcpPagesByPptrPage.get(page);
+          return mcpPage ? [mcpPage] : [];
+        });
+
+        if (newPages.length) {
+          response.push('## New pages');
+          const structuredPages = [];
+          for (const mcpPage of newPages) {
+            const title = await fetchPageTitle(mcpPage.pptrPage);
+            const pageLabel = title
+              ? `${truncateTitle(title)} (${mcpPage.pptrPage.url()})`
+              : mcpPage.pptrPage.url();
+            response.push(`${mcpPage.id}: ${pageLabel}`);
+            structuredPages.push(createStructuredPage(mcpPage, context, title));
+          }
+          structuredContent.newPages = structuredPages;
+        }
       }
     }
 

--- a/src/utils/WaitForHelper.ts
+++ b/src/utils/WaitForHelper.ts
@@ -12,6 +12,7 @@ export type DialogAction = 'accept' | 'dismiss' | string;
 
 export class WaitForHelper {
   #abortController = new AbortController();
+  #sourcePage: Page;
   #page: CdpPage;
   #stableDomTimeout: number;
   #stableDomFor: number;
@@ -22,6 +23,7 @@ export class WaitForHelper {
   /** Track all dialogs as they pause the renderer. */
   #dialogDetected = false;
   #initialUrl: string;
+  #newPages: Page[] = [];
 
   constructor(
     page: Page,
@@ -32,6 +34,7 @@ export class WaitForHelper {
     this.#stableDomFor = 100 * cpuTimeoutMultiplier;
     this.#expectNavigationIn = 100 * cpuTimeoutMultiplier;
     this.#navigationTimeout = 3000 * networkTimeoutMultiplier;
+    this.#sourcePage = page;
     this.#page = page as unknown as CdpPage;
     this.#initialUrl = page.url();
   }
@@ -153,6 +156,16 @@ export class WaitForHelper {
     this.#page.on('dialog', dialogHandler);
     this.#abortController.signal.addEventListener('abort', () => {
       this.#page.off('dialog', dialogHandler);
+    });
+
+    const popupHandler = (page: Page | null) => {
+      if (page) {
+        this.#newPages.push(page);
+      }
+    };
+    this.#sourcePage.on('popup', popupHandler);
+    this.#abortController.signal.addEventListener('abort', () => {
+      this.#sourcePage.off('popup', popupHandler);
     });
 
     // A scoped AbortController used to clean up navigation probe listeners.
@@ -281,6 +294,7 @@ export class WaitForHelper {
         ? {navigatedToUrl: urlAfterAction}
         : {}),
       dialogHandled: this.#dialogHandled,
+      ...(this.#newPages.length ? {newPages: this.#newPages} : {}),
     };
   }
 }
@@ -295,6 +309,8 @@ export interface WaitForEventsResult {
    * Whether a dialog was automatically handled during the action.
    */
   dialogHandled?: boolean;
+  /** Pages opened by the action. */
+  newPages?: Page[];
 }
 
 export function getNetworkMultiplierFromString(

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -89,6 +89,105 @@ describe('input', () => {
         assert.ok(await page.$('text/dblclicked'));
       });
     });
+
+    it('reports only pages opened by the click', async () => {
+      server.addHtmlRoute(
+        '/popup',
+        '<!DOCTYPE html><title>Opened by click</title>',
+      );
+
+      await withMcpContext(async (response, context) => {
+        const sourcePage = context.getSelectedMcpPage();
+        const page = sourcePage.pptrPage;
+        const popupUrl = server.getRoute('/popup');
+        const unrelatedPage = await context.newPage(true);
+        await unrelatedPage.pptrPage.setContent(
+          '<!DOCTYPE html><title>Unrelated page</title>',
+        );
+        context.selectPage(sourcePage);
+        await page.setContent(`<!DOCTYPE html>
+          <title>Original page</title>
+          <button onclick="window.open('${popupUrl}')">open</button>`);
+        sourcePage.textSnapshot = await TextSnapshot.create(sourcePage);
+
+        await click.handler(
+          {
+            params: {
+              uid: '1_1',
+            },
+            page: sourcePage,
+          },
+          response,
+          context,
+        );
+
+        const result = await response.handle(context);
+        const textContent = getTextContent(result.content[0]);
+        assert.match(textContent, /## New pages\n\d+: Opened by click \(/);
+        assert.ok(textContent.includes(popupUrl));
+        assert.ok(!textContent.includes('## Pages'));
+        assert.ok(!textContent.includes('Original page'));
+        assert.ok(!textContent.includes('Unrelated page'));
+
+        const newPages = getStructuredNewPages(result.structuredContent);
+        assert.deepStrictEqual(
+          newPages.map(({url, title}) => ({url, title})),
+          [{url: popupUrl, title: 'Opened by click'}],
+        );
+      });
+    });
+
+    it('reports multiple pages opened by one click in event order', async () => {
+      server.addHtmlRoute(
+        '/popup-one',
+        '<!DOCTYPE html><title>First popup</title>',
+      );
+      server.addHtmlRoute(
+        '/popup-two',
+        '<!DOCTYPE html><title>Second popup</title>',
+      );
+
+      await withMcpContext(async (response, context) => {
+        const sourcePage = context.getSelectedMcpPage();
+        const firstUrl = server.getRoute('/popup-one');
+        const secondUrl = server.getRoute('/popup-two');
+        await sourcePage.pptrPage.setContent(`<!DOCTYPE html>
+          <button onclick="window.open('${firstUrl}'); window.open('${secondUrl}')">
+            open two
+          </button>`);
+        sourcePage.textSnapshot = await TextSnapshot.create(sourcePage);
+
+        await click.handler(
+          {
+            params: {
+              uid: '1_1',
+            },
+            page: sourcePage,
+          },
+          response,
+          context,
+        );
+
+        const result = await response.handle(context);
+        const newPages = getStructuredNewPages(result.structuredContent);
+        assert.deepStrictEqual(
+          newPages.map(({url, title}) => ({url, title})),
+          [
+            {url: firstUrl, title: 'First popup'},
+            {url: secondUrl, title: 'Second popup'},
+          ],
+        );
+        assert.strictEqual(new Set(newPages.map(({id}) => id)).size, 2);
+
+        const textContent = getTextContent(result.content[0]);
+        assert.match(
+          textContent,
+          /## New pages\n\d+: First popup \([^\n]+\)\n\d+: Second popup \(/,
+        );
+        assert.ok(!textContent.includes('## Pages'));
+      });
+    });
+
     it('waits for navigation', async () => {
       const resolveNavigation = Promise.withResolvers<void>();
       server.addHtmlRoute(
@@ -1468,3 +1567,20 @@ describe('input', () => {
     });
   });
 });
+
+function getStructuredNewPages(
+  structuredContent: object,
+): Array<{id: number; url: string; title: string}> {
+  assert.ok('newPages' in structuredContent);
+  const newPages: unknown = structuredContent.newPages;
+  assert.ok(Array.isArray(newPages));
+  const entries: unknown[] = newPages;
+
+  return entries.map(entry => {
+    assert.ok(typeof entry === 'object' && entry !== null);
+    assert.ok('id' in entry && typeof entry.id === 'number');
+    assert.ok('url' in entry && typeof entry.url === 'string');
+    assert.ok('title' in entry && typeof entry.title === 'string');
+    return {id: entry.id, url: entry.url, title: entry.title};
+  });
+}

--- a/tests/utils/WaitForHelper.test.ts
+++ b/tests/utils/WaitForHelper.test.ts
@@ -7,6 +7,7 @@
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
 
+import type {Page} from '../../src/third_party/index.js';
 import {serverHooks} from '../server.js';
 import {html, withMcpContext} from '../utils.js';
 
@@ -152,6 +153,31 @@ describe('WaitForHelper', () => {
       );
 
       assert.strictEqual(result.navigatedToUrl, targetUrl);
+    });
+  });
+
+  it('captures pages opened by the action', async () => {
+    await withMcpContext(async (response, context) => {
+      const mcpPage = context.getSelectedMcpPage();
+      const listenerCountBefore = mcpPage.pptrPage.listenerCount('popup');
+      const popup = Promise.withResolvers<Page | null>();
+      mcpPage.pptrPage.once('popup', page => popup.resolve(page));
+
+      const result = await mcpPage.waitForEventsAfterAction(
+        async () => {
+          await mcpPage.pptrPage.evaluate(() => {
+            window.open('about:blank');
+          });
+        },
+        {waitForStableDom: false},
+      );
+
+      assert.strictEqual(result.newPages?.length, 1);
+      assert.strictEqual(result.newPages[0], await popup.promise);
+      assert.strictEqual(
+        mcpPage.pptrPage.listenerCount('popup'),
+        listenerCountBefore,
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes #367

When an input action opens one or more pages, capture the source page's Puppeteer `popup` events and report only those newly opened pages in the action response.

Each new page is listed under `## New pages` with its MCP page ID, title, and URL. The same entries are exposed through `structuredContent.newPages`. Pages that were already open are not included, and the complete page list is not enabled implicitly.

Tests cover a single popup with an unrelated pre-existing page, multiple popups in event order with distinct MCP page IDs, and popup listener cleanup.

## Testing

- `npm run build`
- `npm run check-format`
- `npm run test -- tests/utils/WaitForHelper.test.ts tests/tools/input.test.ts`
- `npm run test -- tests/tools/extensions.test.ts tests/tools/pages.test.ts`