### PR TITLE
fix: account for scroll offsets in downscaled screenshots

### DIFF
--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -28,13 +28,24 @@ async function getSourceBox(
 ): Promise<SourceBox | undefined> {
   if (element) {
     const viewport = page.viewport();
-    const [box, devicePixelRatio] = await Promise.all([
+    const [box, metrics] = await Promise.all([
       element.boundingBox(),
-      viewport
-        ? (viewport.deviceScaleFactor ?? 1)
-        : page.evaluate(() => window.devicePixelRatio),
+      page.evaluate(() => ({
+        x: window.scrollX,
+        y: window.scrollY,
+        devicePixelRatio: window.devicePixelRatio,
+      })),
     ]);
-    return box ? {...box, devicePixelRatio} : undefined;
+    return box
+      ? {
+          ...box,
+          x: box.x + metrics.x,
+          y: box.y + metrics.y,
+          devicePixelRatio: viewport
+            ? (viewport.deviceScaleFactor ?? 1)
+            : metrics.devicePixelRatio,
+        }
+      : undefined;
   }
   if (fullPage) {
     const dims = await page.evaluate(() => ({
@@ -60,10 +71,19 @@ async function getSourceBox(
     };
   }
   const viewport = page.viewport();
+  // Clips use page coordinates. Read the scroll offset alongside the native
+  // dimensions used when no viewport is emulated.
+  const dims = await page.evaluate(() => ({
+    x: window.scrollX,
+    y: window.scrollY,
+    width: window.innerWidth,
+    height: window.innerHeight,
+    devicePixelRatio: window.devicePixelRatio,
+  }));
   if (viewport) {
     return {
-      x: 0,
-      y: 0,
+      x: dims.x,
+      y: dims.y,
       width: viewport.width,
       height: viewport.height,
       devicePixelRatio: viewport.deviceScaleFactor ?? 1,
@@ -72,17 +92,12 @@ async function getSourceBox(
   // The browser is launched and connected with `defaultViewport: null`, so
   // `page.viewport()` stays null until something emulates one. Fall back to the
   // window's own dimensions, which is the area a viewport screenshot captures.
-  const dims = await page.evaluate(() => ({
-    width: window.innerWidth,
-    height: window.innerHeight,
-    devicePixelRatio: window.devicePixelRatio,
-  }));
   if (dims.width <= 0 || dims.height <= 0) {
     return undefined;
   }
   return {
-    x: 0,
-    y: 0,
+    x: dims.x,
+    y: dims.y,
     width: dims.width,
     height: dims.height,
     devicePixelRatio: dims.devicePixelRatio,

--- a/tests/tools/screenshot.test.ts
+++ b/tests/tools/screenshot.test.ts
@@ -13,6 +13,7 @@ import {describe, it, afterEach} from 'node:test';
 import sinon from 'sinon';
 
 import type {ParsedArguments} from '../../src/config/mcp-options.js';
+import {parseArguments} from '../../src/config/mcp-options.js';
 import {TextSnapshot} from '../../src/TextSnapshot.js';
 import {screenshot} from '../../src/tools/screenshot.js';
 import {resolveCanonicalPath} from '../../src/utils/files.js';
@@ -402,6 +403,89 @@ describe('screenshot', () => {
         assert.equal(pngHeight(buf), 75);
       });
     });
+
+    for (const mode of ['emulated viewport', 'native viewport', 'element']) {
+      it(`preserves the scrolled region when downscaling ${mode} screenshots`, async () => {
+        const tool = screenshot({
+          ...parseArguments('1.0.0', ['node', 'test']),
+          screenshotMaxWidth: 100,
+        });
+        await withMcpContext(async (response, context) => {
+          const mcpPage = context.getSelectedMcpPage();
+          const pptrPage = mcpPage.pptrPage;
+          if (mode === 'emulated viewport') {
+            await pptrPage.setViewport({width: 800, height: 600});
+          }
+          await pptrPage.setContent(html`
+            <style>
+              body {
+                margin: 0;
+                width: calc(100vw + 800px);
+                height: calc(100vh + 1000px);
+                background: red;
+              }
+              button {
+                position: absolute;
+                left: ${mode === 'element' ? '920px' : '800px'};
+                top: ${mode === 'element' ? '1080px' : '1000px'};
+                width: ${mode === 'element' ? '400px' : '100vw'};
+                height: ${mode === 'element' ? '300px' : '100vh'};
+                border: 0;
+                background: linear-gradient(to right, blue 50%, lime 50%);
+              }
+            </style>
+            <button aria-label="Target"></button>
+          `);
+          await pptrPage.evaluate(() => window.scrollTo(800, 1000));
+          assert.deepStrictEqual(
+            await pptrPage.evaluate(() => [window.scrollX, window.scrollY]),
+            [800, 1000],
+          );
+          if (mode === 'element') {
+            mcpPage.textSnapshot = await TextSnapshot.create(mcpPage);
+          }
+
+          await tool.handler(
+            {
+              params: {
+                format: 'png',
+                uid: mode === 'element' ? '1_1' : undefined,
+              },
+              page: mcpPage,
+            },
+            response,
+            context,
+          );
+
+          assert.equal(response.images.length, 1);
+          const data = response.images[0].data;
+          assert.equal(pngWidth(Buffer.from(data, 'base64')), 100);
+          const pixels = await pptrPage.evaluate(async data => {
+            const image = new Image();
+            image.src = `data:image/png;base64,${data}`;
+            await image.decode();
+            const canvas = document.createElement('canvas');
+            const context = canvas.getContext('2d');
+            if (!context) {
+              throw new Error('Could not create a 2D canvas context');
+            }
+            context.drawImage(image, 0, 0);
+            return [
+              [...context.getImageData(10, 10, 1, 1).data],
+              [...context.getImageData(90, 10, 1, 1).data],
+            ];
+          }, data);
+          assert.deepStrictEqual(pixels, [
+            [0, 0, 255, 255],
+            [0, 255, 0, 255],
+          ]);
+          assert.deepStrictEqual(
+            await pptrPage.evaluate(() => [window.scrollX, window.scrollY]),
+            [800, 1000],
+          );
+        });
+      });
+    }
 
     it('honors screenshotMaxWidth at device scale factors above 1', async () => {
       const tool = screenshot({


### PR DESCRIPTION
Fixes #2684

When a screenshot size limit causes downscaling, viewport and element screenshots on a scrolled page capture the wrong region because their clip coordinates omit the page scroll offset.

## Summary

- Return document coordinates from `getSourceBox()` by reading scroll offsets alongside the existing dimensions and device pixel ratio. Add the main page offset to element bounding boxes; keep full-page boxes at the document origin.
- Add three browser regression tests for emulated viewports, native viewports, and element screenshots. They check captured pixels after horizontal and vertical scrolling and verify that the scroll position is preserved.

## Testing

All three regressions fail against unmodified source and pass with the fix.

- `npm run test -- --test-concurrency=2`: 897 passed, 3 skipped, 0 failed.
- Screenshot tests: 23 pass, including against the bundled build.
- `npm run check-format` and `npm run gen`: pass; no generated-file changes.
- `NODE_OPTIONS=--max_old_space_size=4096 npm run bundle` and `npm run test:notices:no-build`: pass.

Separate clipped-capture problems with pinch zoom and RTL layouts also reproduce before this patch and are not addressed here.