### PR TITLE
fix: block javascript links when evaluation is disabled

### DIFF
--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -5,11 +5,13 @@
  */
 
 import type {McpContext} from '../McpContext.js';
+import type {ParsedArguments} from '../config/mcp-options.js';
 import {zod} from '../third_party/index.js';
 import type {ElementHandle, KeyInput} from '../third_party/index.js';
 import type {TextSnapshotNode} from '../types.js';
 import {parseKey} from '../utils/keyboard.js';
 import {logger} from '../utils/logger.js';
+import {validateUrl} from '../utils/url.js';
 import type {WaitForEventsResult} from '../utils/WaitForHelper.js';
 
 import {ToolCategory} from './categories.js';
@@ -81,57 +83,77 @@ async function selectNativeSelectOption(handle: ElementHandle<Element>) {
   return true;
 }
 
-export const click = definePageTool({
-  name: 'click',
-  description: `Clicks on the provided element`,
-  annotations: {
-    category: ToolCategory.INPUT,
-    readOnlyHint: false,
-  },
-  schema: {
-    uid: zod
-      .string()
-      .describe(
-        'The uid of an element on the page from the page content snapshot',
-      ),
-    dblClick: dblClickSchema,
-    includeSnapshot: includeSnapshotSchema,
-  },
-  blockedByDialog: true,
-  verifyFilesSchema: {},
-  handler: async (request, response) => {
-    const uid = request.params.uid;
-    using handle = await request.page.getElementByUid(uid);
-    const aXNode = request.page.getAXNodeByUid(uid);
-    const shouldSelectNativeOption =
-      !request.params.dblClick && aXNode?.role === 'option';
-    try {
-      const result = await request.page.waitForEventsAfterAction(async () => {
-        if (
-          shouldSelectNativeOption &&
-          (await selectNativeSelectOption(handle))
-        ) {
-          return;
-        }
-
-        await handle.asLocator().click({
-          count: request.params.dblClick ? 2 : 1,
+export const click = (
+  args?: Partial<
+    Pick<ParsedArguments, 'javascriptEvaluation' | 'categoryExtensions'>
+  >,
+) =>
+  definePageTool({
+    name: 'click',
+    description: `Clicks on the provided element`,
+    annotations: {
+      category: ToolCategory.INPUT,
+      readOnlyHint: false,
+    },
+    schema: {
+      uid: zod
+        .string()
+        .describe(
+          'The uid of an element on the page from the page content snapshot',
+        ),
+      dblClick: dblClickSchema,
+      includeSnapshot: includeSnapshotSchema,
+    },
+    blockedByDialog: true,
+    verifyFilesSchema: {},
+    handler: async (request, response) => {
+      const uid = request.params.uid;
+      using handle = await request.page.getElementByUid(uid);
+      const aXNode = request.page.getAXNodeByUid(uid);
+      const shouldSelectNativeOption =
+        !request.params.dblClick && aXNode?.role === 'option';
+      if (args?.javascriptEvaluation === false) {
+        const href = await handle.evaluate(element => {
+          const target = element.closest('a[href], area[href]');
+          return target instanceof HTMLAnchorElement ||
+            target instanceof HTMLAreaElement
+            ? target.href
+            : null;
         });
-      });
-      response.appendResponseLine(
-        request.params.dblClick
-          ? `Successfully double clicked on the element`
-          : `Successfully clicked on the element`,
-      );
-      response.attachWaitForResult(result);
-      if (request.params.includeSnapshot) {
-        response.includeSnapshot();
+        if (href) {
+          validateUrl(href, {
+            javascriptEvaluation: args.javascriptEvaluation,
+            categoryExtensions: args.categoryExtensions,
+          });
+        }
       }
-    } catch (error) {
-      handleActionError(error, uid);
-    }
-  },
-});
+      try {
+        const result = await request.page.waitForEventsAfterAction(async () => {
+          if (
+            shouldSelectNativeOption &&
+            (await selectNativeSelectOption(handle))
+          ) {
+            return;
+          }
+
+          await handle.asLocator().click({
+            count: request.params.dblClick ? 2 : 1,
+          });
+        });
+        response.appendResponseLine(
+          request.params.dblClick
+            ? `Successfully double clicked on the element`
+            : `Successfully clicked on the element`,
+        );
+        response.attachWaitForResult(result);
+        if (request.params.includeSnapshot) {
+          response.includeSnapshot();
+        }
+      } catch (error) {
+        handleActionError(error, uid);
+      }
+    },
+  });
 
 export const clickAt = definePageTool({
   name: 'click_at',

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -41,7 +41,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -59,6 +59,38 @@ describe('input', () => {
         assert.ok(await page.$('text/clicked'));
       });
     });
+    it('blocks javascript links when JavaScript evaluation is disabled', async () => {
+      await withMcpContext(async (response, context) => {
+        const page = context.getSelectedMcpPage().pptrPage;
+        await page.setContent(
+          html`<a href="javascript:document.body.dataset.mcpJs = 'executed'"
+            >Run script</a
+          >`,
+        );
+        context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
+          context.getSelectedMcpPage(),
+        );
+
+        await assert.rejects(
+          click({javascriptEvaluation: false}).handler(
+            {
+              params: {uid: '1_1'},
+              page: context.getSelectedMcpPage(),
+            },
+            response,
+            context,
+          ),
+          {
+            message:
+              'Navigating to javascript: URLs is not allowed when JavaScript evaluation is disabled.',
+          },
+        );
+        assert.strictEqual(
+          await page.evaluate(() => document.body.dataset.mcpJs),
+          undefined,
+        );
+      });
+    });
     it('double clicks', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedMcpPage().pptrPage;
@@ -70,7 +102,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -107,7 +139,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        const clickPromise = click.handler(
+        const clickPromise = click().handler(
           {
             params: {
               uid: '1_1',
@@ -144,7 +176,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_2',
@@ -173,7 +205,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -213,7 +245,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        const handlerResolveTime = await click
+        const handlerResolveTime = await click()
           .handler(
             {
               params: {
@@ -243,7 +275,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -270,7 +302,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -305,7 +337,7 @@ describe('input', () => {
         );
         assert.ok(optionNode);
 
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: optionNode.id,
@@ -354,7 +386,7 @@ describe('input', () => {
         );
         assert.ok(optionNode);
 
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: optionNode.id,
@@ -406,7 +438,7 @@ describe('input', () => {
         );
         assert.ok(optionNode);
 
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: optionNode.id,


### PR DESCRIPTION
## Summary\n- prevent click from activating javascript: links when --no-javascript-evaluation is enabled\n- validate the closest anchor/area target before dispatching the click\n- add a regression test covering the bypass\n\n## Validation\n- 
pm run test -- tests/tools/input.test.ts\n- 
pm run format\n- git diff --check\n\nCloses #2726