### PR TITLE
docs: add FLUJO client configuration

### DIFF
--- a/docs/client-configurations.md
+++ b/docs/client-configurations.md
@@ -242,6 +242,22 @@ droid mcp add chrome-devtools "npx -y chrome-devtools-mcp@latest"
 </details>
 
 <details>
+  <summary>FLUJO</summary>
+
+To connect [FLUJO](https://flujo.com.co/) to an existing Chrome instance, first
+[start Chrome with remote debugging enabled](./advanced-usage.md#manual-connection-using-port-forwarding).
+Use the debugging port from that setup in the argument below.
+
+1. With Node.js installed, run `npm install chrome-devtools-mcp@latest` in a local directory.
+2. In FLUJO, open **Connected Apps > Connect App > I'm an expert > Configure & Test**.
+3. Set **Server name** to `chrome-devtools` and **MCP server root path** to the directory containing the installed package.
+4. Select **Standard IO** and set **Run command** to `npx`. Use **Add argument** to enter `-y`, `chrome-devtools-mcp@latest`, and `--browser-url=http://127.0.0.1:9222` as separate arguments, adjusting the port if needed.
+5. Click **3) Test run**. After the MCP handshake succeeds, click **Add server**.
+6. Open the saved server's **Tools** tab. Use **Test tool** to call `new_page` with the URL you want to debug, then call `take_snapshot` with the returned page ID to verify browser access.
+
+</details>
+
+<details>
   <summary>Gemini CLI</summary>
 Install the Chrome DevTools MCP server using the Gemini CLI.
 


### PR DESCRIPTION
Adds FLUJO to the client configuration guide in alphabetical order. The instructions cover an existing Chrome instance, separate executable/arguments in FLUJO's Standard IO form, and verification with the built-in tool tester.

Validated in an isolated Debian 12 cloud environment:
- FLUJO 3.45.2, Chrome DevTools MCP 1.8.0, Node 22.23.2.
- Actual Google Chrome for Testing 152.0.7977.82 with a dedicated profile and local debugging endpoint.
- FLUJO's connection test completed the MCP handshake and discovered 29 tools.
- new_page opened a disposable local fixture URL.
- take_snapshot returned the fixture's title, heading and button.
- git diff --check and the scoped Prettier check for docs/client-configurations.md passed using the repository dependency/config.

The full-repository npm run format did not finish in this 2GB VM: ESLint exceeded the default Node heap, and a 1536MB heap retry was killed. The changed Markdown file passes its scoped formatting check.

The FLUJO data directory and browser profiles were fresh; the installed FLUJO/Node runtime was reused. This verifies the existing-browser connection route, not automatic Chrome launch, performance tracing, or model chat.

[Genuine screenshots and test details](https://github.com/flujo-app/flujo-mcp-client-validation/tree/main/chrome-devtools).

Prepared and tested with Codex assistance for the FLUJO project. Submitted as a draft; the Google CLA has not been signed.
