### PR TITLE
chore: add hidden devtoolsComments flag

### DIFF
--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -50,6 +50,13 @@ export const mcpOptions = {
       'Require pageId on page-scoped tools and route requests by page ID (useful for concurrent agent sessions). Use --no-page-id-routing to disable.',
     default: true,
   },
+  devtoolsComments: {
+    type: 'boolean',
+    describe:
+      'Whether to enable DevTools comments tools. Internal WIP feature.',
+    hidden: true,
+    default: false,
+  },
   experimentalDevtools: {
     type: 'boolean',
     describe: 'Whether to enable automation over DevTools targets',

--- a/src/telemetry/flag_usage_metrics.json
+++ b/src/telemetry/flag_usage_metrics.json
@@ -449,5 +449,13 @@
   {
     "name": "config_present",
     "flagType": "boolean"
+  },
+  {
+    "name": "devtools_comments_present",
+    "flagType": "boolean"
+  },
+  {
+    "name": "devtools_comments",
+    "flagType": "boolean"
   }
 ]

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -57,6 +57,7 @@ describe('cli args parsing', () => {
     experimentalStructuredContent: false,
     pageIdRouting: true,
     sourceMaps: true,
+    devtoolsComments: false,
   };
 
   it('parses with default args', async () => {
@@ -512,5 +513,10 @@ describe('cli args parsing', () => {
       () => parseArguments(['--config', testConfig.path]),
       /Invalid JSON config file: Unknown argument: category-memory/,
     );
+  });
+
+  it('parses with devtoolsComments enabled', async () => {
+    const args = parseArguments(['--devtoolsComments']);
+    assert.strictEqual(args.devtoolsComments, true);
   });
 });


### PR DESCRIPTION
This is part 1 of stacked PRs for DevTools comments support.

Adds the hidden CLI flag `devtoolsComments` to feature-gate all new DevTools comment tools.