### PR TITLE
fix: block javascript links when evaluation is disabled

### DIFF
--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -10,6 +10,7 @@ import type {ElementHandle, KeyInput} from '../third_party/index.js';
 import type {TextSnapshotNode} from '../types.js';
 import {parseKey} from '../utils/keyboard.js';
 import {logger} from '../utils/logger.js';
+import {validateJavaScriptEvaluationUrl} from '../utils/url.js';
 import type {WaitForEventsResult} from '../utils/WaitForHelper.js';
 
 import {ToolCategory} from './categories.js';
@@ -81,7 +82,28 @@ async function selectNativeSelectOption(handle: ElementHandle<Element>) {
   return true;
 }
 
-export const click = definePageTool({
+async function validateClickNavigation(
+  handle: ElementHandle<Element>,
+  javascriptEvaluation: boolean | undefined,
+) {
+  if (javascriptEvaluation !== false) {
+    return;
+  }
+
+  const href = await handle.evaluate(node => {
+    const link = node.closest('a[href], area[href]');
+    if (link instanceof HTMLAnchorElement || link instanceof HTMLAreaElement) {
+      return link.href;
+    }
+    return null;
+  });
+
+  if (href) {
+    validateJavaScriptEvaluationUrl(href, javascriptEvaluation);
+  }
+}
+
+export const click = definePageTool(args => ({
   name: 'click',
   description: `Clicks on the provided element`,
   annotations: {
@@ -105,6 +127,7 @@ export const click = definePageTool({
     const aXNode = request.page.getAXNodeByUid(uid);
     const shouldSelectNativeOption =
       !request.params.dblClick && aXNode?.role === 'option';
+    await validateClickNavigation(handle, args?.javascriptEvaluation);
     try {
       const result = await request.page.waitForEventsAfterAction(async () => {
         if (
@@ -131,7 +154,7 @@ export const click = definePageTool({
       handleActionError(error, uid);
     }
   },
-});
+}));
 
 export const clickAt = definePageTool({
   name: 'click_at',

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -113,17 +113,17 @@ export function isAllowedUrl(
 const DISALLOWED_PROTOCOLS = new Set(['javascript:', 'data:', 'vbscript:']);
 
 /**
- * Validates a URL string by parsing it with `new URL` and checking for disallowed protocols and restricted schemes.
+ * Validates whether a URL is compatible with the JavaScript evaluation setting.
  *
  * @param url The URL string to validate.
- * @param options Options object containing javascriptEvaluation and categoryExtensions.
+ * @param javascriptEvaluation Whether JavaScript evaluation is enabled.
  * @returns The parsed URL.
- * @throws Error if the URL does not parse with `new URL`, or if JavaScript evaluation is disabled and a disallowed URL is passed,
- * or if navigating to a restricted scheme.
+ * @throws Error if the URL does not parse with `new URL`, or if JavaScript evaluation is disabled and a disallowed URL is passed.
  */
-export function validateUrl(url: string, options: ValidateUrlOptions): URL {
-  const {javascriptEvaluation, categoryExtensions} = options;
-
+export function validateJavaScriptEvaluationUrl(
+  url: string,
+  javascriptEvaluation: boolean | undefined,
+): URL {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -141,6 +141,22 @@ export function validateUrl(url: string, options: ValidateUrlOptions): URL {
       `Navigating to ${parsed.protocol} URLs is not allowed when JavaScript evaluation is disabled.`,
     );
   }
+
+  return parsed;
+}
+
+/**
+ * Validates a URL string by parsing it with `new URL` and checking for disallowed protocols and restricted schemes.
+ *
+ * @param url The URL string to validate.
+ * @param options Options object containing javascriptEvaluation and categoryExtensions.
+ * @returns The parsed URL.
+ * @throws Error if the URL does not parse with `new URL`, or if JavaScript evaluation is disabled and a disallowed URL is passed,
+ * or if navigating to a restricted scheme.
+ */
+export function validateUrl(url: string, options: ValidateUrlOptions): URL {
+  const {javascriptEvaluation, categoryExtensions} = options;
+  const parsed = validateJavaScriptEvaluationUrl(url, javascriptEvaluation);
 
   if (!isAllowedUrl(url, {categoryExtensions})) {
     if (parsed.protocol === 'chrome-extension:') {

--- a/tests/tools/input.test.ts
+++ b/tests/tools/input.test.ts
@@ -41,7 +41,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -70,7 +70,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -107,7 +107,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        const clickPromise = click.handler(
+        const clickPromise = click().handler(
           {
             params: {
               uid: '1_1',
@@ -144,7 +144,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_2',
@@ -164,6 +164,39 @@ describe('input', () => {
       });
     });
 
+    it('blocks javascript URL navigation through click when JavaScript evaluation is disabled', async () => {
+      await withMcpContext(async (response, context) => {
+        const mcpPage = context.getSelectedMcpPage();
+        const page = mcpPage.pptrPage;
+        await page.setContent(
+          html`<a href="javascript:document.body.dataset.executed='true'"
+            >Run script</a
+          >`,
+        );
+        mcpPage.textSnapshot = await TextSnapshot.create(mcpPage);
+        const linkNode = [...mcpPage.textSnapshot.idToNode.values()].find(
+          node => node.role === 'link' && node.name === 'Run script',
+        );
+        assert.ok(linkNode);
+
+        const tool = click({javascriptEvaluation: false} as ParsedArguments);
+        await assert.rejects(
+          tool.handler(
+            {
+              params: {uid: linkNode.id},
+              page: mcpPage,
+            },
+            response,
+            context,
+          ),
+          /Navigating to javascript: URLs is not allowed when JavaScript evaluation is disabled/,
+        );
+        assert.strictEqual(
+          await page.evaluate(() => document.body.dataset.executed),
+          undefined,
+        );
+      });
+    });
     it('does not report navigation when click does not navigate', async () => {
       await withMcpContext(async (response, context) => {
         const page = context.getSelectedMcpPage().pptrPage;
@@ -173,7 +206,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -213,7 +246,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        const handlerResolveTime = await click
+        const handlerResolveTime = await click()
           .handler(
             {
               params: {
@@ -243,7 +276,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -270,7 +303,7 @@ describe('input', () => {
         context.getSelectedMcpPage().textSnapshot = await TextSnapshot.create(
           context.getSelectedMcpPage(),
         );
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: '1_1',
@@ -305,7 +338,7 @@ describe('input', () => {
         );
         assert.ok(optionNode);
 
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: optionNode.id,
@@ -354,7 +387,7 @@ describe('input', () => {
         );
         assert.ok(optionNode);
 
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: optionNode.id,
@@ -406,7 +439,7 @@ describe('input', () => {
         );
         assert.ok(optionNode);
 
-        await click.handler(
+        await click().handler(
           {
             params: {
               uid: optionNode.id,


### PR DESCRIPTION
Fixes #2726

## Summary
- reuse the existing JavaScript-evaluation URL validation for click-triggered navigations
- inspect the clicked element (or link ancestor) before dispatching the click
- block javascript:, data:, and vbscript: link navigations when --no-javascript-evaluation is active
- keep normal clicks and regular event-handler interactions unchanged

## Tests
- npm run typecheck
- npm run build
- npm run test:no-build -- tests/tools/input.test.ts
- npm run test:no-build -- tests/utils/url.test.ts
- git diff --check