### PR TITLE
build: fix devtools-frontend dependabot ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,5 +61,5 @@ updates:
     ignore:
       # Ignore tagged releases to fall back to branch commits.
       # Untagged commits get versions like `0.0.0-0.<index>`.
-      - dependency-name: 'devtools-frontend'
+      - dependency-name: 'third_party/devtools-frontend'
         versions: ['> 0.0.0']


### PR DESCRIPTION
Dependabot identifies git submodules by their path in `.gitmodules` (`third_party/devtools-frontend`), not by the submodule section name (`devtools-frontend`).

Because `dependency-name` was configured as `devtools-frontend`, the ignore condition never matched, causing Dependabot to pick the latest semver tag (`v1.0.x`) instead of the latest commit on the tracked `main` branch.

This updates the `dependency-name` to `third_party/devtools-frontend` so tagged releases are properly ignored and Dependabot falls back to branch commits.