### PR TITLE
fix(cli): forward explicit false options on start

### DIFF
--- a/src/bin/chrome-devtools.ts
+++ b/src/bin/chrome-devtools.ts
@@ -155,7 +155,7 @@ y.command(
     ) {
       argv.headless = true;
     }
-    const args = serializeArgs(mcpOptions, argv);
+    const args = serializeArgs(getCliOptions(), argv);
     await start(args, argv.sessionId);
     process.exit(0);
   },

--- a/tests/e2e/chrome-devtools-start-stop.test.ts
+++ b/tests/e2e/chrome-devtools-start-stop.test.ts
@@ -79,6 +79,22 @@ describe('chrome-devtools', () => {
     await assertDaemonIsRunning(sessionId);
   });
 
+  it('forwards an explicit headless=false option', async () => {
+    const startResult = await runCli(['start', '--headless=false'], sessionId);
+    assert.strictEqual(
+      startResult.status,
+      0,
+      `start command failed: ${startResult.stderr}`,
+    );
+
+    const statusResult = await runCli(['status'], sessionId);
+    assert.strictEqual(statusResult.status, 0);
+    assert.ok(
+      statusResult.stdout.includes('--no-headless'),
+      `headless=false was not forwarded: ${statusResult.stdout}`,
+    );
+  });
+
   it('can start the daemon with a workspace', async () => {
     const workspace = fs.mkdtempSync(
       path.join(os.tmpdir(), 'chrome-devtools-workspace-'),


### PR DESCRIPTION
## Summary

- Serialize `chrome-devtools start` arguments against the CLI defaults.
- Preserve explicit false values such as `--headless=false` as `--no-headless`.
- Add an end-to-end regression test for the forwarded daemon arguments.

## Problem

The CLI defaults `headless` to true while the MCP server defaults it to false. The start command parsed an explicit false value correctly, but then serialized it against the server defaults. Because false matched the server default, the argument was dropped. The daemon subsequently reparsed the missing option in CLI mode and restored `headless=true`.

Using the CLI option definitions for serialization keeps the default compact while forwarding explicit values that differ from the CLI default.

## Testing

- `npm run test tests/e2e/chrome-devtools-start-stop.test.ts`
- `npm run format`
- `npm run test` (all relevant tests passed; the local full-suite run only failed the unrelated large full-page screenshot case because Chrome returned `Page is too large`)