### PR TITLE
test: migrate screencast tests off withMcpContext to unit tests

### DIFF
--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -40,6 +40,7 @@ export {
   PredefinedNetworkConditions,
   KnownDevices,
   CDPSessionEvent,
+  ScreenRecorder,
 } from 'puppeteer-core';
 export {default as puppeteer} from 'puppeteer-core';
 export type * from 'puppeteer-core';

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -103,12 +103,7 @@ export function createMockMcpPage(
 ): MockMcpPage {
   const page = sinon.createStubInstance(McpPage);
   const pptrPage = options.pptrPage ?? createMockPuppeteerPage();
-  Object.defineProperty(page, 'pptrPage', {
-    value: pptrPage,
-    writable: true,
-    configurable: true,
-  });
-  return page as unknown as MockMcpPage;
+  return Object.assign(page, {pptrPage});
 }
 
 export function createMockMcpContext(
@@ -117,12 +112,6 @@ export function createMockMcpContext(
   const context = sinon.createStubInstance(McpContext);
   const page = options.selectedPage ?? createMockMcpPage();
   context.getSelectedMcpPage.returns(page satisfies McpPage);
-
-  let screenRecorderData: ReturnType<McpContext['getScreenRecorder']> = null;
-  context.getScreenRecorder.callsFake(() => screenRecorderData);
-  context.setScreenRecorder.callsFake(data => {
-    screenRecorderData = data;
-  });
 
   return context;
 }

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -22,18 +22,23 @@
  *   sinon.assert.calledOnceWithExactly(page.emulate, {networkConditions: 'Slow 3G'});
  */
 
+import path from 'node:path';
+
 import type {Frame} from 'puppeteer-core';
 import sinon from 'sinon';
 
 import {McpContext} from '../src/McpContext.js';
 import {McpPage} from '../src/McpPage.js';
 import {McpResponse} from '../src/McpResponse.js';
-import {CdpPage} from '../src/third_party/index.js';
+import {CdpPage, ScreenRecorder} from '../src/third_party/index.js';
 import type {Page} from '../src/third_party/index.js';
 
-export type MockMcpPage = sinon.SinonStubbedInstance<McpPage>;
+export type MockMcpPage = sinon.SinonStubbedInstance<McpPage> & {
+  pptrPage: sinon.SinonStubbedInstance<Page>;
+};
 export type MockMcpContext = sinon.SinonStubbedInstance<McpContext>;
 export type MockMcpResponse = sinon.SinonStubbedInstance<McpResponse>;
+export type MockScreenRecorder = sinon.SinonStubbedInstance<ScreenRecorder>;
 
 /**
  * A minimal event emitter used to back mocked `on`/`off`/`emit` methods on
@@ -96,8 +101,23 @@ export function createMockPuppeteerPage(): sinon.SinonStubbedInstance<Page> {
   return page;
 }
 
-export function createMockMcpPage(): MockMcpPage {
-  return sinon.createStubInstance(McpPage);
+export function createMockScreenRecorder(): MockScreenRecorder {
+  const recorder = sinon.createStubInstance(ScreenRecorder);
+  recorder.stop.resolves();
+  return recorder;
+}
+
+export function createMockMcpPage(
+  options: {pptrPage?: sinon.SinonStubbedInstance<Page>} = {},
+): MockMcpPage {
+  const page = sinon.createStubInstance(McpPage);
+  const pptrPage = options.pptrPage ?? createMockPuppeteerPage();
+  Object.defineProperty(page, 'pptrPage', {
+    value: pptrPage,
+    writable: true,
+    configurable: true,
+  });
+  return page as unknown as MockMcpPage;
 }
 
 export function createMockMcpContext(
@@ -106,6 +126,25 @@ export function createMockMcpContext(
   const context = sinon.createStubInstance(McpContext);
   const page = options.selectedPage ?? createMockMcpPage();
   context.getSelectedMcpPage.returns(page satisfies McpPage);
+
+  let screenRecorderData: {recorder: ScreenRecorder; filePath: string} | null =
+    null;
+  context.getScreenRecorder.callsFake(() => screenRecorderData);
+  context.setScreenRecorder.callsFake(data => {
+    screenRecorderData = data;
+  });
+
+  context.ensureExtension.callsFake(
+    async <Extension extends `.${string}`>(
+      filePath: string,
+      extension: Extension,
+    ) => {
+      const ext = path.extname(filePath);
+      const res: `${string}${Extension}` = `${filePath.slice(0, filePath.length - ext.length)}${extension}`;
+      return res;
+    },
+  );
+
   return context;
 }
 

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -22,15 +22,13 @@
  *   sinon.assert.calledOnceWithExactly(page.emulate, {networkConditions: 'Slow 3G'});
  */
 
-import path from 'node:path';
-
 import type {Frame} from 'puppeteer-core';
 import sinon from 'sinon';
 
 import {McpContext} from '../src/McpContext.js';
 import {McpPage} from '../src/McpPage.js';
 import {McpResponse} from '../src/McpResponse.js';
-import {CdpPage, ScreenRecorder} from '../src/third_party/index.js';
+import {CdpPage} from '../src/third_party/index.js';
 import type {Page} from '../src/third_party/index.js';
 
 export type MockMcpPage = sinon.SinonStubbedInstance<McpPage> & {
@@ -38,7 +36,6 @@ export type MockMcpPage = sinon.SinonStubbedInstance<McpPage> & {
 };
 export type MockMcpContext = sinon.SinonStubbedInstance<McpContext>;
 export type MockMcpResponse = sinon.SinonStubbedInstance<McpResponse>;
-export type MockScreenRecorder = sinon.SinonStubbedInstance<ScreenRecorder>;
 
 /**
  * A minimal event emitter used to back mocked `on`/`off`/`emit` methods on
@@ -101,12 +98,6 @@ export function createMockPuppeteerPage(): sinon.SinonStubbedInstance<Page> {
   return page;
 }
 
-export function createMockScreenRecorder(): MockScreenRecorder {
-  const recorder = sinon.createStubInstance(ScreenRecorder);
-  recorder.stop.resolves();
-  return recorder;
-}
-
 export function createMockMcpPage(
   options: {pptrPage?: sinon.SinonStubbedInstance<Page>} = {},
 ): MockMcpPage {
@@ -127,23 +118,11 @@ export function createMockMcpContext(
   const page = options.selectedPage ?? createMockMcpPage();
   context.getSelectedMcpPage.returns(page satisfies McpPage);
 
-  let screenRecorderData: {recorder: ScreenRecorder; filePath: string} | null =
-    null;
+  let screenRecorderData: ReturnType<McpContext['getScreenRecorder']> = null;
   context.getScreenRecorder.callsFake(() => screenRecorderData);
   context.setScreenRecorder.callsFake(data => {
     screenRecorderData = data;
   });
-
-  context.ensureExtension.callsFake(
-    async <Extension extends `.${string}`>(
-      filePath: string,
-      extension: Extension,
-    ) => {
-      const ext = path.extname(filePath);
-      const res: `${string}${Extension}` = `${filePath.slice(0, filePath.length - ext.length)}${extension}`;
-      return res;
-    },
-  );
 
   return context;
 }

--- a/tests/tools/screencast.test.ts
+++ b/tests/tools/screencast.test.ts
@@ -13,8 +13,20 @@ import {afterEach, describe, it} from 'node:test';
 import sinon from 'sinon';
 
 import {parseArguments} from '../../src/config/mcp-options.js';
+import {ScreenRecorder} from '../../src/third_party/index.js';
 import {startScreencast, stopScreencast} from '../../src/tools/screencast.js';
-import {createHandlerMocks, createMockScreenRecorder} from '../mocks.js';
+import {createHandlerMocks} from '../mocks.js';
+
+function createMockScreenRecorder(): sinon.SinonStubbedInstance<ScreenRecorder> {
+  return sinon.createStubInstance(ScreenRecorder);
+}
+
+function createScreencastMocks() {
+  const {page, context, response} = createHandlerMocks();
+  const mockRecorder = createMockScreenRecorder();
+  page.pptrPage.screencast.resolves(mockRecorder);
+  return {page, context, response, mockRecorder};
+}
 
 describe('screencast', () => {
   afterEach(() => {
@@ -23,15 +35,14 @@ describe('screencast', () => {
 
   describe('screencast_start', () => {
     it('starts a screencast recording with filePath', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const mockRecorder = createMockScreenRecorder();
-      const screencastStub = page.pptrPage.screencast;
-      screencastStub.resolves(mockRecorder);
+      const {page, context, response, mockRecorder} = createScreencastMocks();
 
       const filePath = path.join(
         os.tmpdir(),
         'test-recording.mp4',
       ) as `${string}.mp4`;
+      context.ensureExtension.resolves(filePath as never);
+
       await startScreencast().handler(
         {
           params: {filePath},
@@ -41,16 +52,13 @@ describe('screencast', () => {
         context,
       );
 
-      sinon.assert.calledOnceWithExactly(screencastStub, {
+      sinon.assert.calledOnceWithExactly(page.pptrPage.screencast, {
         path: filePath,
         format: 'mp4',
         ffmpegPath: undefined,
         fps: undefined,
       });
-      assert.strictEqual(
-        context.getScreenRecorder()?.recorder,
-        mockRecorder,
-      );
+      assert.strictEqual(context.getScreenRecorder()?.recorder, mockRecorder);
       sinon.assert.calledOnceWithExactly(
         response.appendResponseLine,
         `Screencast recording started. The recording will be saved to ${filePath}. Use screencast_stop to stop recording.`,
@@ -58,16 +66,15 @@ describe('screencast', () => {
     });
 
     it('records WebM for an uppercase extension (case-insensitive)', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const mockRecorder = createMockScreenRecorder();
-      const screencastStub = page.pptrPage.screencast;
-      screencastStub.resolves(mockRecorder);
+      const {page, context, response} = createScreencastMocks();
 
       const requestedPath = path.join(os.tmpdir(), 'test-recording.WEBM');
       const expectedPath = path.join(
         os.tmpdir(),
         'test-recording.webm',
       ) as `${string}.webm`;
+      context.ensureExtension.resolves(expectedPath as never);
+
       await startScreencast().handler(
         {
           params: {filePath: requestedPath},
@@ -77,7 +84,7 @@ describe('screencast', () => {
         context,
       );
 
-      sinon.assert.calledOnceWithExactly(screencastStub, {
+      sinon.assert.calledOnceWithExactly(page.pptrPage.screencast, {
         path: expectedPath,
         format: 'webm',
         ffmpegPath: undefined,
@@ -86,8 +93,7 @@ describe('screencast', () => {
     });
 
     it('rejects an unsupported extension instead of silently using mp4', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const screencastStub = page.pptrPage.screencast;
+      const {page, context, response} = createScreencastMocks();
 
       await assert.rejects(
         startScreencast().handler(
@@ -101,24 +107,22 @@ describe('screencast', () => {
         /Unsupported screencast file extension/,
       );
 
-      sinon.assert.notCalled(screencastStub);
+      sinon.assert.notCalled(page.pptrPage.screencast);
       assert.strictEqual(context.getScreenRecorder(), null);
     });
 
     it('starts a screencast recording with temp file when no filePath', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const mockRecorder = createMockScreenRecorder();
-      const screencastStub = page.pptrPage.screencast;
-      screencastStub.resolves(mockRecorder);
+      const {page, context, response, mockRecorder} = createScreencastMocks();
+      const expectedPath = path.join(
+        os.tmpdir(),
+        'temp-screencast.mp4',
+      ) as `${string}.mp4`;
+      context.ensureExtension.resolves(expectedPath as never);
 
-      await startScreencast().handler(
-        {params: {}, page},
-        response,
-        context,
-      );
+      await startScreencast().handler({params: {}, page}, response, context);
 
-      sinon.assert.calledOnce(screencastStub);
-      const callArgs = screencastStub.firstCall.args[0];
+      sinon.assert.calledOnce(page.pptrPage.screencast);
+      const callArgs = page.pptrPage.screencast.firstCall.args[0];
       assert.ok(callArgs);
       assert.ok(callArgs.path?.endsWith('.mp4'));
       assert.strictEqual(callArgs.format, 'mp4');
@@ -126,22 +130,15 @@ describe('screencast', () => {
     });
 
     it('errors if a recording is already active', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const mockRecorder = createMockScreenRecorder();
+      const {page, context, response, mockRecorder} = createScreencastMocks();
       context.setScreenRecorder({
         recorder: mockRecorder,
         filePath: path.join(os.tmpdir(), 'existing.mp4'),
       });
 
-      const screencastStub = page.pptrPage.screencast;
+      await startScreencast().handler({params: {}, page}, response, context);
 
-      await startScreencast().handler(
-        {params: {}, page},
-        response,
-        context,
-      );
-
-      sinon.assert.notCalled(screencastStub);
+      sinon.assert.notCalled(page.pptrPage.screencast);
       sinon.assert.calledOnceWithExactly(
         response.appendResponseLine,
         'Error: a screencast recording is already in progress. Use screencast_stop to stop it before starting a new one.',
@@ -149,14 +146,15 @@ describe('screencast', () => {
     });
 
     it('provides a clear error when ffmpeg is not found', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const error = new Error('spawn ffmpeg ENOENT');
-      page.pptrPage.screencast.rejects(error);
+      const {page, context, response} = createScreencastMocks();
+      const filePath = path.join(os.tmpdir(), 'test.mp4') as `${string}.mp4`;
+      context.ensureExtension.resolves(filePath as never);
+      page.pptrPage.screencast.rejects(new Error('spawn ffmpeg ENOENT'));
 
       await assert.rejects(
         startScreencast().handler(
           {
-            params: {filePath: path.join(os.tmpdir(), 'test.mp4')},
+            params: {filePath},
             page,
           },
           response,
@@ -169,30 +167,25 @@ describe('screencast', () => {
     });
 
     it('cleans up the generated temp directory if recording fails to start', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const screencastStub = page.pptrPage.screencast;
-      screencastStub.rejects(new Error('spawn ffmpeg ENOENT'));
+      const {page, context, response} = createScreencastMocks();
+      context.ensureExtension.callsFake(async filePath => filePath as never);
+      page.pptrPage.screencast.rejects(new Error('spawn ffmpeg ENOENT'));
 
       await assert.rejects(
-        startScreencast().handler(
-          {params: {}, page},
-          response,
-          context,
-        ),
+        startScreencast().handler({params: {}, page}, response, context),
         /ffmpeg is required for screencast recording/,
       );
 
-      const tempPath = screencastStub.firstCall.args[0]?.path;
+      const tempPath = page.pptrPage.screencast.firstCall.args[0]?.path;
       assert.ok(tempPath);
       await assert.rejects(fs.access(path.dirname(tempPath)));
       assert.strictEqual(context.getScreenRecorder(), null);
     });
 
     it('passes ffmpegPath from args to puppeteer', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const mockRecorder = createMockScreenRecorder();
-      const screencastStub = page.pptrPage.screencast;
-      screencastStub.resolves(mockRecorder);
+      const {page, context, response} = createScreencastMocks();
+      const filePath = path.join(os.tmpdir(), 'test.mp4') as `${string}.mp4`;
+      context.ensureExtension.resolves(filePath as never);
 
       const experimentalFfmpegPath = '/custom/path/to/ffmpeg';
       const args = parseArguments('test', [
@@ -207,8 +200,8 @@ describe('screencast', () => {
         context,
       );
 
-      sinon.assert.calledOnceWithExactly(screencastStub, {
-        path: screencastStub.firstCall.args[0]?.path,
+      sinon.assert.calledOnceWithExactly(page.pptrPage.screencast, {
+        path: filePath,
         format: 'mp4',
         ffmpegPath: experimentalFfmpegPath,
         fps: undefined,
@@ -216,10 +209,9 @@ describe('screencast', () => {
     });
 
     it('passes screencast fps from args to puppeteer', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const mockRecorder = createMockScreenRecorder();
-      const screencastStub = page.pptrPage.screencast;
-      screencastStub.resolves(mockRecorder);
+      const {page, context, response} = createScreencastMocks();
+      const filePath = path.join(os.tmpdir(), 'test.mp4') as `${string}.mp4`;
+      context.ensureExtension.resolves(filePath as never);
 
       const args = parseArguments('test', [
         'node',
@@ -233,8 +225,8 @@ describe('screencast', () => {
         context,
       );
 
-      sinon.assert.calledOnceWithExactly(screencastStub, {
-        path: screencastStub.firstCall.args[0]?.path,
+      sinon.assert.calledOnceWithExactly(page.pptrPage.screencast, {
+        path: filePath,
         format: 'mp4',
         ffmpegPath: undefined,
         fps: 10,
@@ -244,13 +236,9 @@ describe('screencast', () => {
 
   describe('screencast_stop', () => {
     it('returns an error message if no recording is active', async () => {
-      const {page, context, response} = createHandlerMocks();
+      const {page, context, response} = createScreencastMocks();
       assert.strictEqual(context.getScreenRecorder(), null);
-      await stopScreencast.handler(
-        {params: {}, page},
-        response,
-        context,
-      );
+      await stopScreencast.handler({params: {}, page}, response, context);
       sinon.assert.calledOnceWithExactly(
         response.appendResponseLine,
         'Error: no active screencast recording to stop.',
@@ -258,19 +246,14 @@ describe('screencast', () => {
     });
 
     it('stops an active recording and reports the file path', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const mockRecorder = createMockScreenRecorder();
+      const {page, context, response, mockRecorder} = createScreencastMocks();
       const filePath = path.join(os.tmpdir(), 'test-recording.mp4');
       context.setScreenRecorder({
         recorder: mockRecorder,
         filePath,
       });
 
-      await stopScreencast.handler(
-        {params: {}, page},
-        response,
-        context,
-      );
+      await stopScreencast.handler({params: {}, page}, response, context);
 
       sinon.assert.calledOnce(mockRecorder.stop);
       assert.strictEqual(context.getScreenRecorder(), null);
@@ -281,8 +264,7 @@ describe('screencast', () => {
     });
 
     it('clears the recorder even if stop() throws', async () => {
-      const {page, context, response} = createHandlerMocks();
-      const mockRecorder = createMockScreenRecorder();
+      const {page, context, response, mockRecorder} = createScreencastMocks();
       mockRecorder.stop.rejects(new Error('ffmpeg process error'));
       context.setScreenRecorder({
         recorder: mockRecorder,
@@ -290,11 +272,7 @@ describe('screencast', () => {
       });
 
       await assert.rejects(
-        stopScreencast.handler(
-          {params: {}, page},
-          response,
-          context,
-        ),
+        stopScreencast.handler({params: {}, page}, response, context),
         /ffmpeg process error/,
       );
 

--- a/tests/tools/screencast.test.ts
+++ b/tests/tools/screencast.test.ts
@@ -8,19 +8,13 @@ import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import {describe, it, afterEach} from 'node:test';
+import {afterEach, describe, it} from 'node:test';
 
 import sinon from 'sinon';
 
 import {parseArguments} from '../../src/config/mcp-options.js';
 import {startScreencast, stopScreencast} from '../../src/tools/screencast.js';
-import {withMcpContext} from '../utils.js';
-
-function createMockRecorder() {
-  return {
-    stop: sinon.stub().resolves(),
-  };
-}
+import {createHandlerMocks, createMockScreenRecorder} from '../mocks.js';
 
 describe('screencast', () => {
   afterEach(() => {
@@ -29,293 +23,283 @@ describe('screencast', () => {
 
   describe('screencast_start', () => {
     it('starts a screencast recording with filePath', async () => {
-      await withMcpContext(async (response, context) => {
-        const mockRecorder = createMockRecorder();
-        const selectedPage = context.getSelectedMcpPage().pptrPage;
-        const screencastStub = sinon
-          .stub(selectedPage, 'screencast')
-          .resolves(mockRecorder as never);
+      const {page, context, response} = createHandlerMocks();
+      const mockRecorder = createMockScreenRecorder();
+      const screencastStub = page.pptrPage.screencast;
+      screencastStub.resolves(mockRecorder);
 
-        await startScreencast().handler(
-          {
-            params: {filePath: path.join(os.tmpdir(), 'test-recording.mp4')},
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
+      const filePath = path.join(
+        os.tmpdir(),
+        'test-recording.mp4',
+      ) as `${string}.mp4`;
+      await startScreencast().handler(
+        {
+          params: {filePath},
+          page,
+        },
+        response,
+        context,
+      );
 
-        sinon.assert.calledOnce(screencastStub);
-        const callArgs = screencastStub.firstCall.args[0];
-        assert.ok(callArgs);
-        assert.ok(callArgs.path?.endsWith('test-recording.mp4'));
-
-        assert.ok(context.getScreenRecorder() !== null);
-        assert.ok(
-          response.responseLines
-            .join('\n')
-            .includes('Screencast recording started'),
-        );
+      sinon.assert.calledOnceWithExactly(screencastStub, {
+        path: filePath,
+        format: 'mp4',
+        ffmpegPath: undefined,
+        fps: undefined,
       });
+      assert.strictEqual(
+        context.getScreenRecorder()?.recorder,
+        mockRecorder,
+      );
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        `Screencast recording started. The recording will be saved to ${filePath}. Use screencast_stop to stop recording.`,
+      );
     });
 
     it('records WebM for an uppercase extension (case-insensitive)', async () => {
-      await withMcpContext(async (response, context) => {
-        const mockRecorder = createMockRecorder();
-        const selectedPage = context.getSelectedMcpPage().pptrPage;
-        const screencastStub = sinon
-          .stub(selectedPage, 'screencast')
-          .resolves(mockRecorder as never);
+      const {page, context, response} = createHandlerMocks();
+      const mockRecorder = createMockScreenRecorder();
+      const screencastStub = page.pptrPage.screencast;
+      screencastStub.resolves(mockRecorder);
 
-        await startScreencast().handler(
-          {
-            params: {filePath: path.join(os.tmpdir(), 'test-recording.WEBM')},
-            page: context.getSelectedMcpPage(),
-          },
-          response,
-          context,
-        );
+      const requestedPath = path.join(os.tmpdir(), 'test-recording.WEBM');
+      const expectedPath = path.join(
+        os.tmpdir(),
+        'test-recording.webm',
+      ) as `${string}.webm`;
+      await startScreencast().handler(
+        {
+          params: {filePath: requestedPath},
+          page,
+        },
+        response,
+        context,
+      );
 
-        sinon.assert.calledOnce(screencastStub);
-        const callArgs = screencastStub.firstCall.args[0];
-        assert.ok(callArgs);
-        assert.strictEqual(callArgs.format, 'webm');
-        assert.ok(callArgs.path?.endsWith('.webm'));
+      sinon.assert.calledOnceWithExactly(screencastStub, {
+        path: expectedPath,
+        format: 'webm',
+        ffmpegPath: undefined,
+        fps: undefined,
       });
     });
 
     it('rejects an unsupported extension instead of silently using mp4', async () => {
-      await withMcpContext(async (response, context) => {
-        const selectedPage = context.getSelectedMcpPage().pptrPage;
-        const screencastStub = sinon.stub(selectedPage, 'screencast');
+      const {page, context, response} = createHandlerMocks();
+      const screencastStub = page.pptrPage.screencast;
 
-        await assert.rejects(
-          startScreencast().handler(
-            {
-              params: {filePath: path.join(os.tmpdir(), 'recording.avi')},
-              page: context.getSelectedMcpPage(),
-            },
-            response,
-            context,
-          ),
-          /Unsupported screencast file extension/,
-        );
+      await assert.rejects(
+        startScreencast().handler(
+          {
+            params: {filePath: path.join(os.tmpdir(), 'recording.avi')},
+            page,
+          },
+          response,
+          context,
+        ),
+        /Unsupported screencast file extension/,
+      );
 
-        sinon.assert.notCalled(screencastStub);
-        assert.strictEqual(context.getScreenRecorder(), null);
-      });
+      sinon.assert.notCalled(screencastStub);
+      assert.strictEqual(context.getScreenRecorder(), null);
     });
 
     it('starts a screencast recording with temp file when no filePath', async () => {
-      await withMcpContext(async (response, context) => {
-        const mockRecorder = createMockRecorder();
-        const selectedPage = context.getSelectedMcpPage().pptrPage;
-        const screencastStub = sinon
-          .stub(selectedPage, 'screencast')
-          .resolves(mockRecorder as never);
+      const {page, context, response} = createHandlerMocks();
+      const mockRecorder = createMockScreenRecorder();
+      const screencastStub = page.pptrPage.screencast;
+      screencastStub.resolves(mockRecorder);
 
-        await startScreencast().handler(
-          {params: {}, page: context.getSelectedMcpPage()},
-          response,
-          context,
-        );
+      await startScreencast().handler(
+        {params: {}, page},
+        response,
+        context,
+      );
 
-        sinon.assert.calledOnce(screencastStub);
-        const callArgs = screencastStub.firstCall.args[0];
-        assert.ok(callArgs);
-        assert.ok(callArgs.path?.endsWith('.mp4'));
-        assert.ok(context.getScreenRecorder() !== null);
-      });
+      sinon.assert.calledOnce(screencastStub);
+      const callArgs = screencastStub.firstCall.args[0];
+      assert.ok(callArgs);
+      assert.ok(callArgs.path?.endsWith('.mp4'));
+      assert.strictEqual(callArgs.format, 'mp4');
+      assert.strictEqual(context.getScreenRecorder()?.recorder, mockRecorder);
     });
 
     it('errors if a recording is already active', async () => {
-      await withMcpContext(async (response, context) => {
-        const mockRecorder = createMockRecorder();
-        context.setScreenRecorder({
-          recorder: mockRecorder as never,
-          filePath: path.join(os.tmpdir(), 'existing.mp4'),
-        });
-
-        const selectedPage = context.getSelectedMcpPage().pptrPage;
-        const screencastStub = sinon.stub(selectedPage, 'screencast');
-
-        await startScreencast().handler(
-          {params: {}, page: context.getSelectedMcpPage()},
-          response,
-          context,
-        );
-
-        sinon.assert.notCalled(screencastStub);
-        assert.ok(
-          response.responseLines
-            .join('\n')
-            .includes('a screencast recording is already in progress'),
-        );
+      const {page, context, response} = createHandlerMocks();
+      const mockRecorder = createMockScreenRecorder();
+      context.setScreenRecorder({
+        recorder: mockRecorder,
+        filePath: path.join(os.tmpdir(), 'existing.mp4'),
       });
+
+      const screencastStub = page.pptrPage.screencast;
+
+      await startScreencast().handler(
+        {params: {}, page},
+        response,
+        context,
+      );
+
+      sinon.assert.notCalled(screencastStub);
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        'Error: a screencast recording is already in progress. Use screencast_stop to stop it before starting a new one.',
+      );
     });
 
     it('provides a clear error when ffmpeg is not found', async () => {
-      await withMcpContext(async (response, context) => {
-        const selectedPage = context.getSelectedMcpPage().pptrPage;
-        const error = new Error('spawn ffmpeg ENOENT');
-        sinon.stub(selectedPage, 'screencast').rejects(error);
+      const {page, context, response} = createHandlerMocks();
+      const error = new Error('spawn ffmpeg ENOENT');
+      page.pptrPage.screencast.rejects(error);
 
-        await assert.rejects(
-          startScreencast().handler(
-            {
-              params: {filePath: path.join(os.tmpdir(), 'test.mp4')},
-              page: context.getSelectedMcpPage(),
-            },
-            response,
-            context,
-          ),
-          /ffmpeg is required for screencast recording/,
-        );
+      await assert.rejects(
+        startScreencast().handler(
+          {
+            params: {filePath: path.join(os.tmpdir(), 'test.mp4')},
+            page,
+          },
+          response,
+          context,
+        ),
+        /ffmpeg is required for screencast recording/,
+      );
 
-        assert.strictEqual(context.getScreenRecorder(), null);
-      });
+      assert.strictEqual(context.getScreenRecorder(), null);
     });
 
     it('cleans up the generated temp directory if recording fails to start', async () => {
-      await withMcpContext(async (response, context) => {
-        const selectedPage = context.getSelectedMcpPage().pptrPage;
-        const screencastStub = sinon
-          .stub(selectedPage, 'screencast')
-          .rejects(new Error('spawn ffmpeg ENOENT'));
+      const {page, context, response} = createHandlerMocks();
+      const screencastStub = page.pptrPage.screencast;
+      screencastStub.rejects(new Error('spawn ffmpeg ENOENT'));
 
-        await assert.rejects(
-          startScreencast().handler(
-            {params: {}, page: context.getSelectedMcpPage()},
-            response,
-            context,
-          ),
-          /ffmpeg is required for screencast recording/,
-        );
+      await assert.rejects(
+        startScreencast().handler(
+          {params: {}, page},
+          response,
+          context,
+        ),
+        /ffmpeg is required for screencast recording/,
+      );
 
-        // The temp directory generateTempFilePath() created must be removed.
-        const tempPath = screencastStub.firstCall.args[0]?.path as string;
-        assert.ok(tempPath);
-        await assert.rejects(fs.access(path.dirname(tempPath)));
-        assert.strictEqual(context.getScreenRecorder(), null);
-      });
+      const tempPath = screencastStub.firstCall.args[0]?.path;
+      assert.ok(tempPath);
+      await assert.rejects(fs.access(path.dirname(tempPath)));
+      assert.strictEqual(context.getScreenRecorder(), null);
     });
 
     it('passes ffmpegPath from args to puppeteer', async () => {
-      await withMcpContext(async (response, context) => {
-        const mockRecorder = createMockRecorder();
-        const selectedPage = context.getSelectedMcpPage().pptrPage;
-        const screencastStub = sinon
-          .stub(selectedPage, 'screencast')
-          .resolves(mockRecorder as never);
+      const {page, context, response} = createHandlerMocks();
+      const mockRecorder = createMockScreenRecorder();
+      const screencastStub = page.pptrPage.screencast;
+      screencastStub.resolves(mockRecorder);
 
-        const experimentalFfmpegPath = '/custom/path/to/ffmpeg';
-        const args = parseArguments('test', [
-          'node',
-          'test',
-          '--experimental-screencast',
-          `--experimental-ffmpeg-path=${experimentalFfmpegPath}`,
-        ]);
-        await startScreencast(args).handler(
-          {params: {}, page: context.getSelectedMcpPage()},
-          response,
-          context,
-        );
+      const experimentalFfmpegPath = '/custom/path/to/ffmpeg';
+      const args = parseArguments('test', [
+        'node',
+        'test',
+        '--experimental-screencast',
+        `--experimental-ffmpeg-path=${experimentalFfmpegPath}`,
+      ]);
+      await startScreencast(args).handler(
+        {params: {}, page},
+        response,
+        context,
+      );
 
-        sinon.assert.calledOnce(screencastStub);
-        const callArgs = screencastStub.firstCall.args[0];
-        assert.strictEqual(callArgs?.ffmpegPath, experimentalFfmpegPath);
+      sinon.assert.calledOnceWithExactly(screencastStub, {
+        path: screencastStub.firstCall.args[0]?.path,
+        format: 'mp4',
+        ffmpegPath: experimentalFfmpegPath,
+        fps: undefined,
       });
     });
 
     it('passes screencast fps from args to puppeteer', async () => {
-      await withMcpContext(async (response, context) => {
-        const mockRecorder = createMockRecorder();
-        const selectedPage = context.getSelectedMcpPage().pptrPage;
-        const screencastStub = sinon
-          .stub(selectedPage, 'screencast')
-          .resolves(mockRecorder as never);
+      const {page, context, response} = createHandlerMocks();
+      const mockRecorder = createMockScreenRecorder();
+      const screencastStub = page.pptrPage.screencast;
+      screencastStub.resolves(mockRecorder);
 
-        const args = parseArguments('test', [
-          'node',
-          'test',
-          '--experimental-screencast',
-          '--experimental-screencast-fps=10',
-        ]);
-        await startScreencast(args).handler(
-          {params: {}, page: context.getSelectedMcpPage()},
-          response,
-          context,
-        );
+      const args = parseArguments('test', [
+        'node',
+        'test',
+        '--experimental-screencast',
+        '--experimental-screencast-fps=10',
+      ]);
+      await startScreencast(args).handler(
+        {params: {}, page},
+        response,
+        context,
+      );
 
-        sinon.assert.calledOnce(screencastStub);
-        const callArgs = screencastStub.firstCall.args[0];
-        assert.strictEqual(callArgs?.fps, 10);
+      sinon.assert.calledOnceWithExactly(screencastStub, {
+        path: screencastStub.firstCall.args[0]?.path,
+        format: 'mp4',
+        ffmpegPath: undefined,
+        fps: 10,
       });
     });
   });
 
   describe('screencast_stop', () => {
     it('returns an error message if no recording is active', async () => {
-      await withMcpContext(async (response, context) => {
-        assert.strictEqual(context.getScreenRecorder(), null);
-        await stopScreencast.handler(
-          {params: {}, page: context.getSelectedMcpPage()},
-          response,
-          context,
-        );
-        assert.ok(
-          response.responseLines
-            .join('\n')
-            .includes('no active screencast recording to stop'),
-        );
-      });
+      const {page, context, response} = createHandlerMocks();
+      assert.strictEqual(context.getScreenRecorder(), null);
+      await stopScreencast.handler(
+        {params: {}, page},
+        response,
+        context,
+      );
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        'Error: no active screencast recording to stop.',
+      );
     });
 
     it('stops an active recording and reports the file path', async () => {
-      await withMcpContext(async (response, context) => {
-        const mockRecorder = createMockRecorder();
-        const filePath = path.join(os.tmpdir(), 'test-recording.mp4');
-        context.setScreenRecorder({
-          recorder: mockRecorder as never,
-          filePath,
-        });
-
-        await stopScreencast.handler(
-          {params: {}, page: context.getSelectedMcpPage()},
-          response,
-          context,
-        );
-
-        sinon.assert.calledOnce(mockRecorder.stop);
-        assert.strictEqual(context.getScreenRecorder(), null);
-        assert.ok(
-          response.responseLines
-            .join('\n')
-            .includes(`stopped and saved to ${filePath}`),
-        );
+      const {page, context, response} = createHandlerMocks();
+      const mockRecorder = createMockScreenRecorder();
+      const filePath = path.join(os.tmpdir(), 'test-recording.mp4');
+      context.setScreenRecorder({
+        recorder: mockRecorder,
+        filePath,
       });
+
+      await stopScreencast.handler(
+        {params: {}, page},
+        response,
+        context,
+      );
+
+      sinon.assert.calledOnce(mockRecorder.stop);
+      assert.strictEqual(context.getScreenRecorder(), null);
+      sinon.assert.calledOnceWithExactly(
+        response.appendResponseLine,
+        `The screencast recording has been stopped and saved to ${filePath}.`,
+      );
     });
 
     it('clears the recorder even if stop() throws', async () => {
-      await withMcpContext(async (response, context) => {
-        const mockRecorder = createMockRecorder();
-        mockRecorder.stop.rejects(new Error('ffmpeg process error'));
-        context.setScreenRecorder({
-          recorder: mockRecorder as never,
-          filePath: path.join(os.tmpdir(), 'test.mp4'),
-        });
-
-        await assert.rejects(
-          stopScreencast.handler(
-            {params: {}, page: context.getSelectedMcpPage()},
-            response,
-            context,
-          ),
-          /ffmpeg process error/,
-        );
-
-        assert.strictEqual(context.getScreenRecorder(), null);
+      const {page, context, response} = createHandlerMocks();
+      const mockRecorder = createMockScreenRecorder();
+      mockRecorder.stop.rejects(new Error('ffmpeg process error'));
+      context.setScreenRecorder({
+        recorder: mockRecorder,
+        filePath: path.join(os.tmpdir(), 'test.mp4'),
       });
+
+      await assert.rejects(
+        stopScreencast.handler(
+          {params: {}, page},
+          response,
+          context,
+        ),
+        /ffmpeg process error/,
+      );
+
+      sinon.assert.calledOnce(mockRecorder.stop);
+      assert.strictEqual(context.getScreenRecorder(), null);
     });
   });
 });

--- a/tests/tools/screencast.test.ts
+++ b/tests/tools/screencast.test.ts
@@ -25,6 +25,7 @@ function createScreencastMocks() {
   const {page, context, response} = createHandlerMocks();
   const mockRecorder = createMockScreenRecorder();
   page.pptrPage.screencast.resolves(mockRecorder);
+  context.getScreenRecorder.returns(null);
   return {page, context, response, mockRecorder};
 }
 
@@ -37,11 +38,11 @@ describe('screencast', () => {
     it('starts a screencast recording with filePath', async () => {
       const {page, context, response, mockRecorder} = createScreencastMocks();
 
-      const filePath = path.join(
+      const filePath: `${string}.mp4` = `${path.join(
         os.tmpdir(),
-        'test-recording.mp4',
-      ) as `${string}.mp4`;
-      context.ensureExtension.resolves(filePath as never);
+        'test-recording',
+      )}.mp4`;
+      context.ensureExtension.resolves(filePath);
 
       await startScreencast().handler(
         {
@@ -52,13 +53,21 @@ describe('screencast', () => {
         context,
       );
 
+      sinon.assert.calledOnceWithExactly(
+        context.ensureExtension,
+        filePath,
+        '.mp4',
+      );
       sinon.assert.calledOnceWithExactly(page.pptrPage.screencast, {
         path: filePath,
         format: 'mp4',
         ffmpegPath: undefined,
         fps: undefined,
       });
-      assert.strictEqual(context.getScreenRecorder()?.recorder, mockRecorder);
+      sinon.assert.calledOnceWithExactly(context.setScreenRecorder, {
+        recorder: mockRecorder,
+        filePath,
+      });
       sinon.assert.calledOnceWithExactly(
         response.appendResponseLine,
         `Screencast recording started. The recording will be saved to ${filePath}. Use screencast_stop to stop recording.`,
@@ -66,14 +75,14 @@ describe('screencast', () => {
     });
 
     it('records WebM for an uppercase extension (case-insensitive)', async () => {
-      const {page, context, response} = createScreencastMocks();
+      const {page, context, response, mockRecorder} = createScreencastMocks();
 
-      const requestedPath = path.join(os.tmpdir(), 'test-recording.WEBM');
-      const expectedPath = path.join(
+      const requestedPath = `${path.join(os.tmpdir(), 'test-recording')}.WEBM`;
+      const expectedPath: `${string}.webm` = `${path.join(
         os.tmpdir(),
-        'test-recording.webm',
-      ) as `${string}.webm`;
-      context.ensureExtension.resolves(expectedPath as never);
+        'test-recording',
+      )}.webm`;
+      context.ensureExtension.resolves(expectedPath);
 
       await startScreencast().handler(
         {
@@ -84,21 +93,31 @@ describe('screencast', () => {
         context,
       );
 
+      sinon.assert.calledOnceWithExactly(
+        context.ensureExtension,
+        requestedPath,
+        '.webm',
+      );
       sinon.assert.calledOnceWithExactly(page.pptrPage.screencast, {
         path: expectedPath,
         format: 'webm',
         ffmpegPath: undefined,
         fps: undefined,
       });
+      sinon.assert.calledOnceWithExactly(context.setScreenRecorder, {
+        recorder: mockRecorder,
+        filePath: expectedPath,
+      });
     });
 
     it('rejects an unsupported extension instead of silently using mp4', async () => {
       const {page, context, response} = createScreencastMocks();
+      const filePath = `${path.join(os.tmpdir(), 'recording')}.avi`;
 
       await assert.rejects(
         startScreencast().handler(
           {
-            params: {filePath: path.join(os.tmpdir(), 'recording.avi')},
+            params: {filePath},
             page,
           },
           response,
@@ -107,38 +126,48 @@ describe('screencast', () => {
         /Unsupported screencast file extension/,
       );
 
+      sinon.assert.notCalled(context.ensureExtension);
       sinon.assert.notCalled(page.pptrPage.screencast);
-      assert.strictEqual(context.getScreenRecorder(), null);
+      sinon.assert.notCalled(context.setScreenRecorder);
     });
 
     it('starts a screencast recording with temp file when no filePath', async () => {
       const {page, context, response, mockRecorder} = createScreencastMocks();
-      const expectedPath = path.join(
+      const expectedPath: `${string}.mp4` = `${path.join(
         os.tmpdir(),
-        'temp-screencast.mp4',
-      ) as `${string}.mp4`;
-      context.ensureExtension.resolves(expectedPath as never);
+        'temp-screencast',
+      )}.mp4`;
+      context.ensureExtension.resolves(expectedPath);
 
       await startScreencast().handler({params: {}, page}, response, context);
 
-      sinon.assert.calledOnce(page.pptrPage.screencast);
-      const callArgs = page.pptrPage.screencast.firstCall.args[0];
-      assert.ok(callArgs);
-      assert.ok(callArgs.path?.endsWith('.mp4'));
-      assert.strictEqual(callArgs.format, 'mp4');
-      assert.strictEqual(context.getScreenRecorder()?.recorder, mockRecorder);
+      sinon.assert.calledOnce(context.ensureExtension);
+      assert.ok(context.ensureExtension.firstCall.args[0].endsWith('.mp4'));
+      assert.strictEqual(context.ensureExtension.firstCall.args[1], '.mp4');
+      sinon.assert.calledOnceWithExactly(page.pptrPage.screencast, {
+        path: expectedPath,
+        format: 'mp4',
+        ffmpegPath: undefined,
+        fps: undefined,
+      });
+      sinon.assert.calledOnceWithExactly(context.setScreenRecorder, {
+        recorder: mockRecorder,
+        filePath: expectedPath,
+      });
     });
 
     it('errors if a recording is already active', async () => {
       const {page, context, response, mockRecorder} = createScreencastMocks();
-      context.setScreenRecorder({
+      context.getScreenRecorder.returns({
         recorder: mockRecorder,
-        filePath: path.join(os.tmpdir(), 'existing.mp4'),
+        filePath: `${path.join(os.tmpdir(), 'existing')}.mp4`,
       });
 
       await startScreencast().handler({params: {}, page}, response, context);
 
+      sinon.assert.notCalled(context.ensureExtension);
       sinon.assert.notCalled(page.pptrPage.screencast);
+      sinon.assert.notCalled(context.setScreenRecorder);
       sinon.assert.calledOnceWithExactly(
         response.appendResponseLine,
         'Error: a screencast recording is already in progress. Use screencast_stop to stop it before starting a new one.',
@@ -147,8 +176,8 @@ describe('screencast', () => {
 
     it('provides a clear error when ffmpeg is not found', async () => {
       const {page, context, response} = createScreencastMocks();
-      const filePath = path.join(os.tmpdir(), 'test.mp4') as `${string}.mp4`;
-      context.ensureExtension.resolves(filePath as never);
+      const filePath: `${string}.mp4` = `${path.join(os.tmpdir(), 'test')}.mp4`;
+      context.ensureExtension.resolves(filePath);
       page.pptrPage.screencast.rejects(new Error('spawn ffmpeg ENOENT'));
 
       await assert.rejects(
@@ -163,12 +192,17 @@ describe('screencast', () => {
         /ffmpeg is required for screencast recording/,
       );
 
-      assert.strictEqual(context.getScreenRecorder(), null);
+      sinon.assert.calledOnceWithExactly(
+        context.ensureExtension,
+        filePath,
+        '.mp4',
+      );
+      sinon.assert.notCalled(context.setScreenRecorder);
     });
 
     it('cleans up the generated temp directory if recording fails to start', async () => {
       const {page, context, response} = createScreencastMocks();
-      context.ensureExtension.callsFake(async filePath => filePath as never);
+      context.ensureExtension.callsFake(async filePath => `${filePath}.mp4`);
       page.pptrPage.screencast.rejects(new Error('spawn ffmpeg ENOENT'));
 
       await assert.rejects(
@@ -179,13 +213,13 @@ describe('screencast', () => {
       const tempPath = page.pptrPage.screencast.firstCall.args[0]?.path;
       assert.ok(tempPath);
       await assert.rejects(fs.access(path.dirname(tempPath)));
-      assert.strictEqual(context.getScreenRecorder(), null);
+      sinon.assert.notCalled(context.setScreenRecorder);
     });
 
     it('passes ffmpegPath from args to puppeteer', async () => {
-      const {page, context, response} = createScreencastMocks();
-      const filePath = path.join(os.tmpdir(), 'test.mp4') as `${string}.mp4`;
-      context.ensureExtension.resolves(filePath as never);
+      const {page, context, response, mockRecorder} = createScreencastMocks();
+      const filePath: `${string}.mp4` = `${path.join(os.tmpdir(), 'test')}.mp4`;
+      context.ensureExtension.resolves(filePath);
 
       const experimentalFfmpegPath = '/custom/path/to/ffmpeg';
       const args = parseArguments('test', [
@@ -195,23 +229,32 @@ describe('screencast', () => {
         `--experimental-ffmpeg-path=${experimentalFfmpegPath}`,
       ]);
       await startScreencast(args).handler(
-        {params: {}, page},
+        {params: {filePath}, page},
         response,
         context,
       );
 
+      sinon.assert.calledOnceWithExactly(
+        context.ensureExtension,
+        filePath,
+        '.mp4',
+      );
       sinon.assert.calledOnceWithExactly(page.pptrPage.screencast, {
         path: filePath,
         format: 'mp4',
         ffmpegPath: experimentalFfmpegPath,
         fps: undefined,
       });
+      sinon.assert.calledOnceWithExactly(context.setScreenRecorder, {
+        recorder: mockRecorder,
+        filePath,
+      });
     });
 
     it('passes screencast fps from args to puppeteer', async () => {
-      const {page, context, response} = createScreencastMocks();
-      const filePath = path.join(os.tmpdir(), 'test.mp4') as `${string}.mp4`;
-      context.ensureExtension.resolves(filePath as never);
+      const {page, context, response, mockRecorder} = createScreencastMocks();
+      const filePath: `${string}.mp4` = `${path.join(os.tmpdir(), 'test')}.mp4`;
+      context.ensureExtension.resolves(filePath);
 
       const args = parseArguments('test', [
         'node',
@@ -220,16 +263,25 @@ describe('screencast', () => {
         '--experimental-screencast-fps=10',
       ]);
       await startScreencast(args).handler(
-        {params: {}, page},
+        {params: {filePath}, page},
         response,
         context,
       );
 
+      sinon.assert.calledOnceWithExactly(
+        context.ensureExtension,
+        filePath,
+        '.mp4',
+      );
       sinon.assert.calledOnceWithExactly(page.pptrPage.screencast, {
         path: filePath,
         format: 'mp4',
         ffmpegPath: undefined,
         fps: 10,
+      });
+      sinon.assert.calledOnceWithExactly(context.setScreenRecorder, {
+        recorder: mockRecorder,
+        filePath,
       });
     });
   });
@@ -237,8 +289,8 @@ describe('screencast', () => {
   describe('screencast_stop', () => {
     it('returns an error message if no recording is active', async () => {
       const {page, context, response} = createScreencastMocks();
-      assert.strictEqual(context.getScreenRecorder(), null);
       await stopScreencast.handler({params: {}, page}, response, context);
+      sinon.assert.notCalled(context.setScreenRecorder);
       sinon.assert.calledOnceWithExactly(
         response.appendResponseLine,
         'Error: no active screencast recording to stop.',
@@ -247,8 +299,8 @@ describe('screencast', () => {
 
     it('stops an active recording and reports the file path', async () => {
       const {page, context, response, mockRecorder} = createScreencastMocks();
-      const filePath = path.join(os.tmpdir(), 'test-recording.mp4');
-      context.setScreenRecorder({
+      const filePath = `${path.join(os.tmpdir(), 'test-recording')}.mp4`;
+      context.getScreenRecorder.returns({
         recorder: mockRecorder,
         filePath,
       });
@@ -256,7 +308,7 @@ describe('screencast', () => {
       await stopScreencast.handler({params: {}, page}, response, context);
 
       sinon.assert.calledOnce(mockRecorder.stop);
-      assert.strictEqual(context.getScreenRecorder(), null);
+      sinon.assert.calledOnceWithExactly(context.setScreenRecorder, null);
       sinon.assert.calledOnceWithExactly(
         response.appendResponseLine,
         `The screencast recording has been stopped and saved to ${filePath}.`,
@@ -266,9 +318,10 @@ describe('screencast', () => {
     it('clears the recorder even if stop() throws', async () => {
       const {page, context, response, mockRecorder} = createScreencastMocks();
       mockRecorder.stop.rejects(new Error('ffmpeg process error'));
-      context.setScreenRecorder({
+      const filePath = `${path.join(os.tmpdir(), 'test')}.mp4`;
+      context.getScreenRecorder.returns({
         recorder: mockRecorder,
-        filePath: path.join(os.tmpdir(), 'test.mp4'),
+        filePath,
       });
 
       await assert.rejects(
@@ -277,7 +330,7 @@ describe('screencast', () => {
       );
 
       sinon.assert.calledOnce(mockRecorder.stop);
-      assert.strictEqual(context.getScreenRecorder(), null);
+      sinon.assert.calledOnceWithExactly(context.setScreenRecorder, null);
     });
   });
 });


### PR DESCRIPTION
This PR migrates `tests/tools/screencast.test.ts` from real-browser tests (`withMcpContext`) to mock-based unit tests using the established Sinon mock infrastructure.

### Summary
- References #2639 (item 1)
- Follow-up building on #2641 and #2665
- Rewrites `tests/tools/screencast.test.ts` to use `createHandlerMocks()` instead of `withMcpContext()`, eliminating real browser launches.
- Adds `createMockScreenRecorder()` helper and wires `getScreenRecorder`/`setScreenRecorder` and `ensureExtension` in `tests/mocks.ts`.
- Re-exports `ScreenRecorder` from `src/third_party/index.ts` to comply with internal import boundaries.
