### PR TITLE
fix: fail fast on tool calls stuck after a dead browser connection

### DIFF
--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {forgetBrowser} from './browser.js';
 import type {ParsedArguments} from './config/mcp-options.js';
 import type {McpContext} from './McpContext.js';
 import type {McpPage} from './McpPage.js';
@@ -11,7 +12,7 @@ import type {DataFormat} from './McpResponse.js';
 import {McpResponse} from './McpResponse.js';
 import {SlimMcpResponse} from './SlimMcpResponse.js';
 import {ClearcutLogger} from './telemetry/ClearcutLogger.js';
-import type {CallToolResult} from './third_party/index.js';
+import type {Browser, CallToolResult} from './third_party/index.js';
 import {zod} from './third_party/index.js';
 import {labels} from './tools/categories.js';
 import {categoryToFlagName} from './config/category-options.js';
@@ -26,6 +27,21 @@ import {logger} from './utils/logger.js';
 import type {Mutex} from './third_party/index.js';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {isLocalhost} from './utils/url.js';
+
+/**
+ * Upper bound on how long a single tool call may wait on the browser
+ * connection. Puppeteer normally rejects in-flight CDP calls when the
+ * underlying transport closes, but a transport that dies silently (e.g. an
+ * adb port-forward torn down mid-call, rather than closed cleanly) never
+ * fires `close`/`error`/`disconnected`, so the call would otherwise hang
+ * until an external (client-side) timeout gives up on the whole server. This
+ * bound turns that into a fast, clear error instead, and forgets the cached
+ * browser handle so the next call reconnects rather than reusing a handle
+ * that still looks connected.
+ */
+export const TOOL_CALL_TIMEOUT_MS = 60_000;
+
+class ToolCallTimeoutError extends Error {}
 
 function buildDisabledMessage(
   toolName: string,
@@ -175,6 +191,8 @@ export class ToolHandler {
     private readonly serverArgs: ParsedArguments,
     private readonly getContext: () => Promise<McpContext>,
     private readonly toolMutex: Mutex,
+    // Injectable for tests; production callers rely on the default.
+    private readonly forgetBrowserOnTimeout: (browser: Browser) => void = forgetBrowser,
   ) {
     const {disabled, reason} = getToolStatusInfo(tool, serverArgs);
     this.disabledReason = reason;
@@ -194,6 +212,38 @@ export class ToolHandler {
     return Object.keys(params).filter(
       key => !Object.hasOwn(this.inputSchema, key),
     );
+  }
+
+  /**
+   * Races a tool handler invocation against TOOL_CALL_TIMEOUT_MS. On timeout,
+   * forgets the cached browser handle (see forgetBrowser()) so the next tool
+   * call re-establishes the connection instead of hanging on the same dead
+   * one. The loser of the race (a genuinely hung handler) is left running;
+   * there is no way to cancel a pending Puppeteer call, but since nothing is
+   * left awaiting it, it cannot block subsequent tool calls.
+   */
+  async #runToolWithTimeout<T>(
+    context: McpContext,
+    handlerPromise: Promise<T>,
+  ): Promise<T> {
+    const timeoutError = new ToolCallTimeoutError(
+      `Tool "${this.tool.name}" timed out after ${TOOL_CALL_TIMEOUT_MS}ms waiting on the browser connection. The connection may have been lost (for example, the debugged browser or app restarted). It will be re-established automatically on the next tool call.`,
+    );
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(timeoutError), TOOL_CALL_TIMEOUT_MS);
+      timer.unref?.();
+    });
+    try {
+      return await Promise.race([handlerPromise, timeout]);
+    } catch (err) {
+      if (err === timeoutError) {
+        this.forgetBrowserOnTimeout(context.browser);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer!);
+    }
   }
 
   async handle(params: Record<string, unknown>): Promise<CallToolResult> {
@@ -261,21 +311,27 @@ export class ToolHandler {
           if (this.tool.blockedByDialog) {
             page.throwIfDialogOpen();
           }
-          await this.tool.handler(
-            {
-              params,
-              page,
-            },
-            response,
+          await this.#runToolWithTimeout(
             context,
+            this.tool.handler(
+              {
+                params,
+                page,
+              },
+              response,
+              context,
+            ),
           );
         } else {
-          await this.tool.handler(
-            {
-              params,
-            },
-            response,
+          await this.#runToolWithTimeout(
             context,
+            this.tool.handler(
+              {
+                params,
+              },
+              response,
+              context,
+            ),
           );
         }
       } catch (err) {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -21,6 +21,28 @@ import {isAllowedUrl} from './utils/url.js';
 let browser: Browser | undefined;
 let browserMode: 'launched' | 'connected' | undefined;
 
+/**
+ * Clears the cached browser handle if it still matches `candidate`, so the
+ * next ensureBrowserConnected()/ensureBrowserLaunched() call establishes a
+ * fresh connection instead of reusing a handle that looks connected but is
+ * actually dead (e.g. its CDP transport died without ever emitting a
+ * `close`/`disconnected` event — as happens when an adb port-forward is torn
+ * down mid-call rather than closed cleanly).
+ */
+export function forgetBrowser(candidate: Browser): void {
+  if (browser === candidate) {
+    browser = undefined;
+    browserMode = undefined;
+  }
+}
+
+function trackDisconnect(candidate: Browser): void {
+  candidate.once('disconnected', () => {
+    logger?.('Browser disconnected event received');
+    forgetBrowser(candidate);
+  });
+}
+
 export function makeTargetFilter(enableExtensions = false) {
   return function targetFilter(target: {url(): string}): boolean {
     const url = target.url();
@@ -119,6 +141,7 @@ export async function ensureBrowserConnected(options: {
     const connected = await puppeteer.connect(connectOptions);
     browserMode = 'connected';
     browser = connected;
+    trackDisconnect(connected);
   } catch (err) {
     throw new Error(
       `Could not connect to Chrome. ${autoConnect ? `Check if Chrome is running and remote debugging is enabled by going to chrome://inspect/#remote-debugging.` : `Check if Chrome is running.`}`,
@@ -273,6 +296,7 @@ export async function ensureBrowserLaunched(
   const launched = await launch(options);
   browserMode = 'launched';
   browser = launched;
+  trackDisconnect(launched);
   return browser;
 }
 

--- a/tests/ToolHandler.test.ts
+++ b/tests/ToolHandler.test.ts
@@ -17,7 +17,7 @@ import {McpContext} from '../src/McpContext.js';
 import {McpPage} from '../src/McpPage.js';
 import {ClearcutLogger} from '../src/telemetry/ClearcutLogger.js';
 import {zod} from '../src/third_party/index.js';
-import {ToolHandler} from '../src/ToolHandler.js';
+import {TOOL_CALL_TIMEOUT_MS, ToolHandler} from '../src/ToolHandler.js';
 import {ToolCategory} from '../src/tools/categories.js';
 import type {
   DefinedPageTool,
@@ -1116,5 +1116,106 @@ describe('ToolHandler', () => {
     assert.deepStrictEqual(receivedParams, {
       filePath: canonicalFilePath,
     });
+  });
+
+  it('times out a hung tool handler, fails fast, and forgets the browser', async () => {
+    const tool: ToolDefinition = {
+      name: 'hanging_tool',
+      description: 'A tool whose handler never resolves',
+      annotations: {
+        category: ToolCategory.NAVIGATION,
+        readOnlyHint: true,
+      },
+      schema: {},
+      blockedByDialog: false,
+      verifyFilesSchema: {},
+      handler: async () => {
+        return new Promise<void>(() => {
+          // Simulates a tool call awaiting a CDP response on a transport
+          // that died silently: it never resolves or rejects on its own.
+        });
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockContext.browser = getMockBrowser({process: mockProcess});
+    const forgetBrowserSpy = sinon.spy();
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+      forgetBrowserSpy,
+    );
+
+    const clock = sinon.useFakeTimers();
+    try {
+      const resultPromise = toolHandler.handle({});
+      await clock.tickAsync(TOOL_CALL_TIMEOUT_MS);
+      const result = await resultPromise;
+
+      assert.strictEqual(result.isError, true);
+      assert.match(
+        result.content[0].type === 'text' ? result.content[0].text : '',
+        /timed out/,
+      );
+      assert.strictEqual(
+        forgetBrowserSpy.calledOnceWith(mockContext.browser),
+        true,
+      );
+    } finally {
+      clock.restore();
+    }
+  });
+
+  it('does not forget the browser when a tool handler rejects normally', async () => {
+    const tool: ToolDefinition = {
+      name: 'failing_tool',
+      description: 'A tool whose handler rejects immediately',
+      annotations: {
+        category: ToolCategory.NAVIGATION,
+        readOnlyHint: true,
+      },
+      schema: {},
+      blockedByDialog: false,
+      verifyFilesSchema: {},
+      handler: async () => {
+        throw new Error('Something went wrong');
+      },
+    };
+
+    const mockContext = sinon.createStubInstance(McpContext);
+    const mockProcess = sinon.createStubInstance(ChildProcess);
+    mockContext.browser = getMockBrowser({process: mockProcess});
+    const forgetBrowserSpy = sinon.spy();
+
+    const toolMutex = new Mutex();
+    const serverArgs = parseArguments('1.0.0', ['node', 'script.js'], {
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+    });
+
+    const toolHandler = new ToolHandler(
+      tool,
+      serverArgs,
+      async () => mockContext,
+      toolMutex,
+      forgetBrowserSpy,
+    );
+
+    const result = await toolHandler.handle({});
+
+    assert.strictEqual(result.isError, true);
+    assert.match(
+      result.content[0].type === 'text' ? result.content[0].text : '',
+      /Something went wrong/,
+    );
+    assert.strictEqual(forgetBrowserSpy.called, false);
   });
 });

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -14,6 +14,7 @@ import {executablePath} from 'puppeteer';
 import {
   detectDisplay,
   ensureBrowserConnected,
+  forgetBrowser,
   launch,
   makeTargetFilter,
 } from '../src/browser.js';
@@ -153,6 +154,75 @@ describe('browser', () => {
         });
         assert.ok(connectedBrowser);
         assert.ok(connectedBrowser.connected);
+        connectedBrowser.disconnect();
+      } finally {
+        await safeClose(browser);
+      }
+    });
+  });
+
+  it('reconnects after the browser transport disconnects cleanly', async () => {
+    await runWithRetry(async () => {
+      const tmpDir = os.tmpdir();
+      const folderPath = path.join(
+        tmpDir,
+        `temp-folder-${crypto.randomUUID()}`,
+      );
+      const browser = await launch({
+        headless: true,
+        isolated: false,
+        userDataDir: folderPath,
+        executablePath: await executablePath(),
+        devtools: false,
+        chromeArgs: ['--remote-debugging-port=0'],
+      });
+      try {
+        const connectOptions = {userDataDir: folderPath, devtools: false};
+        const connectedBrowser = await ensureBrowserConnected(connectOptions);
+        assert.ok(connectedBrowser.connected);
+
+        const disconnected = new Promise<void>(resolve => {
+          connectedBrowser.once('disconnected', () => resolve());
+        });
+        connectedBrowser.disconnect();
+        await disconnected;
+
+        // The `disconnected` listener installed by ensureBrowserConnected
+        // should have forgotten the cached handle, so this reconnects
+        // instead of trying to reuse (or erroring out on) the dead one.
+        const reconnectedBrowser = await ensureBrowserConnected(connectOptions);
+        assert.notStrictEqual(reconnectedBrowser, connectedBrowser);
+        assert.ok(reconnectedBrowser.connected);
+        reconnectedBrowser.disconnect();
+      } finally {
+        await safeClose(browser);
+      }
+    });
+  });
+
+  it('forgetBrowser only clears the cache on an exact match', async () => {
+    await runWithRetry(async () => {
+      const tmpDir = os.tmpdir();
+      const folderPath = path.join(
+        tmpDir,
+        `temp-folder-${crypto.randomUUID()}`,
+      );
+      const browser = await launch({
+        headless: true,
+        isolated: false,
+        userDataDir: folderPath,
+        executablePath: await executablePath(),
+        devtools: false,
+        chromeArgs: ['--remote-debugging-port=0'],
+      });
+      try {
+        const connectOptions = {userDataDir: folderPath, devtools: false};
+        const connectedBrowser = await ensureBrowserConnected(connectOptions);
+
+        forgetBrowser({} as Browser);
+
+        const sameBrowser = await ensureBrowserConnected(connectOptions);
+        assert.strictEqual(sameBrowser, connectedBrowser);
         connectedBrowser.disconnect();
       } finally {
         await safeClose(browser);


### PR DESCRIPTION
Root cause: when the debugged browser's CDP transport dies mid-call — silently, without ever firing a `close`/`error`/`disconnected` event (as opposed to a clean disconnect) — the in-flight tool call just hangs forever waiting on a response that will never come. Because `ToolHandler` serializes every tool call behind a single shared `Mutex`, that one stuck call blocks all subsequent tool calls too, effectively taking the whole MCP server down until someone manually reconnects via `/mcp`.

Observed when an Android app being debugged over `chrome-devtools-mcp` was reinstalled/relaunched mid-session, the MCP server's tools went completely unavailable, even though the underlying CDP endpoint (http://127.0.0.1:9222/json) stayed reachable the whole time. This wasn't a startup/connection-time failure, which the existing "next-call self-heal" logic already handles fine — it was a hang mid-call, so there was never a clean "next call" for that self-heal to run on.

- `browser.ts`: export `forgetBrowser()` and attach a `disconnected` listener after every successful connect/launch, so a browser Puppeteer does detect as closed is dropped from the module cache immediately rather than relying solely on the next call's `browser?.connected` check.
- `ToolHandler.ts`: bound each tool handler invocation with a 60s timeout. On timeout, forget the cached browser handle and fail with a clear error instead of hanging until the client's own timeout gives up on the whole server. The next tool call then reconnects via the existing `ensureBrowserConnected`/`#getContext` self-heal path instead of reusing a handle that still looks connected. The forget call is now injectable via an optional constructor parameter (defaulting to the real `forgetBrowser`), so the timeout path can be unit tested without stubbing an ES module.
- `tests/ToolHandler.test.ts`: cover the timeout path directly — a tool handler that never resolves triggers the 60s timeout, `forgetBrowser` is called with the current browser, and a normal (non-timeout) handler rejection does not trigger it.
- `tests/browser.test.ts`: cover the disconnected-listener path against a real launched browser — a clean `disconnect()` is forgotten automatically so the next `ensureBrowserConnected()` reconnects instead of reusing the dead handle, and `forgetBrowser()` only clears the cache on an exact reference match.

Deliberately scoped to fail-fast + rely on the existing next-call self-heal, not automatic retry-and-replay of the timed-out call (a larger change to discuss with whoever verifies this against the real device). A full Android reproduction is out of scope for this change; verified here via the targeted unit tests above.