### PR TITLE
feat: allow new pages to default to background

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,11 @@ The Chrome DevTools MCP server supports the following configuration option:
   - **Type:** boolean
   - **Default:** `false`
 
+- **`--defaultBackground`/ `--default-background`**
+  Open new pages in the background by default.
+  - **Type:** boolean
+  - **Default:** `false`
+
 - **`--pageIdRouting`/ `--page-id-routing`**
   Require pageId on page-scoped tools and route requests by page ID (useful for concurrent agent sessions). Use --no-page-id-routing to disable.
   - **Type:** boolean

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -243,7 +243,7 @@
 **Parameters:**
 
 - **url** (string) **(required)**: URL to load in a new page.
-- **background** (boolean) _(optional)_: Whether to open the page in the background without bringing it to the front. Default is false (foreground).
+- **background** (boolean) _(optional)_: Whether to open the page in the background without bringing it to the front. Defaults to the server defaultBackground setting.
 - **isolatedContext** (string) _(optional)_: If specified, the page is created in an isolated browser context with the given name. Pages in the same browser context share cookies and storage. Pages in different browser contexts are fully isolated (useful for clean-slate testing of cookies and authentication).
 - **timeout** (integer) _(optional)_: Maximum wait time in milliseconds. If set to 0, the default timeout will be used.
 

--- a/src/config/cli-options.ts
+++ b/src/config/cli-options.ts
@@ -1141,7 +1141,7 @@ export const commands: Commands = {
         name: 'background',
         type: 'boolean',
         description:
-          'Whether to open the page in the background without bringing it to the front. Default is false (foreground).',
+          'Whether to open the page in the background without bringing it to the front. Defaults to the server defaultBackground setting.',
         required: false,
       },
       isolatedContext: {

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -44,6 +44,11 @@ export const mcpOptions = {
     type: 'boolean',
     description: `If enabled, ignores errors relative to self-signed and expired certificates. Use with caution.`,
   },
+  defaultBackground: {
+    type: 'boolean',
+    default: false,
+    describe: 'Open new pages in the background by default.',
+  },
   pageIdRouting: {
     type: 'boolean',
     describe:

--- a/src/telemetry/flag_usage_metrics.json
+++ b/src/telemetry/flag_usage_metrics.json
@@ -457,5 +457,13 @@
   {
     "name": "devtools_comments",
     "flagType": "boolean"
+  },
+  {
+    "name": "default_background_present",
+    "flagType": "boolean"
+  },
+  {
+    "name": "default_background",
+    "flagType": "boolean"
   }
 ]

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -111,7 +111,7 @@ export const newPage = defineTool(args => {
         .boolean()
         .optional()
         .describe(
-          'Whether to open the page in the background without bringing it to the front. Default is false (foreground).',
+          'Whether to open the page in the background without bringing it to the front. Defaults to the server defaultBackground setting.',
         ),
       isolatedContext: zod
         .string()
@@ -132,7 +132,7 @@ export const newPage = defineTool(args => {
       });
 
       const page = await context.newPage(
-        request.params.background,
+        request.params.background ?? args?.defaultBackground,
         request.params.isolatedContext,
       );
 

--- a/tests/tools/pages.test.ts
+++ b/tests/tools/pages.test.ts
@@ -383,6 +383,22 @@ describe('pages', () => {
         );
       });
     });
+    it('uses the configured background default', async () => {
+      await withMcpContext(async (response, context) => {
+        const args = parseArguments(
+          '1.0.0',
+          ['node', 'script.js', '--default-background'],
+          {CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true'},
+        );
+        const newPageSpy = sinon.spy(context, 'newPage');
+        await newPage(args).handler(
+          {params: {url: 'data:text/html,<html></html>'}},
+          response,
+          context,
+        );
+        sinon.assert.calledWith(newPageSpy, true, undefined);
+      });
+    });
     it('create a page in the background', async () => {
       await withMcpContext(async (response, context) => {
         const originalPage = context.getPageById(1);


### PR DESCRIPTION
## Summary

- add `--defaultBackground` / `--default-background`
- use it when `new_page.background` is omitted
- preserve an explicit per-call `background` value

This keeps the existing foreground default unchanged while allowing side-agent setups to opt into background tabs without repeating `background: true` on every `new_page` call. It intentionally does not change `select_page` or other focus behavior.

## Tests

- `npm run gen`
- `npm run check-format`
- `node scripts/test.js tests/tools/pages.test.ts`