### PR TITLE
test: cover scheduled script navigation

### DIFF
--- a/tests/utils/WaitForHelper.test.ts
+++ b/tests/utils/WaitForHelper.test.ts
@@ -51,6 +51,27 @@ describe('WaitForHelper', () => {
     });
   });
 
+  it('awaits a navigation scheduled after the action returns', async () => {
+    await withMcpContext(async (response, context) => {
+      server.addHtmlRoute('/scheduled-nav-target', html`<main>scheduled</main>`);
+      const targetUrl = server.getRoute('/scheduled-nav-target');
+      const mcpPage = context.getSelectedMcpPage();
+
+      const result = await mcpPage.waitForEventsAfterAction(
+        async () => {
+          await mcpPage.pptrPage.evaluate(url => {
+            setTimeout(() => {
+              location.href = url;
+            }, 0);
+          }, targetUrl);
+        },
+        {waitForStableDom: false},
+      );
+
+      assert.strictEqual(result.navigatedToUrl, targetUrl);
+    });
+  });
+
   it('awaits navigation when action takes longer than expectNavigationIn', async () => {
     await withMcpContext(async (response, context) => {
       server.addHtmlRoute('/nav-target', html`<main>navigated</main>`);


### PR DESCRIPTION
## Summary

- Add deterministic regression coverage for a main-frame navigation scheduled by a script after the action returns.
- Exercise the `waitForStableDom: false` path from issue #2609.

The production navigation probe is already present on `main` from #2622; this PR adds the missing regression coverage.

## Validation

- `npm run check-format`
- `npm run test tests/utils/WaitForHelper.test.ts`
- `npm run test tests/tools/script.test.ts`

Fixes #2609,