### PR TITLE
feat: add isolated Streamable HTTP sessions

### DIFF
--- a/src/McpHttpServer.ts
+++ b/src/McpHttpServer.ts
@@ -1,0 +1,537 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {randomUUID} from 'node:crypto';
+import type fs from 'node:fs';
+import http, {
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import {isIP} from 'node:net';
+import path from 'node:path';
+
+import {BrowserManager} from './browser.js';
+import type {ParsedArguments} from './config/mcp-options.js';
+import {McpServer} from './index.js';
+import {
+  isInitializeRequest,
+  StreamableHTTPServerTransport,
+} from './third_party/index.js';
+import {logger} from './utils/logger.js';
+
+const MAXIMUM_BODY_SIZE = 4 * 1024 * 1024;
+
+export const DEFAULT_HTTP_HOST = '127.0.0.1';
+export const MCP_HTTP_PATH = '/mcp';
+
+export interface McpHttpServerOptions {
+  port: number;
+  host?: string;
+  logFile?: fs.WriteStream;
+}
+
+interface Session {
+  id?: string;
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+  closePromise?: Promise<void>;
+}
+
+class RequestBodyTooLargeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RequestBodyTooLargeError';
+  }
+}
+
+/** Hosts accepted by the transport's DNS rebinding protection. */
+function getAllowedHosts(host: string, port: number): string[] {
+  const hosts = new Set([host, 'localhost', '127.0.0.1', '::1']);
+  const allowedHosts: string[] = [];
+  for (const allowedHost of hosts) {
+    const formattedHost = formatHost(allowedHost);
+    allowedHosts.push(formattedHost, `${formattedHost}:${port}`);
+  }
+  return allowedHosts;
+}
+
+function formatHost(host: string): string {
+  return isIP(host) === 6 ? `[${host}]` : host;
+}
+
+function validatePort(port: number): void {
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Provided HTTP port ${port} is not a valid port.`);
+  }
+}
+
+function validateHost(host: string): void {
+  const validLabel = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
+  const validHostname = host.split('.').every(label => validLabel.test(label));
+  if (
+    host.length === 0 ||
+    host.length > 253 ||
+    (isIP(host) === 0 && !validHostname)
+  ) {
+    throw new Error(`Provided HTTP host ${host} is not a valid host.`);
+  }
+}
+
+function getSessionId(request: IncomingMessage): string | undefined | null {
+  const header = request.headers['mcp-session-id'];
+  if (Array.isArray(header)) {
+    return header.length === 1 && header[0] !== '' ? header[0] : null;
+  }
+  return header === '' ? null : header;
+}
+
+function isInitializationMessage(body: unknown): boolean {
+  if (Array.isArray(body)) {
+    return body.some(message => isInitializeRequest(message));
+  }
+  return isInitializeRequest(body);
+}
+
+function respondJsonRpcError(
+  response: ServerResponse,
+  statusCode: number,
+  code: number,
+  message: string,
+): void {
+  if (response.headersSent || response.writableEnded) {
+    return;
+  }
+  response.writeHead(statusCode, {'Content-Type': 'application/json'});
+  response.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      error: {code, message},
+      id: null,
+    }),
+  );
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const body = await new Promise<string>((resolve, reject) => {
+    let content = '';
+    let size = 0;
+    let settled = false;
+    request.setEncoding('utf8');
+    request.on('data', (chunk: string) => {
+      if (settled) {
+        return;
+      }
+      size += Buffer.byteLength(chunk);
+      if (size > MAXIMUM_BODY_SIZE) {
+        settled = true;
+        request.resume();
+        reject(
+          new RequestBodyTooLargeError('Request body exceeds maximum size'),
+        );
+        return;
+      }
+      content += chunk;
+    });
+    request.on('end', () => {
+      if (!settled) {
+        resolve(content);
+      }
+    });
+    request.on('error', error => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    });
+    request.on('aborted', () => {
+      if (!settled) {
+        settled = true;
+        reject(new Error('Request aborted'));
+      }
+    });
+  });
+  const parsed: unknown = JSON.parse(body);
+  return parsed;
+}
+
+function validateSessionArguments(args: ParsedArguments): void {
+  if (args.browserUrl || args.wsEndpoint || args.autoConnect) {
+    throw new Error(
+      'HTTP sessions require launched browsers; --browserUrl, --wsEndpoint, and --autoConnect are not supported with --httpPort.',
+    );
+  }
+}
+
+function getSessionArguments(args: ParsedArguments): ParsedArguments {
+  validateSessionArguments(args);
+  const sessionArgs = {...args};
+  sessionArgs.isolated = true;
+  if (args.userDataDir) {
+    sessionArgs.userDataDir = path.join(
+      args.userDataDir,
+      `mcp-http-session-${randomUUID()}`,
+    );
+    sessionArgs.isolated = false;
+  }
+  return sessionArgs;
+}
+
+/**
+ * Hosts one isolated MCP server and browser per Streamable HTTP session.
+ */
+export class McpHttpServer {
+  #args: ParsedArguments;
+  #options: {port: number; host: string; logFile?: fs.WriteStream};
+  #sessions = new Map<string, Session>();
+  #pendingSessions = new Set<Session>();
+  #httpServer: Server;
+  #closed = false;
+  #closePromise?: Promise<void>;
+
+  private constructor(
+    args: ParsedArguments,
+    options: {port: number; host: string; logFile?: fs.WriteStream},
+  ) {
+    this.#args = args;
+    this.#options = options;
+    this.#httpServer = http.createServer((request, response) => {
+      void this.#handleRequest(request, response).catch(error => {
+        logger?.('Error handling HTTP request', error);
+        respondJsonRpcError(response, 500, -32603, 'Internal server error');
+      });
+    });
+  }
+
+  static async start(
+    args: ParsedArguments,
+    options: McpHttpServerOptions,
+  ): Promise<McpHttpServer> {
+    validatePort(options.port);
+    validateSessionArguments(args);
+    const host = options.host ?? DEFAULT_HTTP_HOST;
+    validateHost(host);
+    const server = new McpHttpServer(args, {
+      port: options.port,
+      host,
+      logFile: options.logFile,
+    });
+    await server.#listen();
+    return server;
+  }
+
+  get host(): string {
+    return this.#options.host;
+  }
+
+  get port(): number {
+    const address = this.#httpServer.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('HTTP server is not listening on a TCP port');
+    }
+    return address.port;
+  }
+
+  get url(): string {
+    return `http://${formatHost(this.host)}:${this.port}${MCP_HTTP_PATH}`;
+  }
+
+  get sessionCount(): number {
+    return this.#sessions.size;
+  }
+
+  async close(): Promise<void> {
+    if (this.#closePromise !== undefined) {
+      await this.#closePromise;
+      return;
+    }
+    this.#closed = true;
+    const closePromise = Promise.resolve().then(async () => {
+      await this.#closeSessions();
+      await this.#closeHttpServer();
+    });
+    this.#closePromise = closePromise;
+    await closePromise;
+  }
+
+  async #listen(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error): void => {
+        this.#httpServer.removeListener('error', onError);
+        reject(error);
+      };
+      this.#httpServer.once('error', onError);
+      try {
+        this.#httpServer.listen(this.#options.port, this.#options.host, () => {
+          this.#httpServer.removeListener('error', onError);
+          resolve();
+        });
+      } catch (error) {
+        this.#httpServer.removeListener('error', onError);
+        reject(error);
+      }
+    });
+  }
+
+  async #handleRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    if (this.#closed) {
+      request.resume();
+      respondJsonRpcError(response, 503, -32000, 'Server is shutting down');
+      return;
+    }
+
+    let requestUrl: URL;
+    try {
+      requestUrl = new URL(request.url ?? '/', 'http://localhost');
+    } catch {
+      request.resume();
+      respondJsonRpcError(response, 400, -32000, 'Invalid request URL');
+      return;
+    }
+    if (requestUrl.pathname !== MCP_HTTP_PATH) {
+      request.resume();
+      respondJsonRpcError(response, 404, -32000, 'Not found');
+      return;
+    }
+
+    const sessionId = getSessionId(request);
+    if (sessionId === null) {
+      request.resume();
+      respondJsonRpcError(
+        response,
+        400,
+        -32000,
+        'Bad Request: invalid MCP session ID',
+      );
+      return;
+    }
+    if (sessionId !== undefined) {
+      await this.#handleExistingSession(sessionId, request, response);
+      return;
+    }
+    await this.#handleNewSession(request, response);
+  }
+
+  async #handleExistingSession(
+    sessionId: string,
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    const session = this.#sessions.get(sessionId);
+    if (session === undefined) {
+      request.resume();
+      respondJsonRpcError(response, 404, -32001, 'Session not found');
+      return;
+    }
+    await session.transport.handleRequest(request, response);
+  }
+
+  async #handleNewSession(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    if (request.method !== 'POST') {
+      request.resume();
+      respondJsonRpcError(
+        response,
+        400,
+        -32000,
+        'Bad Request: no valid session ID provided',
+      );
+      return;
+    }
+
+    let body: unknown;
+    try {
+      body = await readJsonBody(request);
+    } catch (error) {
+      const statusCode = error instanceof RequestBodyTooLargeError ? 413 : 400;
+      const message =
+        error instanceof RequestBodyTooLargeError
+          ? 'Request body exceeds maximum size'
+          : 'Parse error';
+      respondJsonRpcError(response, statusCode, -32700, message);
+      return;
+    }
+    if (!isInitializationMessage(body)) {
+      respondJsonRpcError(
+        response,
+        400,
+        -32000,
+        'Bad Request: no valid session ID provided',
+      );
+      return;
+    }
+
+    const session = await this.#createSession();
+    try {
+      await session.transport.handleRequest(request, response, body);
+      if (session.id === undefined) {
+        await this.#closeSession(session).catch(closeError => {
+          logger?.('Error closing rejected HTTP session', closeError);
+        });
+      }
+    } catch (error) {
+      await this.#closeSession(session).catch(closeError => {
+        logger?.('Error closing failed HTTP session', closeError);
+      });
+      throw error;
+    }
+  }
+
+  async #createSession(): Promise<Session> {
+    const browserManager = new BrowserManager();
+    let initializedServer: McpServer | undefined;
+    let session: Session | undefined;
+    try {
+      initializedServer = await McpServer.from(
+        getSessionArguments(this.#args),
+        {
+          logFile: this.#options.logFile,
+          browserManager,
+        },
+      );
+      session = this.#makeSession(initializedServer);
+      await initializedServer.connect(session.transport);
+      return session;
+    } catch (error) {
+      await this.#cleanupSessionSetup(
+        session,
+        initializedServer,
+        browserManager,
+      );
+      throw error;
+    }
+  }
+
+  #makeSession(server: McpServer): Session {
+    const sessionRef: {session?: Session} = {};
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      enableDnsRebindingProtection: true,
+      allowedHosts: getAllowedHosts(this.host, this.port),
+      onsessioninitialized: sessionId => {
+        const session = sessionRef.session;
+        if (session === undefined) {
+          throw new Error('HTTP session was not created');
+        }
+        if (this.#closed) {
+          void this.#closeSession(session).catch(error => {
+            logger?.('Error closing HTTP session after shutdown', error);
+          });
+          return;
+        }
+        session.id = sessionId;
+        this.#pendingSessions.delete(session);
+        this.#sessions.set(sessionId, session);
+        logger?.(`MCP session initialized: ${sessionId}`);
+      },
+      onsessionclosed: sessionId => {
+        const closedSession = this.#sessions.get(sessionId);
+        if (closedSession !== undefined) {
+          this.#sessions.delete(sessionId);
+        }
+      },
+    });
+    const session: Session = {server, transport};
+    sessionRef.session = session;
+    this.#pendingSessions.add(session);
+    transport.onclose = () => {
+      const activeSession = sessionRef.session;
+      if (activeSession !== undefined) {
+        void this.#closeSession(activeSession).catch(error => {
+          logger?.('Error closing HTTP session', error);
+        });
+      }
+    };
+    return session;
+  }
+
+  async #cleanupSessionSetup(
+    session: Session | undefined,
+    server: McpServer | undefined,
+    browserManager: BrowserManager,
+  ): Promise<void> {
+    if (session !== undefined) {
+      await this.#closeSession(session).catch(closeError => {
+        logger?.('Error closing HTTP session after setup failure', closeError);
+      });
+      return;
+    }
+    if (server !== undefined) {
+      await server.close().catch(closeError => {
+        logger?.('Error closing MCP server after setup failure', closeError);
+      });
+      return;
+    }
+    await browserManager.closeBrowser().catch(closeError => {
+      logger?.('Error closing browser after setup failure', closeError);
+    });
+  }
+
+  async #closeSession(session: Session): Promise<void> {
+    if (session.closePromise !== undefined) {
+      await session.closePromise;
+      return;
+    }
+    this.#forgetSession(session);
+    const closePromise = Promise.resolve().then(async () => {
+      try {
+        await session.server.close();
+      } finally {
+        await session.transport.close();
+      }
+    });
+    session.closePromise = closePromise;
+    await closePromise;
+  }
+
+  #forgetSession(session: Session): void {
+    this.#pendingSessions.delete(session);
+    if (
+      session.id !== undefined &&
+      this.#sessions.get(session.id) === session
+    ) {
+      this.#sessions.delete(session.id);
+    }
+  }
+
+  async #closeSessions(): Promise<void> {
+    const sessions = new Set([
+      ...this.#sessions.values(),
+      ...this.#pendingSessions.values(),
+    ]);
+    this.#sessions.clear();
+    this.#pendingSessions.clear();
+    const results = await Promise.allSettled(
+      [...sessions].map(session => this.#closeSession(session)),
+    );
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        logger?.('Error closing HTTP session during shutdown', result.reason);
+      }
+    }
+  }
+
+  async #closeHttpServer(): Promise<void> {
+    if (!this.#httpServer.listening) {
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      this.#httpServer.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+      this.#httpServer.closeAllConnections();
+    });
+  }
+}

--- a/src/bin/chrome-devtools-mcp-main.ts
+++ b/src/bin/chrome-devtools-mcp-main.ts
@@ -8,8 +8,8 @@ import '../utils/polyfill.js';
 
 import process from 'node:process';
 
-import {closeBrowser} from '../browser.js';
 import {McpServer, logDisclaimers} from '../index.js';
+import {McpHttpServer} from '../McpHttpServer.js';
 import {ClearcutLogger} from '../telemetry/ClearcutLogger.js';
 import {computeFlagUsage} from '../telemetry/flagUtils.js';
 import {StdioServerTransport} from '../third_party/index.js';
@@ -33,11 +33,12 @@ if (process.env['CHROME_DEVTOOLS_MCP_CRASH_ON_UNCAUGHT'] !== 'true') {
   });
 }
 
-// Shutdown on stdin EOF (stdio MCP convention — the client closes the
-// transport to signal exit) and on standard termination signals. Without
-// this, an active Chrome subprocess keeps the Node event loop ref'd after
-// stdin closes and the server hangs until something else kills it.
+// Shutdown on standard termination signals and, in stdio mode, on stdin EOF
+// (stdio MCP convention — the client closes the transport to signal exit).
+// Without this, an active Chrome subprocess keeps the Node event loop ref'd
+// after stdin closes and the server hangs until something else kills it.
 let shuttingDown = false;
+const serverState: {server?: McpServer | McpHttpServer} = {};
 async function shutdown(reason: string): Promise<void> {
   if (shuttingDown) {
     return;
@@ -52,15 +53,21 @@ async function shutdown(reason: string): Promise<void> {
     logger?.('Shutdown timeout exceeded, forcing exit');
     process.exit(0);
   }, 5000).unref();
-  await closeBrowser();
+  try {
+    await serverState.server?.close();
+  } catch (error) {
+    logger?.('Failed to close server', error);
+  }
   process.exit(0);
 }
-process.stdin.on('end', () => {
-  void shutdown('stdin end');
-});
-process.stdin.on('close', () => {
-  void shutdown('stdin close');
-});
+if (args.httpPort === undefined) {
+  process.stdin.on('end', () => {
+    void shutdown('stdin end');
+  });
+  process.stdin.on('close', () => {
+    void shutdown('stdin close');
+  });
+}
 process.on('SIGTERM', () => {
   void shutdown('SIGTERM');
 });
@@ -72,12 +79,26 @@ process.on('SIGHUP', () => {
 });
 
 logger?.(`Starting Chrome DevTools MCP Server v${VERSION}`);
-const server = await McpServer.from(args, {
-  logFile,
-});
-const transport = new StdioServerTransport();
-await server.connect(transport);
-logger?.('Chrome DevTools MCP Server connected');
+if (args.httpPort !== undefined) {
+  const httpServer = await McpHttpServer.start(args, {
+    port: args.httpPort,
+    host: args.httpHost,
+    logFile,
+  });
+  serverState.server = httpServer;
+  console.error(
+    `chrome-devtools-mcp: MCP endpoint listening on ${httpServer.url}`,
+  );
+  logger?.(`Chrome DevTools MCP Server listening on ${httpServer.url}`);
+} else {
+  const initializedServer = await McpServer.from(args, {
+    logFile,
+  });
+  serverState.server = initializedServer;
+  const transport = new StdioServerTransport();
+  await initializedServer.connect(transport);
+  logger?.('Chrome DevTools MCP Server connected');
+}
 logDisclaimers(args);
 void ClearcutLogger.get()?.logDailyActiveIfNeeded();
 void ClearcutLogger.get()?.logServerStart(computeFlagUsage(args, mcpOptions));

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -18,9 +18,6 @@ import {puppeteer} from './third_party/index.js';
 import {logger, puppeteerLogger} from './utils/logger.js';
 import {isAllowedUrl} from './utils/url.js';
 
-let browser: Browser | undefined;
-let browserMode: 'launched' | 'connected' | undefined;
-
 export function makeTargetFilter(enableExtensions = false) {
   return function targetFilter(target: {url(): string}): boolean {
     const url = target.url();
@@ -31,7 +28,7 @@ export function makeTargetFilter(enableExtensions = false) {
   };
 }
 
-export async function ensureBrowserConnected(options: {
+export interface BrowserConnectionOptions {
   browserURL?: string;
   wsEndpoint?: string;
   wsHeaders?: Record<string, string>;
@@ -41,12 +38,12 @@ export async function ensureBrowserConnected(options: {
   enableExtensions?: boolean;
   blocklist?: string[];
   allowlist?: string[];
-}) {
-  const {channel, enableExtensions} = options;
-  if (browser?.connected) {
-    return browser;
-  }
+}
 
+async function connectBrowser(
+  options: BrowserConnectionOptions,
+): Promise<Browser> {
+  const {channel, enableExtensions} = options;
   const connectOptions: Parameters<typeof puppeteer.connect>[0] = {
     targetFilter: makeTargetFilter(enableExtensions),
     defaultViewport: null,
@@ -113,12 +110,7 @@ export async function ensureBrowserConnected(options: {
 
   logger?.('Connecting Puppeteer to ', JSON.stringify(connectOptions));
   try {
-    // Assign mode before browser so a concurrent closeBrowser() never sees
-    // `browser` set with `browserMode` still undefined (would fall through
-    // to the disconnect() path and orphan a launched Chrome).
-    const connected = await puppeteer.connect(connectOptions);
-    browserMode = 'connected';
-    browser = connected;
+    return await puppeteer.connect(connectOptions);
   } catch (err) {
     throw new Error(
       `Could not connect to Chrome. ${autoConnect ? `Check if Chrome is running and remote debugging is enabled by going to chrome://inspect/#remote-debugging.` : `Check if Chrome is running.`}`,
@@ -127,8 +119,6 @@ export async function ensureBrowserConnected(options: {
       },
     );
   }
-  logger?.('Connected Puppeteer');
-  return browser;
 }
 
 interface McpLaunchOptions {
@@ -263,43 +253,121 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
   }
 }
 
+export class BrowserManager {
+  #browser: Browser | undefined;
+  #browserMode: 'launched' | 'connected' | undefined;
+  #browserPromise: Promise<Browser> | undefined;
+  #closePromise: Promise<void> | undefined;
+
+  async ensureBrowserConnected(
+    options: BrowserConnectionOptions,
+  ): Promise<Browser> {
+    return await this.#ensureBrowser(
+      () => connectBrowser(options),
+      'connected',
+    );
+  }
+
+  async ensureBrowserLaunched(options: McpLaunchOptions): Promise<Browser> {
+    return await this.#ensureBrowser(() => launch(options), 'launched');
+  }
+
+  async #ensureBrowser(
+    starter: () => Promise<Browser>,
+    mode: 'launched' | 'connected',
+  ): Promise<Browser> {
+    const closing = this.#closePromise;
+    if (closing !== undefined) {
+      await closing;
+    }
+    const existingBrowser = this.#browser;
+    if (existingBrowser?.connected) {
+      return existingBrowser;
+    }
+    const pendingBrowser = this.#browserPromise;
+    if (pendingBrowser !== undefined) {
+      return await pendingBrowser;
+    }
+    const browserPromise = Promise.resolve()
+      .then(starter)
+      .then(browser => {
+        this.#browserMode = mode;
+        this.#browser = browser;
+        if (mode === 'connected') {
+          logger?.('Connected Puppeteer');
+        }
+        return browser;
+      })
+      .finally(() => {
+        this.#browserPromise = undefined;
+      });
+    this.#browserPromise = browserPromise;
+    return await browserPromise;
+  }
+
+  /**
+   * Shutdown hook for the active browser. Closes a launched browser (so the
+   * Chrome subprocess is reaped) or disconnects from an attached browser (so
+   * the user's Chrome instance stays alive). No-op if no browser is active or
+   * the connection has already been dropped.
+   */
+  async closeBrowser(): Promise<void> {
+    if (this.#closePromise !== undefined) {
+      await this.#closePromise;
+      return;
+    }
+    const closePromise = Promise.resolve().then(async () => {
+      const pendingBrowser = this.#browserPromise;
+      if (pendingBrowser !== undefined) {
+        try {
+          await pendingBrowser;
+        } catch {
+          return;
+        }
+      }
+      const activeBrowser = this.#browser;
+      const mode = this.#browserMode;
+      this.#browser = undefined;
+      this.#browserMode = undefined;
+      if (!activeBrowser || !activeBrowser.connected) {
+        return;
+      }
+      if (mode === 'launched') {
+        await activeBrowser.close().catch(err => {
+          logger?.('Failed to close browser', err);
+        });
+        return;
+      }
+      await activeBrowser.disconnect().catch(err => {
+        logger?.('Failed to disconnect from browser', err);
+      });
+    });
+    this.#closePromise = closePromise;
+    try {
+      await closePromise;
+    } finally {
+      this.#closePromise = undefined;
+    }
+  }
+}
+
+// Keep the legacy module-level API for stdio integrations and existing tests.
+const defaultBrowserManager = new BrowserManager();
+
+export async function ensureBrowserConnected(
+  options: BrowserConnectionOptions,
+): Promise<Browser> {
+  return await defaultBrowserManager.ensureBrowserConnected(options);
+}
+
 export async function ensureBrowserLaunched(
   options: McpLaunchOptions,
 ): Promise<Browser> {
-  if (browser?.connected) {
-    return browser;
-  }
-  // Assign mode before browser; see the connect path above for rationale.
-  const launched = await launch(options);
-  browserMode = 'launched';
-  browser = launched;
-  return browser;
+  return await defaultBrowserManager.ensureBrowserLaunched(options);
 }
 
-/**
- * Shutdown hook for the active browser. Closes a launched browser (so the
- * Chrome subprocess is reaped) or disconnects from an attached browser (so
- * the user's Chrome instance stays alive). No-op if no browser is active or
- * the connection has already been dropped. Called from the server entrypoint
- * on stdin EOF / SIGTERM / SIGINT.
- */
 export async function closeBrowser(): Promise<void> {
-  const b = browser;
-  const mode = browserMode;
-  browser = undefined;
-  browserMode = undefined;
-  if (!b || !b.connected) {
-    return;
-  }
-  if (mode === 'launched') {
-    await b.close().catch(err => {
-      logger?.('Failed to close browser', err);
-    });
-    return;
-  }
-  await b.disconnect().catch(err => {
-    logger?.('Failed to disconnect from browser', err);
-  });
+  await defaultBrowserManager.closeBrowser();
 }
 
 export type Channel = 'stable' | 'canary' | 'beta' | 'dev';

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -22,6 +22,36 @@ export const mcpOptions = {
     describe:
       'Path to a file to write debug logs to. Set the env variable `DEBUG` to `*` to enable verbose logs. Useful for submitting bug reports.',
   },
+  httpPort: {
+    type: 'number',
+    describe:
+      'Serve MCP over the Streamable HTTP transport instead of stdio. Each client session gets its own browser and MCP state. Use 0 to let the OS choose a free port.',
+    alias: 'port',
+    coerce: (value: number | undefined) => {
+      if (value === undefined) {
+        return;
+      }
+      if (!Number.isInteger(value) || value < 0 || value > 65535) {
+        throw new Error(`Provided httpPort ${value} is not a valid port.`);
+      }
+      return value;
+    },
+  },
+  httpHost: {
+    type: 'string',
+    describe:
+      'Host interface for the Streamable HTTP server. Defaults to 127.0.0.1.',
+    alias: 'host',
+    coerce: (value: string | undefined) => {
+      if (value === undefined) {
+        return;
+      }
+      if (value.length === 0 || value.trim() !== value) {
+        throw new Error(`Provided httpHost ${value} is not a valid host.`);
+      }
+      return value;
+    },
+  },
   viewport: {
     type: 'string',
     describe:

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import type fs from 'node:fs';
 import path from 'node:path';
 import {pathToFileURL} from 'node:url';
 
+import {BrowserManager} from './browser.js';
 import type {Channel} from './browser.js';
-import {ensureBrowserConnected, ensureBrowserLaunched} from './browser.js';
 import {type ParsedArguments} from './config/mcp-options.js';
 import {loadIssueDescriptions} from './devtools/issueDescriptions.js';
 import {McpContext} from './McpContext.js';
@@ -46,12 +46,14 @@ const ROOTS_REQUEST_TIMEOUT = 5_000;
 
 export interface McpServerOptions {
   logFile?: fs.WriteStream;
+  browserManager?: BrowserManager;
 }
 
 export class McpServer {
   readonly server: SdkMcpServer;
   #serverArgs: ParsedArguments;
   #options: McpServerOptions;
+  #browserManager: BrowserManager;
   #context?: McpContext;
 
   /**
@@ -68,8 +70,9 @@ export class McpServer {
   ) {
     this.#serverArgs = serverArgs;
     this.#options = options;
+    this.#browserManager = options.browserManager ?? new BrowserManager();
 
-    if (this.#serverArgs.usageStatistics) {
+    if (this.#serverArgs.usageStatistics && !ClearcutLogger.get()) {
       ClearcutLogger.initialize({
         persistence: new FilePersistence(),
         logFile: this.#serverArgs.logFile,
@@ -126,12 +129,18 @@ export class McpServer {
   }
 
   /**
-   * Closes the MCP connection and disposes internal context/listeners.
+   * Closes the MCP connection and disposes internal context/listeners and the
+   * server-owned browser session.
    */
   async close(): Promise<void> {
-    this.#context?.dispose();
+    const context = this.#context;
     this.#context = undefined;
-    await this.server.close();
+    try {
+      context?.dispose();
+      await this.server.close();
+    } finally {
+      await this.#browserManager.closeBrowser();
+    }
   }
 
   [Symbol.dispose](): void {
@@ -223,7 +232,7 @@ export class McpServer {
       this.#serverArgs.browserUrl ||
       this.#serverArgs.wsEndpoint ||
       this.#serverArgs.autoConnect
-        ? await ensureBrowserConnected({
+        ? await this.#browserManager.ensureBrowserConnected({
             browserURL: this.#serverArgs.browserUrl,
             wsEndpoint: this.#serverArgs.wsEndpoint,
             wsHeaders: this.#serverArgs.wsHeaders,
@@ -234,7 +243,7 @@ export class McpServer {
             blocklist,
             allowlist,
           })
-        : await ensureBrowserLaunched({
+        : await this.#browserManager.ensureBrowserLaunched({
             headless: this.#serverArgs.headless,
             executablePath: this.#serverArgs.executablePath,
             channel,

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -18,6 +18,7 @@ export {default as yargs} from 'yargs';
 export {hideBin} from 'yargs/helpers';
 export {default as semver} from 'semver';
 export {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+export {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 export {type ShapeOutput} from '@modelcontextprotocol/sdk/server/zod-compat.js';
 export {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
 export {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -33,6 +34,7 @@ export {
   RootsListChangedNotificationSchema,
   ListRootsResultSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+export {isInitializeRequest} from '@modelcontextprotocol/sdk/types.js';
 export {z as zod} from 'zod';
 export {default as ajv} from 'ajv';
 export {

--- a/tests/McpHttpServer.test.ts
+++ b/tests/McpHttpServer.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {afterEach, describe, it} from 'node:test';
+
+import {executablePath} from 'puppeteer';
+
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+import {parseArguments} from '../src/config/mcp-options.js';
+import {McpHttpServer} from '../src/McpHttpServer.js';
+
+async function testArgs() {
+  return parseArguments(
+    '0.0.0',
+    [
+      'node',
+      'test',
+      '--headless',
+      '--isolated',
+      '--executable-path',
+      await executablePath(),
+      '--no-usage-statistics',
+    ],
+    {},
+  );
+}
+
+async function connectClient(url: string) {
+  const transport = new StreamableHTTPClientTransport(new URL(url));
+  const client = new Client({name: 'http-test-client', version: '1.0.0'});
+  await client.connect(transport);
+  return {client, transport};
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error('Condition not met within timeout');
+    }
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+}
+
+describe('McpHttpServer', () => {
+  let server: McpHttpServer | undefined;
+
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+  });
+
+  it('serves multiple isolated MCP sessions', async () => {
+    server = await McpHttpServer.start(await testArgs(), {port: 0});
+    const [first, second] = await Promise.all([
+      connectClient(server.url),
+      connectClient(server.url),
+    ]);
+
+    assert.ok(first.transport.sessionId);
+    assert.ok(second.transport.sessionId);
+    assert.notStrictEqual(
+      first.transport.sessionId,
+      second.transport.sessionId,
+    );
+    assert.strictEqual(server.sessionCount, 2);
+
+    const firstTools = await first.client.listTools();
+    const secondTools = await second.client.listTools();
+    assert.ok(firstTools.tools.length > 0);
+    assert.deepStrictEqual(
+      firstTools.tools.map(tool => tool.name),
+      secondTools.tools.map(tool => tool.name),
+    );
+
+    await first.client.close();
+    await second.client.close();
+  });
+
+  it('keeps browser state isolated between sessions', async () => {
+    server = await McpHttpServer.start(await testArgs(), {port: 0});
+    const first = await connectClient(server.url);
+    const second = await connectClient(server.url);
+
+    try {
+      await first.client.callTool({
+        name: 'new_page',
+        arguments: {
+          url: 'data:text/html,<title>first-http-session</title>',
+        },
+      });
+      const secondPages = await second.client.callTool({
+        name: 'list_pages',
+        arguments: {},
+      });
+
+      assert.doesNotMatch(JSON.stringify(secondPages), /first-http-session/);
+    } finally {
+      await first.client.close();
+      await second.client.close();
+    }
+  });
+
+  it('cleans up a session on DELETE without affecting another session', async () => {
+    server = await McpHttpServer.start(await testArgs(), {port: 0});
+    const first = await connectClient(server.url);
+    const second = await connectClient(server.url);
+    const activeServer = server;
+
+    await first.transport.terminateSession();
+    await waitFor(() => activeServer.sessionCount === 1);
+    const tools = await second.client.listTools();
+    assert.ok(tools.tools.length > 0);
+
+    await first.client.close();
+    await second.client.close();
+  });
+
+  it('rejects requests without a valid session', async () => {
+    server = await McpHttpServer.start(await testArgs(), {port: 0});
+    const response = await fetch(server.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({jsonrpc: '2.0', method: 'tools/list', id: 1}),
+    });
+    await response.text();
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(server.sessionCount, 0);
+  });
+
+  it('cleans up an initialization rejected by the transport', async () => {
+    server = await McpHttpServer.start(await testArgs(), {port: 0});
+    const response = await fetch(server.url, {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: {name: 'http-test-client', version: '1.0.0'},
+        },
+      }),
+    });
+    await response.text();
+
+    assert.strictEqual(response.status, 406);
+    assert.strictEqual(server.sessionCount, 0);
+  });
+
+  it('rejects unknown sessions and paths', async () => {
+    server = await McpHttpServer.start(await testArgs(), {port: 0});
+    const unknownSessionResponse = await fetch(server.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        'mcp-session-id': 'unknown-session',
+      },
+      body: JSON.stringify({jsonrpc: '2.0', method: 'tools/list', id: 1}),
+    });
+    await unknownSessionResponse.text();
+    assert.strictEqual(unknownSessionResponse.status, 404);
+
+    const pathResponse = await fetch(`http://127.0.0.1:${server.port}/other`, {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: '{}',
+    });
+    await pathResponse.text();
+    assert.strictEqual(pathResponse.status, 404);
+  });
+
+  it('closes all sessions and the listener', async () => {
+    server = await McpHttpServer.start(await testArgs(), {port: 0});
+    const client = await connectClient(server.url);
+    assert.strictEqual(server.sessionCount, 1);
+
+    await server.close();
+    server = undefined;
+    await assert.rejects(() => client.client.listTools());
+    await client.client.close();
+  });
+});

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -12,6 +12,7 @@ import {describe, it} from 'node:test';
 import {executablePath} from 'puppeteer';
 
 import {
+  BrowserManager,
   detectDisplay,
   ensureBrowserConnected,
   launch,
@@ -156,6 +157,29 @@ describe('browser', () => {
         connectedBrowser.disconnect();
       } finally {
         await safeClose(browser);
+      }
+    });
+  });
+
+  it('keeps browser lifecycle isolated per manager', async () => {
+    await runWithRetry(async () => {
+      const manager1 = new BrowserManager();
+      const manager2 = new BrowserManager();
+      const options = {
+        headless: true,
+        isolated: true,
+        executablePath: await executablePath(),
+        devtools: false,
+      };
+      const browser1 = await manager1.ensureBrowserLaunched(options);
+      try {
+        const browser2 = await manager2.ensureBrowserLaunched(options);
+        assert.notStrictEqual(browser1, browser2);
+        await manager1.closeBrowser();
+        assert.strictEqual(browser2.connected, true);
+      } finally {
+        await manager1.closeBrowser();
+        await manager2.closeBrowser();
       }
     });
   });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -112,6 +112,18 @@ describe('cli args parsing', () => {
     assert.strictEqual(args.categoryExperimentalWebmcp, true);
   });
 
+  it('parses HTTP transport options', async () => {
+    const args = parseArguments([
+      '--http-port',
+      '0',
+      '--http-host',
+      'localhost',
+    ]);
+
+    assert.strictEqual(args.httpPort, 0);
+    assert.strictEqual(args.httpHost, 'localhost');
+  });
+
   it('parses with user data dir', async () => {
     const args = parseArguments(['--user-data-dir', '/tmp/chrome-profile']);
     assert.deepStrictEqual(args, {


### PR DESCRIPTION
## Summary
- add stateful Streamable HTTP MCP transport
- isolate each MCP session with its own browser and MCP state
- add session routing, cleanup, and HTTP CLI options
- preserve stdio behavior

## Validation
- `npm ci`
- `npm run build`

`npm run check-format` and the focused test command timed out locally.