### PR TITLE
Add .mcp.json so Grok Build attaches the plugin MCP

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "--prefix",
+        "${PLUGIN_DATA}",
+        "chrome-devtools-mcp@1.9.0"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2708.

Grok Build's xAI Official marketplace installs this repo as the `chrome-devtools` plugin. Grok loads plugin MCP **only** from `.mcp.json`. This repo already ships `mcp.json` (agent-plugins.org) plus Claude/Cursor plugin manifests, so Grok attaches the 7 skills and never the MCP server.

This adds `.mcp.json` with the same contents as `mcp.json` (`npx --prefix ${PLUGIN_DATA} chrome-devtools-mcp@…`). After that file is present, `grok inspect` reports `chrome-devtools (stdio) plugin: chrome-devtools`.

Vercel/Neon plugins in the same Grok marketplace already ship `.mcp.json` and attach correctly.

No runtime/code change.