### PR TITLE
chore: add comments and open_devtools tools without implementation

### DIFF
--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {zod} from '../third_party/index.js';
+
+import {ToolCategory} from './categories.js';
+import {definePageTool} from './ToolDefinition.js';
+
+export const openDevtools = definePageTool({
+  name: 'open_devtools',
+  description: 'Open a DevTools window for the selected page.',
+  annotations: {
+    category: ToolCategory.DEBUGGING,
+    readOnlyHint: true,
+    conditions: ['devtoolsComments'],
+  },
+  schema: {},
+  blockedByDialog: false,
+  verifyFilesSchema: [],
+  handler: async () => {
+    throw new Error('Not implemented');
+  },
+});
+
+export const getDevtoolsComments = definePageTool({
+  name: 'get_devtools_comments',
+  description: 'Retrieve user comments from the DevTools window for the page.',
+  annotations: {
+    category: ToolCategory.DEBUGGING,
+    readOnlyHint: true,
+    conditions: ['devtoolsComments'],
+  },
+  schema: {},
+  blockedByDialog: false,
+  verifyFilesSchema: {},
+  handler: async () => {
+    throw new Error('Not implemented');
+  },
+});
+
+export const resolveDevtoolsComment = definePageTool({
+  name: 'resolve_devtools_comment',
+  description:
+    'Append an agent reply to a DevTools comment thread and mark it as resolved.',
+  annotations: {
+    category: ToolCategory.DEBUGGING,
+    readOnlyHint: false,
+    conditions: ['devtoolsComments'],
+  },
+  schema: {
+    threadId: zod
+      .string()
+      .describe(
+        'The unique identifier of the comment thread to resolve (e.g. "comment-1").',
+      ),
+    replyText: zod
+      .string()
+      .optional()
+      .describe(
+        'Optional reply explanation from the AI agent to append to the resolved comment thread.',
+      ),
+  },
+  blockedByDialog: false,
+  verifyFilesSchema: {},
+  handler: async () => {
+    throw new Error('Not implemented');
+  },
+});
+
+export const revealInDevtools = definePageTool({
+  name: 'reveal_in_devtools',
+  description:
+    'Navigate DevTools to a specified panel and highlight a target DOM node or network request.',
+  annotations: {
+    category: ToolCategory.DEBUGGING,
+    readOnlyHint: true,
+    conditions: ['devtoolsComments'],
+  },
+  schema: {
+    panelName: zod
+      .string()
+      .describe(
+        'The target DevTools panel (e.g. "elements", "network", "sources", "console").',
+      ),
+    uid: zod
+      .string()
+      .optional()
+      .describe(
+        'Optional snapshot element UID to reveal in the Elements panel.',
+      ),
+    reqid: zod
+      .number()
+      .optional()
+      .describe(
+        'Optional network request ID (from chrome-devtools-mcp network tools) to reveal in the Network panel.',
+      ),
+  },
+  blockedByDialog: false,
+  verifyFilesSchema: {},
+  handler: async () => {
+    throw new Error('Not implemented');
+  },
+});

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -73,7 +73,7 @@ export const resolveDevtoolsComment = definePageTool({
 export const revealInDevtools = definePageTool({
   name: 'reveal_in_devtools',
   description:
-    'Navigate DevTools to a specified panel and highlight a target DOM node or network request.',
+    'Navigate DevTools to a specified panel and highlight a target DOM node or network request. The parameters uid and reqid are mutually exclusive.',
   annotations: {
     category: ToolCategory.DEBUGGING,
     readOnlyHint: true,
@@ -82,6 +82,7 @@ export const revealInDevtools = definePageTool({
   schema: {
     panelName: zod
       .string()
+      .optional()
       .describe(
         'The target DevTools panel (e.g. "elements", "network", "sources", "console").',
       ),
@@ -94,9 +95,7 @@ export const revealInDevtools = definePageTool({
     reqid: zod
       .number()
       .optional()
-      .describe(
-        'Optional network request ID (from chrome-devtools-mcp network tools) to reveal in the Network panel.',
-      ),
+      .describe('Optional network request ID to reveal in the Network panel.'),
   },
   blockedByDialog: false,
   verifyFilesSchema: {},

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -6,6 +6,7 @@
 
 import type {ParsedArguments} from '../config/mcp-options.js';
 
+import * as commentsTools from './comments.js';
 import * as consoleTools from './console.js';
 import * as emulationTools from './emulation.js';
 import * as extensionTools from './extensions.js';
@@ -29,6 +30,7 @@ export const createTools = (args: ParsedArguments) => {
   const rawTools = args.slim
     ? Object.values(slimTools)
     : [
+        ...(args.devtoolsComments ? Object.values(commentsTools) : []),
         ...Object.values(consoleTools),
         ...Object.values(emulationTools),
         ...Object.values(extensionTools),


### PR DESCRIPTION
This is part 2 of stacked PRs for DevTools comments support.

Defines the `open_devtools`, `get_devtools_comments`, `resolve_devtools_comment`, and `reveal_in_devtools` tools with complete schemas, categories, and descriptions, throwing `Not implemented` until implemented. Gated behind the hidden flag `devtoolsComments`.

### Stack
1. #2692 chore: add hidden devtoolsComments flag
2. **#this PR**: chore: add comments and open_devtools tools without implementation
3. chore: implement bridge and DevTools comments tools