### PR TITLE
feat: support shared MCP server sessions

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,32 +1,216 @@
 # Advanced usage
 
-## Concurrent sessions
+## Shared server for multiple MCP clients
 
-Most MCP clients start one Chrome DevTools MCP server per conversation. If your
-client shares a single server instance across concurrent agents or subagents,
-start the server with `--experimentalPageIdRouting`. This exposes `pageId` on
-page-scoped tools so each agent can route tool calls to the tab it is working
-with.
+A single long-lived `chrome-devtools-mcp` process can serve multiple clients
+over Streamable HTTP. Start it with `--http-port=<port>`; the service listens
+at `http://127.0.0.1:<port>/mcp`. The process owns one browser connection. It
+can launch Chrome itself or attach to a Chrome remote-debugging endpoint.
+
+### Launch a shared server
+
+Choose one of these startup modes. Keep this process running while clients
+connect.
+
+**Headless Chrome launched by the server:**
+
+```bash
+npx -y chrome-devtools-mcp@latest \
+  --http-port=9333 \
+  --headless=true \
+  --isolated=true
+```
+
+`--isolated` gives this shared service a temporary profile. It does not create
+one profile per HTTP client.
+
+**Headed (visible) Chrome launched by the server:**
+
+```bash
+npx -y chrome-devtools-mcp@latest \
+  --http-port=9333 \
+  --headless=false \
+  --isolated=true
+```
+
+Omit `--isolated` or provide `--user-data-dir=...` when the shared service
+should reuse a persistent profile. Only one Chrome instance can use a profile
+at a time.
+
+**Attach to an existing Chrome remote-debugging endpoint:**
+
+Start Chrome with a dedicated profile and remote-debugging port, then point
+the one MCP service at that endpoint:
+
+```bash
+# Use the Chrome executable for your platform.
+/path/to/chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chrome-devtools-mcp-shared
+
+npx -y chrome-devtools-mcp@latest \
+  --http-port=9333 \
+  --browser-url=http://127.0.0.1:9222
+```
+
+The `--browser-url` option attaches the service to the already running
+browser; it does not launch another Chrome. The existing Chrome connection
+instructions below include platform-specific launch commands and the
+WebSocket alternative.
+
+### Connect native MCP clients
+
+MCP clients with native Streamable HTTP support should use the `/mcp` URL
+directly. Configure two or more independent clients with the same URL; do not
+start one `chrome-devtools-mcp` process per client:
 
 ```json
 {
   "mcpServers": {
     "chrome-devtools": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "chrome-devtools-mcp@latest",
-        "--experimentalPageIdRouting"
-      ]
+      "url": "http://127.0.0.1:9333/mcp"
     }
   }
 }
 ```
 
-If you run multiple independent MCP client sessions and want each session to
-launch its own temporary Chrome profile, also pass `--isolated`. This avoids
-sharing the default Chrome DevTools MCP user data directory between those
-server instances.
+Each client performs its own MCP initialization and receives an MCP-generated
+session ID. The HTTP service and its browser remain alive when one client
+disconnects.
+
+### Shared pages, isolated client state
+
+The Chrome connection and its pages are shared. A page opened by one client is
+visible to the others, and navigation, input, page closing, tracing, or other
+browser mutations are observable by every client. Clients that operate on the
+same page must coordinate their actions.
+
+Each HTTP session has its own `McpServer` and `McpContext`. The following state
+is isolated per client and is never reused by another session:
+
+- selected page;
+- negotiated filesystem roots;
+- isolated-context names;
+- trace, recording, and other tool state; and
+- the request mutex.
+
+Selecting a page in one client does not change another client's selected page.
+The selected pages still refer to the shared browser, so per-client selection
+does not prevent one client from changing or closing a page another client is
+using. The per-session mutex serializes that client's requests; it is not a
+global lock for all clients.
+
+Clients should send an explicit HTTP `DELETE` for their session before closing
+their transport. An accepted `DELETE` deterministically closes only that
+session's `McpServer`/`McpContext`; closing a transport is likewise scoped to
+that session, and the stdio proxy sends `DELETE` automatically on EOF. An
+abandoned or otherwise inactive session expires after 30 minutes. An active
+request or an open stream suspends idle expiry. Process shutdown closes all
+sessions first and then closes a browser launched by the service or disconnects
+from an externally attached Chrome.
+
+### Access from another machine
+
+The HTTP service binds to `127.0.0.1` only. It rejects requests whose `Host`
+or `Origin` is not loopback, so a remote machine cannot connect directly and
+the service must not be exposed on a network interface. Use SSH port
+forwarding when the MCP client runs elsewhere:
+
+```bash
+# Run on the client machine; chrome-host runs the MCP service.
+ssh -N -L 9333:127.0.0.1:9333 user@chrome-host
+```
+
+Then configure the remote client with
+`http://127.0.0.1:9333/mcp`, the local end of the tunnel.
+
+> [!WARNING]
+> Anyone who can control this endpoint can control Chrome, including reading
+> and modifying browser data. Keep the listener loopback-only. Remote hosts
+> must use an SSH tunnel; do not bind or forward the service as a public
+> network endpoint.
+
+### Stdio proxy for clients without HTTP transport
+
+Clients that can launch only a stdio MCP command can use the transparent proxy
+mode. Point it at the shared service's absolute `http(s)` URL:
+
+```bash
+npx -y chrome-devtools-mcp@latest \
+  --server-url=http://127.0.0.1:9333/mcp
+```
+
+The equivalent environment variable is useful when the client configuration
+cannot add a command-line flag:
+
+```bash
+export CHROME_DEVTOOLS_MCP_SERVER_URL=http://127.0.0.1:9333/mcp
+npx -y chrome-devtools-mcp@latest
+```
+
+`--server-url` and `CHROME_DEVTOOLS_MCP_SERVER_URL` select stdio-to-Streamable
+HTTP proxy mode. A server URL takes precedence over `--http-port`, and
+`--http-port` takes precedence over the existing stdio server mode. The proxy
+does not launch or attach to Chrome. It forwards JSON-RPC transparently,
+including roots requests and notifications, so the remote server sees the
+original stdio client's identity and creates one remote MCP session for that
+client. In proxy mode, AXI-injected local Chrome launch or attach flags are
+ignored because the proxy owns no browser.
+
+### chrome-devtools-axi
+
+Use a `chrome-devtools-axi` version that supports
+`CHROME_DEVTOOLS_AXI_MCP_SERVER_URL`. Each named AXI bridge starts its own MCP
+stdio proxy, so it receives a separate remote MCP context while all bridges
+use the one shared Chrome:
+
+```bash
+# In this checkout, build the MCP proxy entrypoint.
+npm run build
+
+# In another terminal, start one shared service (choose any startup mode above).
+npx -y chrome-devtools-mcp@latest \
+  --http-port=9333 \
+  --headless=true \
+  --isolated=true
+
+# In each AXI shell, point at this unreleased MCP build and the shared service.
+export CHROME_DEVTOOLS_AXI_MCP_PATH="/path/to/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
+export CHROME_DEVTOOLS_AXI_MCP_SERVER_URL="http://127.0.0.1:9333/mcp"
+
+CHROME_DEVTOOLS_AXI_SESSION=agent-a npx -y chrome-devtools-axi pages
+CHROME_DEVTOOLS_AXI_SESSION=agent-b npx -y chrome-devtools-axi pages
+```
+
+`CHROME_DEVTOOLS_AXI_MCP_PATH` is needed only to test an unreleased MCP build;
+AXI otherwise resolves the installed or latest MCP package normally. AXI
+forwards `CHROME_DEVTOOLS_AXI_MCP_SERVER_URL` to the spawned MCP command as
+`CHROME_DEVTOOLS_MCP_SERVER_URL`, which selects stdio proxy mode. Each named
+AXI bridge therefore gets its own selected page, roots, and tool state while
+the remote service owns the one Chrome connection.
+
+Do not set AXI's local browser-launch or browser-attach variables for this
+arrangement. If they are injected, the MCP `--server-url` mode still wins and
+the proxy does not create another browser.
+
+> [!WARNING]
+> AXI clients can control the same Chrome pages through the shared endpoint.
+> Anyone who can control the endpoint can control Chrome; keep it
+> loopback-only and use SSH port forwarding for remote hosts.
+
+## Concurrent sessions
+
+Most MCP clients start one Chrome DevTools MCP server per conversation. In
+existing stdio mode, multiple independent server processes normally launch
+independent Chrome instances. Pass `--isolated=true` when those processes
+should each use a temporary profile instead of sharing the default profile.
+
+If a client shares one stdio server instance across concurrent agents or
+subagents, leave page-ID routing enabled (the default) with
+`--page-id-routing`. This exposes `pageId` on page-scoped tools so each agent
+can route tool calls to the tab it is working with. For one server shared by
+native HTTP clients or stdio proxies, use the per-session selected-page
+behavior described above.
 
 ## User data directory
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -157,24 +157,50 @@ original stdio client's identity and creates one remote MCP session for that
 client. In proxy mode, AXI-injected local Chrome launch or attach flags are
 ignored because the proxy owns no browser.
 
-### chrome-devtools-axi
+### `chrome-devtools-axi`
 
 Use a `chrome-devtools-axi` version that supports
-`CHROME_DEVTOOLS_AXI_MCP_SERVER_URL`. Each named AXI bridge starts its own MCP
-stdio proxy, so it receives a separate remote MCP context while all bridges
-use the one shared Chrome:
+`CHROME_DEVTOOLS_AXI_MCP_SERVER_URL`. AXI has two deterministic ways to reach
+the shared service. In both modes, one shared `chrome-devtools-mcp` HTTP
+service owns the browser, while each named AXI bridge receives its own remote
+MCP session and context (selected page, roots, isolated contexts, and tool
+state).
+
+**Recommended: direct Streamable HTTP (URL only)**
+
+Set `CHROME_DEVTOOLS_AXI_MCP_SERVER_URL` and leave
+`CHROME_DEVTOOLS_AXI_MCP_PATH` unset or blank:
 
 ```bash
-# In this checkout, build the MCP proxy entrypoint.
-npm run build
-
 # In another terminal, start one shared service (choose any startup mode above).
 npx -y chrome-devtools-mcp@latest \
   --http-port=9333 \
   --headless=true \
   --isolated=true
 
-# In each AXI shell, point at this unreleased MCP build and the shared service.
+# In each AXI shell, use the shared endpoint. No local MCP build is required.
+export CHROME_DEVTOOLS_AXI_MCP_SERVER_URL="http://127.0.0.1:9333/mcp"
+unset CHROME_DEVTOOLS_AXI_MCP_PATH
+
+CHROME_DEVTOOLS_AXI_SESSION=agent-a npx -y chrome-devtools-axi pages
+CHROME_DEVTOOLS_AXI_SESSION=agent-b npx -y chrome-devtools-axi pages
+```
+
+With no nonblank `CHROME_DEVTOOLS_AXI_MCP_PATH`, each AXI bridge constructs its
+own Streamable HTTP transport to the shared URL. This arrangement runs exactly
+one MCP process: the shared HTTP service. The bridges still have separate MCP
+sessions and contexts even though they share the browser and its pages.
+
+**Compatibility and local testing: stdio proxy (URL + MCP_PATH)**
+
+Set both variables only when you intentionally need the verified stdio proxy
+path, such as testing a local MCP build:
+
+```bash
+# Run this in the MCP checkout only when using an unreleased local executable.
+cd /path/to/chrome-devtools-mcp
+npm run build
+
 export CHROME_DEVTOOLS_AXI_MCP_PATH="/path/to/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
 export CHROME_DEVTOOLS_AXI_MCP_SERVER_URL="http://127.0.0.1:9333/mcp"
 
@@ -182,16 +208,18 @@ CHROME_DEVTOOLS_AXI_SESSION=agent-a npx -y chrome-devtools-axi pages
 CHROME_DEVTOOLS_AXI_SESSION=agent-b npx -y chrome-devtools-axi pages
 ```
 
-`CHROME_DEVTOOLS_AXI_MCP_PATH` is needed only to test an unreleased MCP build;
-AXI otherwise resolves the installed or latest MCP package normally. AXI
-forwards `CHROME_DEVTOOLS_AXI_MCP_SERVER_URL` to the spawned MCP command as
-`CHROME_DEVTOOLS_MCP_SERVER_URL`, which selects stdio proxy mode. Each named
-AXI bridge therefore gets its own selected page, roots, and tool state while
-the remote service owns the one Chrome connection.
+When the shared URL and a nonblank `CHROME_DEVTOOLS_AXI_MCP_PATH` are set, AXI
+checks that executable's `--help` output for `--serverUrl`, then spawns only
+that executable with `--server-url=<URL>`. This is the compatibility stdio
+proxy path; each named bridge still gets a separate remote MCP session and
+context. The proxy owns no browser, so configure headless, headed, automatic
+connection, or `--browser-url` options on the shared HTTP service, not in AXI.
 
-Do not set AXI's local browser-launch or browser-attach variables for this
-arrangement. If they are injected, the MCP `--server-url` mode still wins and
-the proxy does not create another browser.
+If the shared URL is absent or blank, AXI keeps its existing standalone stdio
+behavior. Do not set AXI's local browser-launch or browser-attach variables for
+either shared arrangement. For a service reached through an SSH tunnel,
+filesystem artifacts and paths returned by MCP tools remain on the MCP host;
+the tunnel transports MCP traffic but does not copy those files.
 
 > [!WARNING]
 > AXI clients can control the same Chrome pages through the shared endpoint.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,10 +55,18 @@ npx -y chrome-devtools-mcp@latest
 Server URL mode takes precedence over HTTP mode, which takes precedence over
 the existing stdio mode. The proxy owns no browser and forwards JSON-RPC
 transparently, including roots requests and notifications.
-`chrome-devtools-axi` versions with shared-server support forward
-`CHROME_DEVTOOLS_AXI_MCP_SERVER_URL` to the spawned MCP proxy. Each named AXI
-bridge then receives a separate remote MCP context; see the AXI recipe in
-[advanced usage](./advanced-usage.md#chrome-devtools-axi).
+AXI can use this shared endpoint in either of two ways. With
+`CHROME_DEVTOOLS_AXI_MCP_SERVER_URL` nonblank and
+`CHROME_DEVTOOLS_AXI_MCP_PATH` absent or blank, AXI connects directly over
+Streamable HTTP (the recommended mode). Each named AXI bridge creates its own
+HTTP transport, MCP session, and `McpContext`, while the shared service is the
+only MCP process; no local MCP build is required. If the shared URL is
+nonblank and `CHROME_DEVTOOLS_AXI_MCP_PATH` is also nonblank, AXI uses the
+compatibility stdio proxy path: it checks the selected executable's `--help`
+for `--serverUrl` and spawns that executable with only
+`--server-url=<URL>`. Each named bridge still receives a separate remote MCP
+session/context. The generic stdio proxy above remains available for non-AXI
+clients; see the AXI recipe in [advanced usage](./advanced-usage.md#chrome-devtools-axi).
 
 The service is loopback-only and rejects non-loopback `Host` or `Origin`
 values. Remote clients must use SSH port forwarding, for example:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,78 @@
 # Configuration
 
-The Chrome DevTools MCP server supports the following configuration option:
+The Chrome DevTools MCP server supports the following configuration options:
+
+## Shared HTTP server and stdio proxy
+
+Use `--http-port=<1..65535>` to start one long-lived MCP service over
+Streamable HTTP. It binds to `127.0.0.1` and serves native MCP clients at
+`http://127.0.0.1:<port>/mcp`. The usual browser options still choose whether
+that service launches headless or headed Chrome (`--headless`, `--isolated`,
+and related options), or attaches to an existing remote-debugging endpoint
+(`--browser-url` or `--ws-endpoint`). See the [advanced usage guide](./advanced-usage.md)
+for complete launch and attachment recipes.
+
+Configure every native Streamable HTTP client with the same `/mcp` URL instead
+of launching another server process:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "url": "http://127.0.0.1:9333/mcp"
+    }
+  }
+}
+```
+
+Each HTTP client receives its own MCP session, `McpServer`, and `McpContext`.
+Its selected page, negotiated roots, isolated-context names, trace/recording
+and other tool state, and request mutex are isolated from every other client.
+The browser connection and pages are shared: pages opened by one client are
+visible to the others, and browser mutations are visible to all of them.
+Clients should send their session `DELETE` before closing the transport. An
+accepted `DELETE` deterministically releases only that session; closing a
+transport is likewise scoped to that session, and the stdio proxy sends
+`DELETE` automatically on EOF. An abandoned or otherwise inactive session
+expires after 30 minutes. An active request or an open stream suspends idle
+expiry. No per-session close stops the service or shared browser.
+
+Clients that support only stdio can connect through the transparent proxy mode:
+
+```bash
+npx -y chrome-devtools-mcp@latest \
+  --server-url=http://127.0.0.1:9333/mcp
+```
+
+`--server-url` requires an absolute `http(s)` URL. Set
+`CHROME_DEVTOOLS_MCP_SERVER_URL` instead when the client cannot add the flag:
+
+```bash
+export CHROME_DEVTOOLS_MCP_SERVER_URL=http://127.0.0.1:9333/mcp
+npx -y chrome-devtools-mcp@latest
+```
+
+Server URL mode takes precedence over HTTP mode, which takes precedence over
+the existing stdio mode. The proxy owns no browser and forwards JSON-RPC
+transparently, including roots requests and notifications.
+`chrome-devtools-axi` versions with shared-server support forward
+`CHROME_DEVTOOLS_AXI_MCP_SERVER_URL` to the spawned MCP proxy. Each named AXI
+bridge then receives a separate remote MCP context; see the AXI recipe in
+[advanced usage](./advanced-usage.md#chrome-devtools-axi).
+
+The service is loopback-only and rejects non-loopback `Host` or `Origin`
+values. Remote clients must use SSH port forwarding, for example:
+
+```bash
+ssh -N -L 9333:127.0.0.1:9333 user@chrome-host
+```
+
+Then connect to `http://127.0.0.1:9333/mcp` on the client side of the tunnel.
+
+> [!WARNING]
+> Anyone who can control this endpoint can control Chrome, including reading
+> and modifying browser data. Keep it loopback-only; remote hosts must use SSH
+> tunnels and must not expose the service as a public network endpoint.
 
 <!-- BEGIN AUTO GENERATED OPTIONS -->
 
@@ -97,6 +169,16 @@ The Chrome DevTools MCP server supports the following configuration option:
 
 - **`--logFile`/ `--log-file`**
   Path to a file to write debug logs to. Set the env variable `DEBUG` to `*` to enable verbose logs. Useful for submitting bug reports.
+  - **Type:** string
+  - **Default:** `false`
+
+- **`--httpPort`/ `--http-port`**
+  Start a shared Streamable HTTP MCP server on 127.0.0.1. The endpoint is available at /mcp.
+  - **Type:** number
+  - **Default:** `false`
+
+- **`--serverUrl`/ `--server-url`**
+  Use an existing Streamable HTTP MCP server through a transparent stdio proxy.
   - **Type:** string
   - **Default:** `false`
 

--- a/src/McpContext.ts
+++ b/src/McpContext.ts
@@ -19,6 +19,7 @@ import type {
   HeapEdgesQueryOptions,
   HeapQueryOptions,
 } from './processors/HeapSnapshotManager.js';
+import type {TraceResult} from './processors/PerformanceTrace.js';
 import {McpPage} from './McpPage.js';
 import {type UncaughtError} from './collectors/PageCollector.js';
 import {ServiceWorkerConsoleCollector} from './collectors/ServiceWorkerCollector.js';
@@ -43,10 +44,10 @@ import {listPages} from './tools/pages.js';
 import {CLOSE_PAGE_ERROR} from './tools/ToolDefinition.js';
 import type {
   Context,
+  ContextPage,
   DevToolsData,
   SupportedExtensions,
 } from './tools/ToolDefinition.js';
-import type {TraceResult} from './processors/PerformanceTrace.js';
 import type {Logger} from './types.js';
 import type {ExtensionServiceWorker} from './types.js';
 import {getTempFilePath, resolveCanonicalPath} from './utils/files.js';
@@ -91,6 +92,8 @@ export class McpContext implements Context {
 
   // Maps LLM-provided isolatedContext name → Puppeteer BrowserContext.
   #isolatedContexts = new Map<string, BrowserContext>();
+  // Browser contexts created by this context; discovered contexts are never owned.
+  #ownedIsolatedContexts = new Set<BrowserContext>();
   // Auto-generated name counter for when no name is provided.
   #nextIsolatedContextId = 1;
 
@@ -103,8 +106,10 @@ export class McpContext implements Context {
   #serviceWorkerConsoleCollector: ServiceWorkerConsoleCollector;
 
   #isRunningTrace = false;
+  #performanceTracePage?: ContextPage;
   #screenRecorderData: {recorder: ScreenRecorder; filePath: string} | null =
     null;
+  #disposePromise?: Promise<void>;
 
   #reconnectNotice = false;
   #extensionPages = new WeakMap<Target, Page>();
@@ -126,11 +131,7 @@ export class McpContext implements Context {
     options: McpContextOptions,
     locatorClass: typeof Locator,
   ) {
-    overrideDevToolsGlobals({
-      loadResource: (url: string) => {
-        return this.loadResource(url);
-      },
-    });
+    overrideDevToolsGlobals({});
 
     this.browser = browser;
     this.logger = logger;
@@ -153,20 +154,59 @@ export class McpContext implements Context {
     this.browser.on('targetdestroyed', this.#onTargetDestroyed);
   }
 
-  dispose() {
-    this.browser.off('targetcreated', this.#onTargetCreated);
-    this.browser.off('targetdestroyed', this.#onTargetDestroyed);
-
-    this.#serviceWorkerConsoleCollector.dispose();
-    this.#heapSnapshotManager.dispose();
-    for (const mcpPage of this.#mcpPages.values()) {
-      mcpPage.dispose();
+  async dispose(): Promise<void> {
+    if (this.#disposePromise !== undefined) {
+      return await this.#disposePromise;
     }
-    this.#mcpPages.clear();
-    // Isolated contexts are intentionally not closed here.
-    // Either the entire browser will be closed or we disconnect
-    // without destroying browser state.
-    this.#isolatedContexts.clear();
+
+    const disposePromise = (async (): Promise<void> => {
+      const recorderData = this.#screenRecorderData;
+      this.#screenRecorderData = null;
+      if (recorderData !== null) {
+        try {
+          await recorderData.recorder.stop();
+        } catch (error) {
+          this.logger?.(
+            'Failed to stop screencast during context disposal',
+            error,
+          );
+        }
+      }
+
+      const tracePage = this.#performanceTracePage;
+      this.#performanceTracePage = undefined;
+      this.#isRunningTrace = false;
+      if (tracePage !== undefined) {
+        try {
+          await tracePage.pptrPage.tracing.stop();
+        } catch (error) {
+          this.logger?.(
+            'Failed to stop performance trace during context disposal',
+            error,
+          );
+        }
+      }
+
+      this.browser.off('targetcreated', this.#onTargetCreated);
+      this.browser.off('targetdestroyed', this.#onTargetDestroyed);
+      this.#serviceWorkerConsoleCollector.dispose();
+      this.#heapSnapshotManager.dispose();
+      for (const mcpPage of this.#mcpPages.values()) {
+        mcpPage.dispose();
+      }
+      this.#mcpPages.clear();
+
+      const ownedContexts = [...this.#ownedIsolatedContexts];
+      this.#ownedIsolatedContexts.clear();
+      this.#isolatedContexts.clear();
+      await Promise.allSettled(
+        ownedContexts.map(async context => {
+          await context.close();
+        }),
+      );
+    })();
+    this.#disposePromise = disposePromise;
+    return await disposePromise;
   }
 
   #onTargetCreated = async (target: Target) => {
@@ -346,6 +386,7 @@ export class McpContext implements Context {
       let ctx = this.#isolatedContexts.get(isolatedContextName);
       if (!ctx) {
         ctx = await this.browser.createBrowserContext();
+        this.#ownedIsolatedContexts.add(ctx);
         this.#isolatedContexts.set(isolatedContextName, ctx);
       }
       page = await ctx.newPage({background});
@@ -391,10 +432,21 @@ export class McpContext implements Context {
 
   setIsRunningPerformanceTrace(x: boolean): void {
     this.#isRunningTrace = x;
+    if (!x) {
+      this.#performanceTracePage = undefined;
+    }
   }
 
   isRunningPerformanceTrace(): boolean {
     return this.#isRunningTrace;
+  }
+
+  getPerformanceTracePage(): ContextPage | undefined {
+    return this.#performanceTracePage;
+  }
+
+  setPerformanceTracePage(page: ContextPage | undefined): void {
+    this.#performanceTracePage = page;
   }
 
   getScreenRecorder(): {recorder: ScreenRecorder; filePath: string} | null {
@@ -573,6 +625,7 @@ export class McpContext implements Context {
         navigationTimeout: this.#options.navigationTimeout,
         sourceMaps: this.#options.sourceMaps,
         onNotification: this.#options.onNotification,
+        loadResource: (url: string) => this.loadResource(url),
       });
       this.#mcpPages.set(page, mcpPage);
       await mcpPage.init();

--- a/src/McpPage.ts
+++ b/src/McpPage.ts
@@ -149,6 +149,7 @@ export class McpPage implements ContextPage {
   #sourceMaps: boolean;
   #commentBridge?: DevToolsCommentBridge;
   #onNotification?: (message: string) => void;
+  #loadResource?: (url: string) => Promise<string>;
 
   constructor(
     page: Page,
@@ -160,6 +161,7 @@ export class McpPage implements ContextPage {
       navigationTimeout?: number;
       sourceMaps?: boolean;
       onNotification?: (message: string) => void;
+      loadResource?: (url: string) => Promise<string>;
     },
   ) {
     this.#hasNetworkBlockOrAllowlist = options.hasNetworkBlockOrAllowlist;
@@ -167,6 +169,7 @@ export class McpPage implements ContextPage {
     this.#navigationTimeout = options.navigationTimeout ?? NAVIGATION_TIMEOUT;
     this.#sourceMaps = options.sourceMaps ?? true;
     this.#onNotification = options.onNotification;
+    this.#loadResource = options.loadResource;
     this.pptrPage = page;
     this.id = id;
     this.isolatedContextName = options.isolatedContextName;
@@ -213,6 +216,7 @@ export class McpPage implements ContextPage {
       const session = await this.pptrPage.createCDPSession();
       this.#devtoolsUniverse = await createTargetUniverse(session, {
         sourceMaps: this.#sourceMaps,
+        loadResource: this.#loadResource,
       });
     } catch (e) {
       logger?.('Failed to initialize DevTools universe', e);

--- a/src/ToolHandler.ts
+++ b/src/ToolHandler.ts
@@ -6,6 +6,7 @@
 
 import type {ParsedArguments} from './config/mcp-options.js';
 import type {McpContext} from './McpContext.js';
+import {runWithResourceLoader} from './devtools/DevtoolsUtils.js';
 import type {McpPage} from './McpPage.js';
 import type {DataFormat} from './McpResponse.js';
 import {McpResponse} from './McpResponse.js';
@@ -175,6 +176,7 @@ export class ToolHandler {
     private readonly serverArgs: ParsedArguments,
     private readonly getContext: () => Promise<McpContext>,
     private readonly toolMutex: Mutex,
+    private readonly getClientName?: () => string | undefined,
   ) {
     const {disabled, reason} = getToolStatusInfo(tool, serverArgs);
     this.disabledReason = reason;
@@ -248,36 +250,41 @@ export class ToolHandler {
       let page: McpPage | undefined;
       try {
         await validateToolFiles(this.tool, params, context);
-        if (isPageScopedTool(this.tool)) {
-          const pageId =
-            typeof params.pageId === 'number' ? params.pageId : undefined;
-          page =
-            this.serverArgs.pageIdRouting &&
-            pageId !== undefined &&
-            !this.serverArgs.slim
-              ? context.getPageById(pageId)
-              : context.getSelectedMcpPage();
-          response.setPage(page);
-          if (this.tool.blockedByDialog) {
-            page.throwIfDialogOpen();
-          }
-          await this.tool.handler(
-            {
-              params,
-              page,
-            },
-            response,
-            context,
-          );
-        } else {
-          await this.tool.handler(
-            {
-              params,
-            },
-            response,
-            context,
-          );
-        }
+        await runWithResourceLoader(
+          (url: string) => context.loadResource(url),
+          async () => {
+            if (isPageScopedTool(this.tool)) {
+              const pageId =
+                typeof params.pageId === 'number' ? params.pageId : undefined;
+              page =
+                this.serverArgs.pageIdRouting &&
+                pageId !== undefined &&
+                !this.serverArgs.slim
+                  ? context.getPageById(pageId)
+                  : context.getSelectedMcpPage();
+              response.setPage(page);
+              if (this.tool.blockedByDialog) {
+                page.throwIfDialogOpen();
+              }
+              await this.tool.handler(
+                {
+                  params,
+                  page,
+                },
+                response,
+                context,
+              );
+            } else {
+              await this.tool.handler(
+                {
+                  params,
+                },
+                response,
+                context,
+              );
+            }
+          },
+        );
       } catch (err) {
         response.setError(err);
       }
@@ -291,9 +298,11 @@ export class ToolHandler {
         dataFormat = 'toon';
       }
 
-      const {content, structuredContent} = await response.handle(
-        context,
-        dataFormat,
+      const {content, structuredContent} = await runWithResourceLoader(
+        (url: string) => context.loadResource(url),
+        async () => {
+          return await response.handle(context, dataFormat);
+        },
       );
       const result: CallToolResult & {
         structuredContent?: Record<string, unknown>;
@@ -332,6 +341,7 @@ export class ToolHandler {
         latencyMs: Date.now() - startTime,
         devToolsData,
         pageUrl,
+        clientName: this.getClientName?.(),
       });
       guard[Symbol.dispose]();
     }

--- a/src/bin/chrome-devtools-mcp-main.ts
+++ b/src/bin/chrome-devtools-mcp-main.ts
@@ -9,7 +9,9 @@ import '../utils/polyfill.js';
 import process from 'node:process';
 
 import {closeBrowser} from '../browser.js';
+import {startMcpHttpServer, type McpHttpServer} from '../http-server.js';
 import {McpServer, logDisclaimers} from '../index.js';
+import {runStdioProxy} from '../proxy.js';
 import {ClearcutLogger} from '../telemetry/ClearcutLogger.js';
 import {computeFlagUsage} from '../telemetry/flagUtils.js';
 import {StdioServerTransport} from '../third_party/index.js';
@@ -26,6 +28,9 @@ await checkForUpdates(
 export const args = parseArguments(VERSION);
 
 const logFile = args.logFile ? saveLogsToFile(args.logFile) : undefined;
+const serverUrl = args.serverUrl ? new URL(args.serverUrl) : undefined;
+const isHttpMode = serverUrl === undefined && args.httpPort !== undefined;
+const isProxyMode = serverUrl !== undefined;
 
 if (process.env['CHROME_DEVTOOLS_MCP_CRASH_ON_UNCAUGHT'] !== 'true') {
   process.on('unhandledRejection', (reason, promise) => {
@@ -33,11 +38,15 @@ if (process.env['CHROME_DEVTOOLS_MCP_CRASH_ON_UNCAUGHT'] !== 'true') {
   });
 }
 
+let shuttingDown = false;
+let httpServer: McpHttpServer | undefined;
+let stdioServer: McpServer | undefined;
+let proxyPromise: Promise<void> | undefined;
+
 // Shutdown on stdin EOF (stdio MCP convention — the client closes the
 // transport to signal exit) and on standard termination signals. Without
 // this, an active Chrome subprocess keeps the Node event loop ref'd after
 // stdin closes and the server hangs until something else kills it.
-let shuttingDown = false;
 async function shutdown(reason: string): Promise<void> {
   if (shuttingDown) {
     return;
@@ -52,15 +61,37 @@ async function shutdown(reason: string): Promise<void> {
     logger?.('Shutdown timeout exceeded, forcing exit');
     process.exit(0);
   }, 5000).unref();
+
+  if (httpServer !== undefined) {
+    await httpServer.close().catch(error => {
+      logger?.('Failed to close HTTP server', error);
+    });
+  }
+  if (stdioServer !== undefined) {
+    await stdioServer.close().catch(error => {
+      logger?.('Failed to close stdio MCP server', error);
+    });
+  }
+  if (isProxyMode) {
+    // The proxy owns stdin's lifecycle. Destroying it wakes its EOF/close
+    // handler so the remote session is terminated before this process exits.
+    process.stdin.destroy();
+    await proxyPromise?.catch(error => {
+      logger?.('Failed to close stdio proxy', error);
+    });
+  }
   await closeBrowser();
   process.exit(0);
 }
-process.stdin.on('end', () => {
-  void shutdown('stdin end');
-});
-process.stdin.on('close', () => {
-  void shutdown('stdin close');
-});
+
+if (!isHttpMode) {
+  process.stdin.on('end', () => {
+    void shutdown('stdin end');
+  });
+  process.stdin.on('close', () => {
+    void shutdown('stdin close');
+  });
+}
 process.on('SIGTERM', () => {
   void shutdown('SIGTERM');
 });
@@ -72,12 +103,26 @@ process.on('SIGHUP', () => {
 });
 
 logger?.(`Starting Chrome DevTools MCP Server v${VERSION}`);
-const server = await McpServer.from(args, {
-  logFile,
-});
-const transport = new StdioServerTransport();
-await server.connect(transport);
-logger?.('Chrome DevTools MCP Server connected');
-logDisclaimers(args);
-void ClearcutLogger.get()?.logDailyActiveIfNeeded();
-void ClearcutLogger.get()?.logServerStart(computeFlagUsage(args, mcpOptions));
+
+if (isProxyMode) {
+  proxyPromise = runStdioProxy(serverUrl);
+  await proxyPromise;
+  await shutdown('stdio proxy closed');
+} else if (args.httpPort !== undefined) {
+  httpServer = await startMcpHttpServer(args, {
+    port: args.httpPort,
+    logFile,
+  });
+  logger?.(`Chrome DevTools MCP Server listening at ${httpServer.url.href}`);
+  logDisclaimers(args);
+} else {
+  stdioServer = await McpServer.from(args, {
+    logFile,
+  });
+  const transport = new StdioServerTransport();
+  await stdioServer.connect(transport);
+  logger?.('Chrome DevTools MCP Server connected');
+  logDisclaimers(args);
+  void ClearcutLogger.get()?.logDailyActiveIfNeeded();
+  void ClearcutLogger.get()?.logServerStart(computeFlagUsage(args, mcpOptions));
+}

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -19,7 +19,47 @@ import {logger, puppeteerLogger} from './utils/logger.js';
 import {isAllowedUrl} from './utils/url.js';
 
 let browser: Browser | undefined;
-let browserMode: 'launched' | 'connected' | undefined;
+type BrowserMode = 'launched' | 'connected';
+let browserMode: BrowserMode | undefined;
+let browserAcquisition: Promise<Browser> | undefined;
+let browserShutdown: Promise<void> | undefined;
+
+function acquireBrowser(
+  mode: BrowserMode,
+  acquire: () => Promise<Browser>,
+): Promise<Browser> {
+  if (browserShutdown) {
+    return Promise.reject(new Error('Browser is shutting down'));
+  }
+
+  const activeBrowser = browser;
+  if (activeBrowser?.connected) {
+    return Promise.resolve(activeBrowser);
+  }
+  if (browserAcquisition) {
+    return browserAcquisition;
+  }
+
+  const acquisition = acquire().then(acquiredBrowser => {
+    browserMode = mode;
+    browser = acquiredBrowser;
+    return acquiredBrowser;
+  });
+  browserAcquisition = acquisition;
+  void acquisition.then(
+    () => {
+      if (browserAcquisition === acquisition) {
+        browserAcquisition = undefined;
+      }
+    },
+    () => {
+      if (browserAcquisition === acquisition) {
+        browserAcquisition = undefined;
+      }
+    },
+  );
+  return acquisition;
+}
 
 export function makeTargetFilter(enableExtensions = false) {
   return function targetFilter(target: {url(): string}): boolean {
@@ -31,7 +71,7 @@ export function makeTargetFilter(enableExtensions = false) {
   };
 }
 
-export async function ensureBrowserConnected(options: {
+interface McpConnectOptions {
   browserURL?: string;
   wsEndpoint?: string;
   wsHeaders?: Record<string, string>;
@@ -41,12 +81,16 @@ export async function ensureBrowserConnected(options: {
   enableExtensions?: boolean;
   blocklist?: string[];
   allowlist?: string[];
-}) {
-  const {channel, enableExtensions} = options;
-  if (browser?.connected) {
-    return browser;
-  }
+}
 
+export async function ensureBrowserConnected(
+  options: McpConnectOptions,
+): Promise<Browser> {
+  return acquireBrowser('connected', () => connectBrowser(options));
+}
+
+async function connectBrowser(options: McpConnectOptions): Promise<Browser> {
+  const {channel, enableExtensions} = options;
   const connectOptions: Parameters<typeof puppeteer.connect>[0] = {
     targetFilter: makeTargetFilter(enableExtensions),
     defaultViewport: null,
@@ -112,13 +156,9 @@ export async function ensureBrowserConnected(options: {
   }
 
   logger?.('Connecting Puppeteer to ', JSON.stringify(connectOptions));
+  let connected: Browser;
   try {
-    // Assign mode before browser so a concurrent closeBrowser() never sees
-    // `browser` set with `browserMode` still undefined (would fall through
-    // to the disconnect() path and orphan a launched Chrome).
-    const connected = await puppeteer.connect(connectOptions);
-    browserMode = 'connected';
-    browser = connected;
+    connected = await puppeteer.connect(connectOptions);
   } catch (err) {
     throw new Error(
       `Could not connect to Chrome. ${autoConnect ? `Check if Chrome is running and remote debugging is enabled by going to chrome://inspect/#remote-debugging.` : `Check if Chrome is running.`}`,
@@ -128,7 +168,7 @@ export async function ensureBrowserConnected(options: {
     );
   }
   logger?.('Connected Puppeteer');
-  return browser;
+  return connected;
 }
 
 interface McpLaunchOptions {
@@ -266,14 +306,7 @@ export async function launch(options: McpLaunchOptions): Promise<Browser> {
 export async function ensureBrowserLaunched(
   options: McpLaunchOptions,
 ): Promise<Browser> {
-  if (browser?.connected) {
-    return browser;
-  }
-  // Assign mode before browser; see the connect path above for rationale.
-  const launched = await launch(options);
-  browserMode = 'launched';
-  browser = launched;
-  return browser;
+  return acquireBrowser('launched', () => launch(options));
 }
 
 /**
@@ -283,7 +316,39 @@ export async function ensureBrowserLaunched(
  * the connection has already been dropped. Called from the server entrypoint
  * on stdin EOF / SIGTERM / SIGINT.
  */
-export async function closeBrowser(): Promise<void> {
+export function closeBrowser(): Promise<void> {
+  if (browserShutdown) {
+    return browserShutdown;
+  }
+
+  const shutdown = Promise.resolve().then(() => shutdownBrowser());
+  browserShutdown = shutdown;
+  void shutdown.then(
+    () => {
+      if (browserShutdown === shutdown) {
+        browserShutdown = undefined;
+      }
+    },
+    () => {
+      if (browserShutdown === shutdown) {
+        browserShutdown = undefined;
+      }
+    },
+  );
+  return shutdown;
+}
+
+async function shutdownBrowser(): Promise<void> {
+  let acquisition = browserAcquisition;
+  while (acquisition) {
+    try {
+      await acquisition;
+    } catch {
+      // The acquisition caller receives the original error.
+    }
+    acquisition = browserAcquisition;
+  }
+
   const b = browser;
   const mode = browserMode;
   browser = undefined;

--- a/src/config/mcp-options.ts
+++ b/src/config/mcp-options.ts
@@ -11,6 +11,41 @@ import {readFileSync} from 'node:fs';
 
 export const DEFAULT_FILESYSTEM_ROOT = [os.tmpdir()];
 
+function validateServerUrl(value: string | undefined): string | undefined {
+  if (value === undefined || value === '') {
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(
+      `Provided serverUrl ${value} is not a valid absolute HTTP(S) URL.`,
+    );
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `Provided serverUrl ${value} is not a valid absolute HTTP(S) URL.`,
+    );
+  }
+
+  return value;
+}
+
+function validateHttpPort(value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return;
+  }
+  if (!Number.isInteger(value) || value < 1 || value > 65535) {
+    throw new Error(
+      `Invalid httpPort ${value}. Expected an integer from 1 to 65535.`,
+    );
+  }
+  return value;
+}
+
 import {getCategoryOptions} from './category-options.js';
 import {getBrowserOptions} from './browser-options.js';
 
@@ -21,6 +56,18 @@ export const mcpOptions = {
     type: 'string',
     describe:
       'Path to a file to write debug logs to. Set the env variable `DEBUG` to `*` to enable verbose logs. Useful for submitting bug reports.',
+  },
+  httpPort: {
+    type: 'number',
+    describe:
+      'Start a shared Streamable HTTP MCP server on 127.0.0.1. The endpoint is available at /mcp.',
+    coerce: validateHttpPort,
+  },
+  serverUrl: {
+    type: 'string',
+    describe:
+      'Use an existing Streamable HTTP MCP server through a transparent stdio proxy.',
+    coerce: validateServerUrl,
   },
   viewport: {
     type: 'string',
@@ -334,6 +381,14 @@ export function parser(
     .options(options)
     .showHelpOnFail(false, 'Specify --help for available options')
     .middleware(args => {
+      if (args.serverUrl === undefined) {
+        const serverUrl = validateServerUrl(
+          env['CHROME_DEVTOOLS_MCP_SERVER_URL'],
+        );
+        if (serverUrl !== undefined) {
+          args.serverUrl = serverUrl;
+        }
+      }
       if (isViaCli && args.filesystemRoot === DEFAULT_FILESYSTEM_ROOT) {
         const cliFilesystemArgs: {
           allowUnrestrictedPaths?: boolean;

--- a/src/devtools/DevtoolsUtils.ts
+++ b/src/devtools/DevtoolsUtils.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {AsyncLocalStorage} from 'node:async_hooks';
+
 import {DevTools} from '../third_party/index.js';
 import type {
   CDPSession,
@@ -12,6 +14,27 @@ import type {
 } from '../third_party/index.js';
 
 import {McpHostBindingAdapter} from './McpHostBindingAdapter.js';
+type ResourceLoader = (url: string) => Promise<string>;
+
+const resourceLoaderStorage = new AsyncLocalStorage<ResourceLoader>();
+const routedResourceLoader: ResourceLoader = async (url: string) => {
+  const loadResource = resourceLoaderStorage.getStore();
+  if (loadResource === undefined) {
+    throw new Error(
+      'No active MCP context is available to load this resource.',
+    );
+  }
+  return await loadResource(url);
+};
+const routedHost = new McpHostBindingAdapter(routedResourceLoader);
+let routedHostInstalled = false;
+
+export async function runWithResourceLoader<T>(
+  loadResource: ResourceLoader,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return await resourceLoaderStorage.run(loadResource, operation);
+}
 
 /**
  * A mock implementation of an issues manager that only implements the methods
@@ -25,13 +48,17 @@ export class FakeIssuesManager extends DevTools.Common.ObjectWrapper
 }
 
 export function overrideDevToolsGlobals({
-  loadResource,
+  installHost = true,
 }: {
-  loadResource: (url: string) => Promise<string>;
+  loadResource?: ResourceLoader;
+  installHost?: boolean;
 }): void {
-  DevTools.Host.InspectorFrontendHost.installInspectorFrontendHost(
-    new McpHostBindingAdapter(loadResource),
-  );
+  if (installHost && !routedHostInstalled) {
+    DevTools.Host.InspectorFrontendHost.installInspectorFrontendHost(
+      routedHost,
+    );
+    routedHostInstalled = true;
+  }
 
   // DevTools CDP errors can get noisy.
   DevTools.ProtocolClient.InspectorBackend.test.suppressRequestErrors = true;
@@ -139,6 +166,7 @@ export interface TargetUniverse {
 
 export interface CreateTargetUniverseOptions {
   sourceMaps?: boolean;
+  loadResource?: (url: string) => Promise<string>;
 }
 
 export async function createTargetUniverse(
@@ -157,7 +185,9 @@ export async function createTargetUniverse(
     overrideAutoStartModels: new Set([DevTools.DebuggerModel]),
     hostConfig: {},
     inspectorFrontendHost:
-      DevTools.Host.InspectorFrontendHost.InspectorFrontendHostInstance,
+      options?.loadResource === undefined
+        ? DevTools.Host.InspectorFrontendHost.InspectorFrontendHostInstance
+        : new McpHostBindingAdapter(routedResourceLoader),
     supportsEmulation: false,
   });
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,723 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {randomUUID} from 'node:crypto';
+import type fs from 'node:fs';
+import {isIP} from 'node:net';
+import http, {
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+
+import {McpServer} from './index.js';
+import {
+  isInitializeRequest,
+  StreamableHTTPServerTransport,
+} from './third_party/index.js';
+import type {ParsedArguments} from './config/mcp-options.js';
+import {logger} from './utils/logger.js';
+
+const MCP_PATH = '/mcp';
+const ALLOWED_METHODS: Record<string, true> = {
+  GET: true,
+  POST: true,
+  DELETE: true,
+};
+const LOOPBACK_HOSTNAMES: Record<string, true> = {
+  localhost: true,
+  '::1': true,
+};
+const DEFAULT_MAX_SESSIONS = 128;
+const DEFAULT_MAX_PENDING_SESSIONS = 8;
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024;
+const REQUEST_BODY_TIMEOUT_MS = 30 * 1000;
+type TimeoutHandle = NodeJS.Timeout;
+
+export interface McpHttpServerOptions {
+  port: number;
+  logFile?: fs.WriteStream;
+  maxSessions?: number;
+  maxPendingSessions?: number;
+  sessionIdleTimeoutMs?: number;
+}
+
+export interface McpHttpServer {
+  url: URL;
+  close(): Promise<void>;
+}
+
+interface HttpSession {
+  server: McpServer;
+  transport: StreamableHTTPServerTransport;
+  sessionId?: string;
+  idleTimer?: TimeoutHandle;
+  activeRequests: number;
+  closePromise?: Promise<void>;
+}
+
+class HttpRequestError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sendJsonRpcError(
+  response: ServerResponse,
+  status: number,
+  message: string,
+  code = -32000,
+  headers: Record<string, string> = {},
+): void {
+  if (response.headersSent) {
+    if (!response.writableEnded) {
+      response.end();
+    }
+    return;
+  }
+
+  response.writeHead(status, {
+    'Content-Type': 'application/json',
+    ...headers,
+  });
+  response.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      error: {
+        code,
+        message,
+      },
+      id: null,
+    }),
+  );
+}
+
+function getHeader(request: IncomingMessage, name: string): string | undefined {
+  const value = request.headers[name];
+  return typeof value === 'string' ? value : undefined;
+}
+function hasMediaType(value: string | undefined, mediaType: string): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  return value.split(',').some(part => {
+    return part.split(';', 1)[0]?.trim().toLowerCase() === mediaType;
+  });
+}
+
+function validatePostHeaders(request: IncomingMessage): void {
+  const accept = getHeader(request, 'accept');
+  if (
+    !hasMediaType(accept, 'application/json') ||
+    !hasMediaType(accept, 'text/event-stream')
+  ) {
+    throw new HttpRequestError(
+      406,
+      'Accept must include application/json and text/event-stream.',
+    );
+  }
+
+  const contentType = getHeader(request, 'content-type');
+  if (
+    contentType === undefined ||
+    contentType.split(';', 1)[0]?.trim().toLowerCase() !== 'application/json'
+  ) {
+    throw new HttpRequestError(415, 'Content-Type must be application/json.');
+  }
+}
+
+function countInitializeRequests(body: unknown): number {
+  if (Array.isArray(body)) {
+    return body.reduce((count, item) => {
+      return count + (isInitializeRequest(item) ? 1 : 0);
+    }, 0);
+  }
+  return isInitializeRequest(body) ? 1 : 0;
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = request.headers['content-length'];
+  if (declaredLength !== undefined) {
+    if (typeof declaredLength !== 'string' || !/^\d+$/.test(declaredLength)) {
+      request.resume();
+      throw new HttpRequestError(400, 'Invalid Content-Length header.');
+    }
+    const length = Number(declaredLength);
+    if (!Number.isSafeInteger(length) || length > MAX_REQUEST_BODY_BYTES) {
+      request.resume();
+      throw new HttpRequestError(413, 'Request body is too large.');
+    }
+  }
+
+  const {promise, resolve, reject} = Promise.withResolvers<unknown>();
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let settled = false;
+
+  const cleanup = (): void => {
+    clearTimeout(timeout);
+    request.setTimeout(0);
+    request.off('data', onData);
+    request.off('end', onEnd);
+    request.off('aborted', onAborted);
+    request.off('error', onError);
+  };
+  const rejectBody = (error: HttpRequestError): void => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    request.resume();
+    reject(error);
+  };
+  const resolveBody = (body: unknown): void => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    resolve(body);
+  };
+  const onData = (chunk: Buffer | string): void => {
+    const bytes = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    totalBytes += bytes.byteLength;
+    if (totalBytes > MAX_REQUEST_BODY_BYTES) {
+      rejectBody(new HttpRequestError(413, 'Request body is too large.'));
+      return;
+    }
+    chunks.push(bytes);
+  };
+  const onEnd = (): void => {
+    let body: unknown;
+    try {
+      body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    } catch {
+      rejectBody(new HttpRequestError(400, 'Request body must be valid JSON.'));
+      return;
+    }
+    resolveBody(body);
+  };
+  const onAborted = (): void => {
+    rejectBody(new HttpRequestError(400, 'Request body was aborted.'));
+  };
+  const onError = (error: Error): void => {
+    rejectBody(
+      new HttpRequestError(
+        400,
+        `Failed to read request body: ${error.message}`,
+      ),
+    );
+  };
+  const onTimeout = (): void => {
+    rejectBody(new HttpRequestError(408, 'Request body timed out.'));
+  };
+
+  const timeout = setTimeout(onTimeout, REQUEST_BODY_TIMEOUT_MS);
+  timeout.unref();
+  request.setTimeout(REQUEST_BODY_TIMEOUT_MS, onTimeout);
+  request.on('data', onData);
+  request.once('end', onEnd);
+  request.once('aborted', onAborted);
+  request.once('error', onError);
+  return await promise;
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .replace(/\.$/, '')
+    .toLowerCase();
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+  if (LOOPBACK_HOSTNAMES[normalized] === true) {
+    return true;
+  }
+
+  if (isIP(normalized) === 4) {
+    const firstOctet = Number(normalized.split('.')[0]);
+    return firstOctet === 127;
+  }
+
+  return false;
+}
+
+function isLoopbackHost(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(`http://${value}`);
+    return (
+      parsed.username === '' &&
+      parsed.password === '' &&
+      parsed.pathname === '/' &&
+      parsed.search === '' &&
+      parsed.hash === '' &&
+      isLoopbackHostname(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isLoopbackOrigin(value: string | undefined): boolean {
+  if (!value || value === 'null') {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+      parsed.username === '' &&
+      parsed.password === '' &&
+      (parsed.pathname === '' || parsed.pathname === '/') &&
+      parsed.search === '' &&
+      parsed.hash === '' &&
+      isLoopbackHostname(parsed.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function validateRequestSecurity(
+  request: IncomingMessage,
+  response: ServerResponse,
+): boolean {
+  const host = getHeader(request, 'host');
+  if (!isLoopbackHost(host)) {
+    sendJsonRpcError(response, 403, `Invalid Host header: ${host}`);
+    return false;
+  }
+
+  const origin = getHeader(request, 'origin');
+  if (origin !== undefined && !isLoopbackOrigin(origin)) {
+    sendJsonRpcError(response, 403, `Invalid Origin header: ${origin}`);
+    return false;
+  }
+
+  return true;
+}
+
+function validatePort(port: number): void {
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(
+      `Invalid HTTP port ${port}. Expected an integer from 0 to 65535.`,
+    );
+  }
+}
+function resolvePositiveLimit(
+  value: number | undefined,
+  fallback: number,
+  name: string,
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < 1) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return resolved;
+}
+
+function closeNodeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  const {promise, resolve, reject} = Promise.withResolvers<void>();
+  server.close(error => {
+    if (error) {
+      reject(error);
+    } else {
+      resolve();
+    }
+  });
+  return promise;
+}
+export async function startMcpHttpServer(
+  serverArgs: ParsedArguments,
+  options: McpHttpServerOptions,
+): Promise<McpHttpServer> {
+  validatePort(options.port);
+  const maxSessions = resolvePositiveLimit(
+    options.maxSessions,
+    DEFAULT_MAX_SESSIONS,
+    'maxSessions',
+  );
+  const maxPendingSessions = resolvePositiveLimit(
+    options.maxPendingSessions,
+    DEFAULT_MAX_PENDING_SESSIONS,
+    'maxPendingSessions',
+  );
+  const sessionIdleTimeoutMs = resolvePositiveLimit(
+    options.sessionIdleTimeoutMs,
+    DEFAULT_SESSION_IDLE_TIMEOUT_MS,
+    'sessionIdleTimeoutMs',
+  );
+
+  const sessions = new Map<string, HttpSession>();
+  const pendingSessions = new Set<HttpSession>();
+  const pendingInitializationPromises = new Set<Promise<HttpSession>>();
+  let pendingInitializations = 0;
+  const nodeServer = http.createServer();
+  let closing = false;
+  let closePromise: Promise<void> | undefined;
+
+  const removeSession = (session: HttpSession): void => {
+    pendingSessions.delete(session);
+    if (session.idleTimer !== undefined) {
+      clearTimeout(session.idleTimer);
+      session.idleTimer = undefined;
+    }
+    if (
+      session.sessionId !== undefined &&
+      sessions.get(session.sessionId) === session
+    ) {
+      sessions.delete(session.sessionId);
+    }
+  };
+
+  const refreshSession = (session: HttpSession): void => {
+    if (session.idleTimer !== undefined) {
+      clearTimeout(session.idleTimer);
+      session.idleTimer = undefined;
+    }
+    if (session.closePromise !== undefined || session.activeRequests > 0) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      void closeSession(session).catch(error => {
+        logger?.('Failed to close idle HTTP MCP session', error);
+      });
+    }, sessionIdleTimeoutMs);
+    timer.unref();
+    session.idleTimer = timer;
+  };
+
+  const beginSessionRequest = (session: HttpSession): void => {
+    if (session.idleTimer !== undefined) {
+      clearTimeout(session.idleTimer);
+      session.idleTimer = undefined;
+    }
+    session.activeRequests++;
+  };
+
+  const endSessionRequest = (session: HttpSession): void => {
+    session.activeRequests--;
+    if (session.activeRequests === 0) {
+      refreshSession(session);
+    }
+  };
+
+  const closeSession = (session: HttpSession): Promise<void> => {
+    if (session.closePromise !== undefined) {
+      return session.closePromise;
+    }
+
+    removeSession(session);
+    const sessionClosePromise = Promise.resolve().then(async () => {
+      await session.server.close();
+    });
+    session.closePromise = sessionClosePromise;
+    return sessionClosePromise;
+  };
+
+  const createSession = async (): Promise<HttpSession> => {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: randomUUID,
+      onsessioninitialized: sessionId => {
+        if (session === undefined || session.closePromise !== undefined) {
+          return;
+        }
+        session.sessionId = sessionId;
+        pendingSessions.delete(session);
+        sessions.set(sessionId, session);
+        refreshSession(session);
+      },
+      onsessionclosed: async sessionId => {
+        const closedSession = sessions.get(sessionId);
+        if (closedSession !== undefined) {
+          await closeSession(closedSession);
+        }
+      },
+    });
+    const server = await McpServer.from(serverArgs, {
+      logFile: options.logFile,
+      getSessionId: () => transport.sessionId,
+    });
+    const session: HttpSession = {server, transport, activeRequests: 0};
+    pendingSessions.add(session);
+    transport.onclose = () => {
+      if (session !== undefined) {
+        void closeSession(session).catch(error => {
+          logger?.('Failed to close HTTP MCP session', error);
+        });
+      }
+    };
+
+    try {
+      await server.connect(transport);
+      return session;
+    } catch (error) {
+      await closeSession(session).catch(closeError => {
+        logger?.(
+          'Failed to close HTTP MCP session after connect error',
+          closeError,
+        );
+      });
+      throw error;
+    }
+  };
+  const createTrackedSession = async (): Promise<HttpSession> => {
+    if (pendingInitializations + pendingSessions.size >= maxPendingSessions) {
+      throw new HttpRequestError(
+        503,
+        'Too many MCP session initializations are in progress.',
+      );
+    }
+    if (
+      sessions.size + pendingSessions.size + pendingInitializations >=
+      maxSessions
+    ) {
+      throw new HttpRequestError(
+        503,
+        'The MCP session limit has been reached.',
+      );
+    }
+
+    pendingInitializations++;
+    const creation = createSession();
+    pendingInitializationPromises.add(creation);
+    try {
+      return await creation;
+    } finally {
+      pendingInitializationPromises.delete(creation);
+      pendingInitializations--;
+    }
+  };
+
+  const handleRequest = async (
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> => {
+    if (request.url !== MCP_PATH) {
+      sendJsonRpcError(response, 404, 'Not Found', -32000);
+      return;
+    }
+
+    if (!validateRequestSecurity(request, response)) {
+      return;
+    }
+
+    const method = request.method ?? '';
+    if (ALLOWED_METHODS[method] !== true) {
+      sendJsonRpcError(response, 405, 'Method not allowed.', -32000, {
+        Allow: 'GET, POST, DELETE',
+      });
+      return;
+    }
+
+    if (closing) {
+      sendJsonRpcError(response, 503, 'Server is shutting down.', -32000);
+      return;
+    }
+
+    const sessionId = getHeader(request, 'mcp-session-id');
+    let session: HttpSession | undefined;
+    let requestTracked = false;
+    let parsedBody: unknown = undefined;
+
+    const finishSessionRequest = (): void => {
+      if (!requestTracked || session === undefined) {
+        return;
+      }
+      requestTracked = false;
+      endSessionRequest(session);
+    };
+
+    if (sessionId !== undefined) {
+      session = sessions.get(sessionId);
+      if (session === undefined) {
+        sendJsonRpcError(response, 404, 'Session not found', -32001);
+        return;
+      }
+      beginSessionRequest(session);
+      requestTracked = true;
+    }
+
+    if (method === 'POST') {
+      try {
+        validatePostHeaders(request);
+        parsedBody = await readJsonBody(request);
+      } catch (error) {
+        finishSessionRequest();
+        request.resume();
+        if (error instanceof HttpRequestError) {
+          sendJsonRpcError(response, error.status, error.message);
+        } else {
+          sendJsonRpcError(
+            response,
+            400,
+            `Failed to read request body: ${errorMessage(error)}`,
+          );
+        }
+        return;
+      }
+    }
+
+    if (session === undefined) {
+      if (method !== 'POST') {
+        sendJsonRpcError(
+          response,
+          400,
+          'Bad Request: Mcp-Session-Id header is required',
+          -32000,
+        );
+        return;
+      }
+      if (countInitializeRequests(parsedBody) !== 1) {
+        sendJsonRpcError(
+          response,
+          400,
+          'A session-less POST must contain exactly one initialize request.',
+        );
+        return;
+      }
+
+      try {
+        session = await createTrackedSession();
+      } catch (error) {
+        if (error instanceof HttpRequestError) {
+          sendJsonRpcError(response, error.status, error.message);
+        } else {
+          sendJsonRpcError(
+            response,
+            500,
+            `Failed to create MCP session: ${errorMessage(error)}`,
+            -32603,
+          );
+        }
+        return;
+      }
+
+      if (closing) {
+        await closeSession(session).catch(closeError => {
+          logger?.(
+            'Failed to close HTTP MCP session during shutdown',
+            closeError,
+          );
+        });
+        sendJsonRpcError(response, 503, 'Server is shutting down.', -32000);
+        return;
+      }
+
+      beginSessionRequest(session);
+      requestTracked = true;
+    }
+
+    try {
+      if (method === 'POST') {
+        await session.transport.handleRequest(request, response, parsedBody);
+        if (session.sessionId === undefined) {
+          await closeSession(session);
+        }
+      } else {
+        await session.transport.handleRequest(request, response);
+      }
+    } catch (error) {
+      await closeSession(session).catch(closeError => {
+        logger?.(
+          'Failed to close HTTP MCP session after request error',
+          closeError,
+        );
+      });
+      if (!response.headersSent) {
+        sendJsonRpcError(
+          response,
+          500,
+          `MCP request failed: ${errorMessage(error)}`,
+          -32603,
+        );
+      } else if (!response.writableEnded) {
+        response.end();
+      }
+    } finally {
+      finishSessionRequest();
+    }
+  };
+
+  nodeServer.on('request', (request, response) => {
+    void handleRequest(request, response).catch(error => {
+      logger?.('Unhandled HTTP MCP request error', error);
+      if (!response.headersSent) {
+        sendJsonRpcError(response, 500, 'Internal server error', -32603);
+      } else if (!response.writableEnded) {
+        response.end();
+      }
+    });
+  });
+
+  try {
+    const {promise, resolve, reject} = Promise.withResolvers<void>();
+    const onError = (error: Error): void => {
+      nodeServer.off('error', onError);
+      reject(error);
+    };
+    nodeServer.once('error', onError);
+    nodeServer.listen(options.port, '127.0.0.1', () => {
+      nodeServer.off('error', onError);
+      resolve();
+    });
+    await promise;
+  } catch (error) {
+    nodeServer.closeAllConnections();
+    throw error;
+  }
+
+  const address = nodeServer.address();
+  if (address === null || typeof address === 'string') {
+    await closeNodeServer(nodeServer).catch(closeError => {
+      logger?.('Failed to close HTTP server after bind error', closeError);
+    });
+    throw new Error('HTTP server did not provide a bound address');
+  }
+
+  const url = new URL(`http://127.0.0.1:${address.port}${MCP_PATH}`);
+
+  const close = async (): Promise<void> => {
+    if (closePromise !== undefined) {
+      return await closePromise;
+    }
+
+    closing = true;
+    closePromise = (async () => {
+      await Promise.allSettled([...pendingInitializationPromises]);
+      const allSessions = new Set<HttpSession>([
+        ...sessions.values(),
+        ...pendingSessions,
+      ]);
+      await Promise.allSettled(
+        [...allSessions].map(async session => {
+          await closeSession(session);
+        }),
+      );
+      await closeNodeServer(nodeServer);
+    })();
+
+    return await closePromise;
+  };
+
+  return {url, close};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ const ROOTS_REQUEST_TIMEOUT = 5_000;
 
 export interface McpServerOptions {
   logFile?: fs.WriteStream;
+  getSessionId?: () => string | undefined;
 }
 
 export class McpServer {
@@ -61,6 +62,7 @@ export class McpServer {
    */
   #lastClientRoots?: Root[];
   #toolMutex = new Mutex();
+  #closePromise?: Promise<void>;
 
   private constructor(
     serverArgs: ParsedArguments,
@@ -69,7 +71,7 @@ export class McpServer {
     this.#serverArgs = serverArgs;
     this.#options = options;
 
-    if (this.#serverArgs.usageStatistics) {
+    if (this.#serverArgs.usageStatistics && !ClearcutLogger.get()) {
       ClearcutLogger.initialize({
         persistence: new FilePersistence(),
         logFile: this.#serverArgs.logFile,
@@ -129,9 +131,47 @@ export class McpServer {
    * Closes the MCP connection and disposes internal context/listeners.
    */
   async close(): Promise<void> {
-    this.#context?.dispose();
+    if (this.#closePromise !== undefined) {
+      return await this.#closePromise;
+    }
+
+    const context = this.#context;
     this.#context = undefined;
-    await this.server.close();
+    const closePromise = (async (): Promise<void> => {
+      let serverCloseError: unknown;
+      let serverCloseFailed = false;
+      try {
+        await this.server.close();
+      } catch (error) {
+        serverCloseFailed = true;
+        serverCloseError = error;
+      }
+
+      const guard = await this.#toolMutex.acquire();
+      try {
+        // Acquiring and releasing the mutex drains any tool already in flight.
+      } finally {
+        guard[Symbol.dispose]();
+      }
+
+      let contextDisposeError: unknown;
+      let contextDisposeFailed = false;
+      try {
+        await context?.dispose();
+      } catch (error) {
+        contextDisposeFailed = true;
+        contextDisposeError = error;
+      }
+
+      if (serverCloseFailed) {
+        throw serverCloseError;
+      }
+      if (contextDisposeFailed) {
+        throw contextDisposeError;
+      }
+    })();
+    this.#closePromise = closePromise;
+    return await closePromise;
   }
 
   [Symbol.dispose](): void {
@@ -253,7 +293,9 @@ export class McpServer {
           });
 
     if (this.#context?.browser !== browser) {
-      this.#context?.dispose();
+      const previousContext = this.#context;
+      this.#context = undefined;
+      await previousContext?.dispose();
       this.#context = await McpContext.from(browser, logger, {
         experimentalDevToolsDebugging: devtools,
         experimentalIncludeAllPages:
@@ -264,14 +306,17 @@ export class McpServer {
         blocklist: blocklist,
         allowUnrestrictedPaths: this.#serverArgs.allowUnrestrictedPaths,
         // Surfaces a one-time note in the next response after a reconnect.
-        reconnected: this.#context !== undefined,
+        reconnected: previousContext !== undefined,
         categoryExtensions: this.#serverArgs.categoryExtensions,
         onNotification: (message: string) => {
           void this.server
-            .sendLoggingMessage({
-              level: 'info',
-              data: message,
-            })
+            .sendLoggingMessage(
+              {
+                level: 'info',
+                data: message,
+              },
+              this.#options.getSessionId?.(),
+            )
             .catch(e => {
               logger?.('Failed to send MCP notification', e);
             });
@@ -297,6 +342,7 @@ export class McpServer {
       this.#serverArgs,
       () => this.#getContext(),
       this.#toolMutex,
+      () => this.server.server.getClientVersion()?.name,
     );
 
     if (!toolHandler.shouldRegister) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,262 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import process from 'node:process';
+
+import {
+  isJSONRPCNotification,
+  isJSONRPCRequest,
+  isJSONRPCResultResponse,
+  StdioServerTransport,
+  StreamableHTTPClientTransport,
+  type JSONRPCMessage,
+  type RequestId,
+} from './third_party/index.js';
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function getProtocolVersion(message: JSONRPCMessage): string | undefined {
+  if (!isJSONRPCResultResponse(message)) {
+    return undefined;
+  }
+
+  const result: unknown = message.result;
+  if (
+    result === null ||
+    typeof result !== 'object' ||
+    !('protocolVersion' in result)
+  ) {
+    return undefined;
+  }
+
+  const protocolVersion = result.protocolVersion;
+  return typeof protocolVersion === 'string' ? protocolVersion : undefined;
+}
+const INITIALIZATION_CLOSE_WAIT_MS = 1_000;
+
+/**
+ * Runs a transparent JSON-RPC bridge from process stdio to a Streamable HTTP
+ * MCP endpoint. The two transports remain deliberately unwrapped: request
+ * IDs, capabilities, roots traffic, notifications, tool results and errors
+ * all pass through unchanged.
+ */
+export async function runStdioProxy(serverUrl: URL): Promise<void> {
+  const stdioTransport = new StdioServerTransport();
+  let initializedNotificationComplete = false;
+  const httpTransport = new StreamableHTTPClientTransport(serverUrl);
+  const initializeRequestIds = new Set<RequestId>();
+  let initializationComplete = false;
+  let initializeSendPending = false;
+  let remoteSendChain = Promise.resolve();
+
+  let closing = false;
+  let closePromise: Promise<void> | undefined;
+  let doneSettled = false;
+  const doneResolvers = Promise.withResolvers<void>();
+  const done = doneResolvers.promise;
+
+  const stdin = process.stdin;
+  function onStdinEnd(): void {
+    void closeBridge(undefined, true);
+  }
+  function onStdinClose(): void {
+    void closeBridge(undefined, true);
+  }
+
+  function closeBridge(
+    error: Error | undefined,
+    terminateSession: boolean,
+  ): Promise<void> {
+    if (closePromise !== undefined) {
+      return closePromise;
+    }
+
+    closing = true;
+    closePromise = (async () => {
+      const cleanupErrors: Error[] = [];
+      if (terminateSession && initializeSendPending) {
+        const initializeWait = Promise.withResolvers<void>();
+        const initializeTimeout = setTimeout(
+          initializeWait.resolve,
+          INITIALIZATION_CLOSE_WAIT_MS,
+        );
+        try {
+          await Promise.race([remoteSendChain, initializeWait.promise]);
+        } finally {
+          clearTimeout(initializeTimeout);
+        }
+      }
+
+      if (terminateSession) {
+        try {
+          await httpTransport.terminateSession();
+        } catch (cleanupError) {
+          cleanupErrors.push(toError(cleanupError));
+        }
+      }
+
+      try {
+        await httpTransport.close();
+      } catch (cleanupError) {
+        cleanupErrors.push(toError(cleanupError));
+      }
+
+      try {
+        await stdioTransport.close();
+      } catch (cleanupError) {
+        cleanupErrors.push(toError(cleanupError));
+      }
+
+      stdin.off('end', onStdinEnd);
+      stdin.off('close', onStdinClose);
+
+      for (const cleanupError of cleanupErrors) {
+        console.error(`MCP stdio proxy cleanup error: ${cleanupError.message}`);
+      }
+
+      if (doneSettled) {
+        return;
+      }
+      doneSettled = true;
+      if (error === undefined) {
+        doneResolvers.resolve();
+      } else {
+        doneResolvers.reject(error);
+      }
+    })();
+
+    return closePromise;
+  }
+
+  const fail = (side: string, error: unknown): void => {
+    if (closing) {
+      return;
+    }
+
+    const normalizedError = toError(error);
+    console.error(`MCP stdio proxy ${side} error: ${normalizedError.message}`);
+    void closeBridge(normalizedError, true);
+  };
+
+  let localSendChain = Promise.resolve();
+  const sendToStdio = (message: JSONRPCMessage): void => {
+    if (closing) {
+      return;
+    }
+
+    const nextSend = localSendChain.then(async () => {
+      if (!closing) {
+        await stdioTransport.send(message);
+      }
+    });
+    localSendChain = nextSend.catch(error => {
+      fail('stdio', error);
+    });
+  };
+
+  const sendToHTTP = (message: JSONRPCMessage): void => {
+    const isInitializeRequest =
+      isJSONRPCRequest(message) && message.method === 'initialize';
+    const isInitializedNotification =
+      isJSONRPCNotification(message) &&
+      message.method === 'notifications/initialized';
+    if (closing && !isInitializeRequest) {
+      return;
+    }
+    if (isInitializeRequest) {
+      initializeSendPending = true;
+    }
+
+    const nextSend = remoteSendChain.then(() => {
+      if (closing && !isInitializeRequest) {
+        return;
+      }
+
+      const sendPromise = httpTransport.send(message);
+      if (isInitializeRequest) {
+        return sendPromise.then(
+          () => {
+            initializeSendPending = false;
+          },
+          error => {
+            initializeSendPending = false;
+            throw error;
+          },
+        );
+      }
+      if (isInitializedNotification) {
+        return sendPromise.then(() => {
+          if (initializationComplete) {
+            initializedNotificationComplete = true;
+          }
+        });
+      }
+      if (initializationComplete && initializedNotificationComplete) {
+        void sendPromise.catch(error => {
+          fail('HTTP', error);
+        });
+        return;
+      }
+      return sendPromise;
+    });
+    remoteSendChain = nextSend.catch(error => {
+      fail('HTTP', error);
+    });
+  };
+
+  stdioTransport.onmessage = message => {
+    if (isJSONRPCRequest(message) && message.method === 'initialize') {
+      initializeRequestIds.add(message.id);
+    }
+    sendToHTTP(message);
+  };
+  stdioTransport.onerror = error => {
+    fail('stdio', error);
+  };
+  stdioTransport.onclose = () => {
+    if (!closing) {
+      void closeBridge(undefined, true);
+    }
+  };
+
+  httpTransport.onmessage = message => {
+    if (
+      isJSONRPCResultResponse(message) &&
+      initializeRequestIds.delete(message.id)
+    ) {
+      const protocolVersion = getProtocolVersion(message);
+      if (protocolVersion !== undefined) {
+        httpTransport.setProtocolVersion(protocolVersion);
+        initializationComplete = true;
+      }
+    }
+    sendToStdio(message);
+  };
+  httpTransport.onerror = error => {
+    fail('HTTP', error);
+  };
+  httpTransport.onclose = () => {
+    if (!closing) {
+      void closeBridge(undefined, false);
+    }
+  };
+
+  stdin.once('end', onStdinEnd);
+  stdin.once('close', onStdinClose);
+
+  try {
+    await Promise.all([stdioTransport.start(), httpTransport.start()]);
+  } catch (error) {
+    const normalizedError = toError(error);
+    fail('startup', normalizedError);
+    await closeBridge(normalizedError, true);
+    await done;
+  }
+
+  await done;
+}

--- a/src/telemetry/ClearcutLogger.ts
+++ b/src/telemetry/ClearcutLogger.ts
@@ -83,6 +83,35 @@ export interface ClearcutLoggerOptions {
 
 // Not const to allow resetting the instance for testing purposes.
 let _clearcut_logger_instance: ClearcutLogger | undefined;
+let toolActiveLogQueue = Promise.resolve();
+
+function getMcpClient(clientName: string): McpClient {
+  const lowerName = clientName.toLowerCase();
+  if (lowerName.includes('claude-desktop')) {
+    return McpClient.MCP_CLIENT_CLAUDE_DESKTOP;
+  } else if (lowerName.includes('claude')) {
+    return McpClient.MCP_CLIENT_CLAUDE_CODE;
+  } else if (lowerName.includes('gemini')) {
+    return McpClient.MCP_CLIENT_GEMINI_CLI;
+  } else if (clientName === DAEMON_CLIENT_NAME) {
+    return McpClient.MCP_CLIENT_DT_MCP_CLI;
+  } else if (lowerName.includes('openclaw')) {
+    return McpClient.MCP_CLIENT_OPENCLAW;
+  } else if (lowerName.includes('opencode')) {
+    return McpClient.MCP_CLIENT_OPENCODE;
+  } else if (lowerName.includes('codex')) {
+    return McpClient.MCP_CLIENT_CODEX;
+  } else if (lowerName.includes('antigravity')) {
+    return McpClient.MCP_CLIENT_ANTIGRAVITY;
+  } else if (lowerName.includes('grok') || lowerName.includes('xai')) {
+    return McpClient.MCP_CLIENT_GROK;
+  } else if (lowerName.includes('copilot')) {
+    return McpClient.MCP_CLIENT_GITHUB_COPILOT;
+  } else if (lowerName.includes('hermes-agent')) {
+    return McpClient.MCP_CLIENT_HERMES;
+  }
+  return McpClient.MCP_CLIENT_OTHER;
+}
 
 export class ClearcutLogger {
   #persistence: Persistence;
@@ -104,6 +133,7 @@ export class ClearcutLogger {
 
   static resetForTesting(): void {
     _clearcut_logger_instance = undefined;
+    toolActiveLogQueue = Promise.resolve();
   }
 
   private constructor(options: ClearcutLoggerOptions) {
@@ -132,32 +162,7 @@ export class ClearcutLogger {
   }
 
   setClientName(clientName: string): void {
-    const lowerName = clientName.toLowerCase();
-    if (lowerName.includes('claude-desktop')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_CLAUDE_DESKTOP;
-    } else if (lowerName.includes('claude')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_CLAUDE_CODE;
-    } else if (lowerName.includes('gemini')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_GEMINI_CLI;
-    } else if (clientName === DAEMON_CLIENT_NAME) {
-      this.#mcpClient = McpClient.MCP_CLIENT_DT_MCP_CLI;
-    } else if (lowerName.includes('openclaw')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_OPENCLAW;
-    } else if (lowerName.includes('opencode')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_OPENCODE;
-    } else if (lowerName.includes('codex')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_CODEX;
-    } else if (lowerName.includes('antigravity')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_ANTIGRAVITY;
-    } else if (lowerName.includes('grok') || lowerName.includes('xai')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_GROK;
-    } else if (lowerName.includes('copilot')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_GITHUB_COPILOT;
-    } else if (lowerName.includes('hermes-agent')) {
-      this.#mcpClient = McpClient.MCP_CLIENT_HERMES;
-    } else {
-      this.#mcpClient = McpClient.MCP_CLIENT_OTHER;
-    }
+    this.#mcpClient = getMcpClient(clientName);
   }
 
   async logToolInvocation(args: {
@@ -168,8 +173,9 @@ export class ClearcutLogger {
     latencyMs: number;
     devToolsData?: DevToolsData;
     pageUrl?: string;
+    clientName?: string;
   }): Promise<void> {
-    void this.#logToolActiveIfNeeded().catch(error => {
+    void this.#logToolActiveIfNeeded(args.clientName).catch(error => {
       logger?.('Error in logToolActiveIfNeeded:', error);
     });
 
@@ -195,7 +201,10 @@ export class ClearcutLogger {
     this.#watchdog.send({
       type: WatchdogMessageType.LOG_EVENT,
       payload: {
-        mcp_client: this.#mcpClient,
+        mcp_client:
+          args.clientName === undefined
+            ? this.#mcpClient
+            : getMcpClient(args.clientName),
         tool_invocation: tool_invocation,
       },
     });
@@ -256,7 +265,18 @@ export class ClearcutLogger {
     });
   }
 
-  async #logToolActiveIfNeeded(): Promise<void> {
+  async #logToolActiveIfNeeded(clientName?: string): Promise<void> {
+    const queued = toolActiveLogQueue.then(async () => {
+      await this.#logToolActiveIfNeededLocked(clientName);
+    });
+    toolActiveLogQueue = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await queued;
+  }
+
+  async #logToolActiveIfNeededLocked(clientName?: string): Promise<void> {
     // Expect state loaded at first tool call, if not, just skip logging.
     if (!this.#state) {
       return;
@@ -283,7 +303,8 @@ export class ClearcutLogger {
     this.#watchdog.send({
       type: WatchdogMessageType.LOG_EVENT,
       payload: {
-        mcp_client: this.#mcpClient,
+        mcp_client:
+          clientName === undefined ? this.#mcpClient : getMcpClient(clientName),
         tool_active: {
           days_since_last_tool_call: bucketizeDaysSince(daysSinceToolCall),
         },

--- a/src/third_party/index.ts
+++ b/src/third_party/index.ts
@@ -21,10 +21,18 @@ export {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 export {type ShapeOutput} from '@modelcontextprotocol/sdk/server/zod-compat.js';
 export {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
 export {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+export {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+export {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 export {Client} from '@modelcontextprotocol/sdk/client/index.js';
 export type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
 export {
   type CallToolResult,
+  isInitializeRequest,
+  isJSONRPCNotification,
+  isJSONRPCRequest,
+  isJSONRPCResultResponse,
+  type JSONRPCMessage,
+  type RequestId,
   SetLevelRequestSchema,
   type ImageContent,
   type TextContent,
@@ -36,6 +44,7 @@ export {
 export {z as zod} from 'zod';
 export {default as ajv} from 'ajv';
 export {
+  Browser,
   Locator,
   PredefinedNetworkConditions,
   KnownDevices,

--- a/src/tools/ToolDefinition.ts
+++ b/src/tools/ToolDefinition.ts
@@ -229,6 +229,8 @@ export type Context = Readonly<{
   ): Promise<`${string}${Extension}`>;
   isRunningPerformanceTrace(): boolean;
   setIsRunningPerformanceTrace(x: boolean): void;
+  getPerformanceTracePage(): ContextPage | undefined;
+  setPerformanceTracePage(page: ContextPage | undefined): void;
   isCruxEnabled(): boolean;
   recordedTraces(): TraceResult[];
   storeTraceRecording(result: TraceResult): void;

--- a/src/tools/performance.ts
+++ b/src/tools/performance.ts
@@ -59,6 +59,7 @@ export const startTrace = definePageTool({
       return;
     }
     context.setIsRunningPerformanceTrace(true);
+    context.setPerformanceTracePage(request.page);
 
     const page = request.page;
     const pageUrlForTracing = page.pptrPage.url();
@@ -142,7 +143,7 @@ export const stopTrace = definePageTool({
     if (!context.isRunningPerformanceTrace()) {
       return;
     }
-    const page = request.page;
+    const page = context.getPerformanceTracePage() ?? request.page;
     await stopTracingAndAppendOutput(
       page,
       response,

--- a/tests/browser.test.ts
+++ b/tests/browser.test.ts
@@ -7,19 +7,65 @@
 import assert from 'node:assert';
 import os from 'node:os';
 import path from 'node:path';
-import {describe, it} from 'node:test';
+import {afterEach, describe, it} from 'node:test';
 
 import {executablePath} from 'puppeteer';
+import sinon from 'sinon';
 
 import {
+  closeBrowser,
   detectDisplay,
   ensureBrowserConnected,
+  ensureBrowserLaunched,
   launch,
   makeTargetFilter,
 } from '../src/browser.js';
-import type {Browser} from '../src/third_party/index.js';
+import {Browser, puppeteer} from '../src/third_party/index.js';
 
 import {serverHooks} from './server.js';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+  reject(reason?: unknown): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise = (_value: T | PromiseLike<T>): void => {
+    throw new Error('Deferred promise resolver was not initialized');
+  };
+  let rejectPromise = (_reason?: unknown): void => {
+    throw new Error('Deferred promise rejecter was not initialized');
+  };
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return {
+    promise,
+    resolve: value => resolvePromise(value),
+    reject: reason => rejectPromise(reason),
+  };
+}
+
+function createMockBrowser(): sinon.SinonStubbedInstance<Browser> {
+  const mockBrowser = sinon.createStubInstance(Browser);
+  Object.defineProperties(mockBrowser, {
+    connected: {
+      configurable: true,
+      value: true,
+    },
+    close: {
+      configurable: true,
+      value: sinon.stub().resolves(),
+    },
+    disconnect: {
+      configurable: true,
+      value: sinon.stub().resolves(),
+    },
+  });
+  return mockBrowser;
+}
 
 async function safeClose(browser: Browser) {
   try {
@@ -57,8 +103,148 @@ async function runWithRetry(fn: () => Promise<void>) {
 }
 
 describe('browser', () => {
+  afterEach(async () => {
+    await closeBrowser();
+    sinon.restore();
+  });
+
   it('detects display does not crash', () => {
     detectDisplay();
+  });
+
+  it('single-flights concurrent launches', async () => {
+    const deferred = createDeferred<Browser>();
+    const mockBrowser = createMockBrowser();
+    const launchStub = sinon.stub(puppeteer, 'launch');
+    launchStub.returns(deferred.promise);
+
+    const options = {
+      headless: true,
+      isolated: true,
+      devtools: false,
+    };
+    const first = ensureBrowserLaunched(options);
+    const second = ensureBrowserLaunched(options);
+
+    sinon.assert.calledOnce(launchStub);
+    deferred.resolve(mockBrowser);
+    const [firstBrowser, secondBrowser] = await Promise.all([first, second]);
+
+    assert.strictEqual(firstBrowser, mockBrowser);
+    assert.strictEqual(secondBrowser, mockBrowser);
+  });
+
+  it('single-flights concurrent browser connections', async () => {
+    const deferred = createDeferred<Browser>();
+    const mockBrowser = createMockBrowser();
+    const connectStub = sinon.stub(puppeteer, 'connect');
+    connectStub.returns(deferred.promise);
+
+    const options = {
+      browserURL: 'http://127.0.0.1:9222',
+      devtools: false,
+    };
+    const first = ensureBrowserConnected(options);
+    const second = ensureBrowserConnected(options);
+
+    sinon.assert.calledOnce(connectStub);
+    deferred.resolve(mockBrowser);
+    const [firstBrowser, secondBrowser] = await Promise.all([first, second]);
+
+    assert.strictEqual(firstBrowser, mockBrowser);
+    assert.strictEqual(secondBrowser, mockBrowser);
+  });
+
+  it('clears a failed launch acquisition before retrying', async () => {
+    const launchError = new Error('launch failed');
+    const mockBrowser = createMockBrowser();
+    const launchStub = sinon.stub(puppeteer, 'launch');
+    launchStub.onFirstCall().rejects(launchError);
+    launchStub.onSecondCall().resolves(mockBrowser);
+
+    const options = {
+      headless: true,
+      isolated: true,
+      devtools: false,
+    };
+    const first = ensureBrowserLaunched(options);
+    const second = ensureBrowserLaunched(options);
+
+    sinon.assert.calledOnce(launchStub);
+    await assert.rejects(first, /launch failed/);
+    await assert.rejects(second, /launch failed/);
+
+    const retry = await ensureBrowserLaunched(options);
+
+    assert.strictEqual(retry, mockBrowser);
+    sinon.assert.calledTwice(launchStub);
+  });
+
+  it('closes a launched browser acquired during shutdown', async () => {
+    const deferred = createDeferred<Browser>();
+    const mockBrowser = createMockBrowser();
+    const launchStub = sinon.stub(puppeteer, 'launch');
+    launchStub.returns(deferred.promise);
+
+    const acquisition = ensureBrowserLaunched({
+      headless: true,
+      isolated: true,
+      devtools: false,
+    });
+    const shutdown = closeBrowser();
+
+    deferred.resolve(mockBrowser);
+    const [acquiredBrowser] = await Promise.all([acquisition, shutdown]);
+
+    assert.strictEqual(acquiredBrowser, mockBrowser);
+    sinon.assert.calledOnce(mockBrowser.close);
+    sinon.assert.notCalled(mockBrowser.disconnect);
+    sinon.assert.calledOnce(launchStub);
+  });
+
+  it('rejects acquisition while a launched browser is shutting down', async () => {
+    const closeDeferred = createDeferred<void>();
+    const mockBrowser = createMockBrowser();
+    mockBrowser.close.returns(closeDeferred.promise);
+    const launchStub = sinon.stub(puppeteer, 'launch').resolves(mockBrowser);
+
+    const options = {
+      headless: true,
+      isolated: true,
+      devtools: false,
+    };
+    await ensureBrowserLaunched(options);
+    const shutdown = closeBrowser();
+    await Promise.resolve();
+
+    const secondAcquisition = ensureBrowserLaunched(options);
+    await assert.rejects(secondAcquisition, /Browser is shutting down/);
+    sinon.assert.calledOnce(launchStub);
+    sinon.assert.calledOnce(mockBrowser.close);
+
+    closeDeferred.resolve(undefined);
+    await shutdown;
+  });
+
+  it('disconnects an attached browser acquired during shutdown', async () => {
+    const deferred = createDeferred<Browser>();
+    const mockBrowser = createMockBrowser();
+    const connectStub = sinon.stub(puppeteer, 'connect');
+    connectStub.returns(deferred.promise);
+
+    const acquisition = ensureBrowserConnected({
+      browserURL: 'http://127.0.0.1:9222',
+      devtools: false,
+    });
+    const shutdown = closeBrowser();
+
+    deferred.resolve(mockBrowser);
+    const [acquiredBrowser] = await Promise.all([acquisition, shutdown]);
+
+    assert.strictEqual(acquiredBrowser, mockBrowser);
+    sinon.assert.notCalled(mockBrowser.close);
+    sinon.assert.calledOnce(mockBrowser.disconnect);
+    sinon.assert.calledOnce(connectStub);
   });
 
   it('cannot launch multiple times with the same profile', async () => {

--- a/tests/http-multi-client.test.ts
+++ b/tests/http-multi-client.test.ts
@@ -1,0 +1,418 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {randomUUID} from 'node:crypto';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {describe, it} from 'node:test';
+import {pathToFileURL} from 'node:url';
+
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  ListRootsRequestSchema,
+  type Root,
+} from '@modelcontextprotocol/sdk/types.js';
+import {executablePath} from 'puppeteer';
+
+import {closeBrowser} from '../src/browser.js';
+import {parseArguments} from '../src/config/mcp-options.js';
+import {startMcpHttpServer} from '../src/http-server.js';
+import {VERSION} from '../src/version.js';
+
+interface HttpClient {
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+}
+interface HttpService {
+  url: URL;
+  close(): Promise<void>;
+}
+
+interface ProxyClient {
+  client: Client;
+  transport: StdioClientTransport;
+}
+
+interface PageListing {
+  id: number;
+  selected: boolean;
+}
+
+const PAGE_A_TITLE = 'http-multi-client-a';
+const PAGE_B_TITLE = 'http-multi-client-b';
+
+function textFromToolResult(result: unknown): string {
+  if (
+    typeof result !== 'object' ||
+    result === null ||
+    !('content' in result) ||
+    !Array.isArray(result.content)
+  ) {
+    throw new Error('Expected a tool result with content');
+  }
+
+  const firstContent = result.content[0];
+  if (
+    typeof firstContent !== 'object' ||
+    firstContent === null ||
+    !('type' in firstContent) ||
+    firstContent.type !== 'text' ||
+    !('text' in firstContent) ||
+    typeof firstContent.text !== 'string'
+  ) {
+    throw new Error('Expected the first tool result content item to be text');
+  }
+  return firstContent.text;
+}
+
+function isToolError(result: unknown): boolean {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'isError' in result &&
+    result.isError === true
+  );
+}
+
+function pageListing(result: unknown, title: string): PageListing | undefined {
+  const line = textFromToolResult(result)
+    .split('\n')
+    .find(candidate => /^\d+:\s/.test(candidate) && candidate.includes(title));
+  if (line === undefined) {
+    return undefined;
+  }
+
+  const idText = line.match(/^(\d+):/)?.[1];
+  if (idText === undefined) {
+    throw new Error(`Could not parse page ID from page listing: ${line}`);
+  }
+
+  const id = Number(idText);
+  if (!Number.isSafeInteger(id)) {
+    throw new Error(`Invalid page ID in page listing: ${line}`);
+  }
+  return {id, selected: line.includes(' [selected]')};
+}
+
+function requiredPage(
+  pages: Map<string, PageListing>,
+  title: string,
+): PageListing {
+  const page = pages.get(title);
+  if (page === undefined) {
+    throw new Error(`Page ${title} was not found`);
+  }
+  return page;
+}
+
+async function waitForPages(
+  client: Client,
+  titles: readonly string[],
+): Promise<Map<string, PageListing>> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const result = await client.callTool({
+      name: 'list_pages',
+      arguments: {},
+    });
+    const pages = new Map<string, PageListing>();
+    for (const title of titles) {
+      const page = pageListing(result, title);
+      if (page !== undefined) {
+        pages.set(title, page);
+      }
+    }
+    if (pages.size === titles.length) {
+      return pages;
+    }
+    // Target-created events arrive asynchronously through the shared browser;
+    // the HTTP protocol exposes no event we can await for this propagation.
+    const {promise, resolve} = Promise.withResolvers<void>();
+    setTimeout(resolve, 50);
+    await promise;
+  }
+  throw new Error(`Timed out waiting for pages: ${titles.join(', ')}`);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function connectClient(
+  url: URL,
+  name: string,
+  roots: Root[],
+): Promise<HttpClient> {
+  const transport = new StreamableHTTPClientTransport(url);
+  const client = new Client(
+    {name, version: '1.0.0'},
+    {
+      capabilities: {
+        roots: {listChanged: true},
+      },
+    },
+  );
+  client.setRequestHandler(ListRootsRequestSchema, () => {
+    return {roots};
+  });
+  try {
+    await client.connect(transport);
+    return {client, transport};
+  } catch (error) {
+    try {
+      await transport.close();
+    } catch {
+      // Preserve the initialization error.
+    }
+    throw error;
+  }
+}
+
+async function connectProxyClient(url: URL): Promise<ProxyClient> {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [
+      path.resolve('build/src/bin/chrome-devtools-mcp.js'),
+      '--isolated',
+      '--headless',
+      '--chrome-arg=--password-store=basic',
+    ],
+    env: {
+      ...process.env,
+      CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS: 'true',
+      CHROME_DEVTOOLS_MCP_SERVER_URL: url.href,
+    },
+  });
+  const client = new Client(
+    {name: 'http-multi-client-proxy', version: '1.0.0'},
+    {
+      capabilities: {
+        roots: {listChanged: true},
+      },
+    },
+  );
+  client.setRequestHandler(ListRootsRequestSchema, () => {
+    return {roots: []};
+  });
+  try {
+    await client.connect(transport);
+    return {client, transport};
+  } catch (error) {
+    try {
+      await transport.close();
+    } catch {
+      // Preserve the initialization error.
+    }
+    throw error;
+  }
+}
+
+async function closeClient(connection: HttpClient | undefined): Promise<void> {
+  if (connection === undefined) {
+    return;
+  }
+  try {
+    await connection.transport.terminateSession();
+  } catch {
+    // The service may already be closed while the test is unwinding.
+  }
+  try {
+    await connection.client.close();
+  } catch {
+    // The service may already be closed while the test is unwinding.
+  }
+}
+
+async function closeProxyClient(
+  connection: ProxyClient | undefined,
+): Promise<void> {
+  if (connection === undefined) {
+    return;
+  }
+  try {
+    await connection.client.close();
+  } catch {
+    // The proxy may already be closed while the test is unwinding.
+  }
+}
+
+describe('shared-browser HTTP MCP service', () => {
+  it('keeps pages, selection, and roots independent across sessions', async () => {
+    const rootPath = await fs.mkdtemp(
+      path.join(os.homedir(), '.chrome-devtools-mcp-http-root-'),
+    );
+    let service: HttpService | undefined;
+    let clientA: HttpClient | undefined;
+    let clientB: HttpClient | undefined;
+    let proxyClient: ProxyClient | undefined;
+    const screenshotA = path.join(rootPath, 'a.png');
+    const screenshotB = path.join(rootPath, 'b.png');
+    const screenshotBAfterClose = path.join(
+      os.tmpdir(),
+      `http-multi-client-b-${randomUUID()}.png`,
+    );
+
+    try {
+      const serverArgs = parseArguments(
+        VERSION,
+        [
+          'node',
+          'test',
+          '--headless',
+          '--isolated',
+          '--executable-path',
+          await executablePath(),
+          '--no-usage-statistics',
+        ],
+        {},
+      );
+      service = await startMcpHttpServer(serverArgs, {port: 0});
+      const root: Root = {
+        uri: pathToFileURL(rootPath).href,
+        name: 'client-a-home-temp-root',
+      };
+      clientA = await connectClient(service.url, 'http-multi-client-a', [root]);
+      clientB = await connectClient(service.url, 'http-multi-client-b', []);
+
+      assert.ok(clientA.transport.sessionId);
+      assert.ok(clientB.transport.sessionId);
+      assert.notStrictEqual(
+        clientA.transport.sessionId,
+        clientB.transport.sessionId,
+      );
+
+      const createdA = await clientA.client.callTool({
+        name: 'new_page',
+        arguments: {
+          url: 'data:text/html,<title>http-multi-client-a</title>',
+        },
+      });
+      const createdAPage = pageListing(createdA, PAGE_A_TITLE);
+      assert.ok(createdAPage);
+      assert.strictEqual(createdAPage.selected, true);
+
+      await waitForPages(clientB.client, [PAGE_A_TITLE]);
+      const createdB = await clientB.client.callTool({
+        name: 'new_page',
+        arguments: {
+          url: 'data:text/html,<title>http-multi-client-b</title>',
+        },
+      });
+      const createdBPage = pageListing(createdB, PAGE_B_TITLE);
+      assert.ok(createdBPage);
+      assert.strictEqual(createdBPage.selected, true);
+
+      const pagesA = await waitForPages(clientA.client, [
+        PAGE_A_TITLE,
+        PAGE_B_TITLE,
+      ]);
+      const pagesB = await waitForPages(clientB.client, [
+        PAGE_A_TITLE,
+        PAGE_B_TITLE,
+      ]);
+      assert.notStrictEqual(
+        requiredPage(pagesA, PAGE_A_TITLE).id,
+        requiredPage(pagesA, PAGE_B_TITLE).id,
+      );
+      assert.notStrictEqual(
+        requiredPage(pagesB, PAGE_A_TITLE).id,
+        requiredPage(pagesB, PAGE_B_TITLE).id,
+      );
+
+      await clientA.client.callTool({
+        name: 'select_page',
+        arguments: {pageId: requiredPage(pagesA, PAGE_A_TITLE).id},
+      });
+      await clientB.client.callTool({
+        name: 'select_page',
+        arguments: {pageId: requiredPage(pagesB, PAGE_B_TITLE).id},
+      });
+
+      const selectedA = await waitForPages(clientA.client, [
+        PAGE_A_TITLE,
+        PAGE_B_TITLE,
+      ]);
+      const selectedB = await waitForPages(clientB.client, [
+        PAGE_A_TITLE,
+        PAGE_B_TITLE,
+      ]);
+      assert.strictEqual(requiredPage(selectedA, PAGE_A_TITLE).selected, true);
+      assert.strictEqual(requiredPage(selectedA, PAGE_B_TITLE).selected, false);
+      assert.strictEqual(requiredPage(selectedB, PAGE_A_TITLE).selected, false);
+      assert.strictEqual(requiredPage(selectedB, PAGE_B_TITLE).selected, true);
+
+      const screenshotResultA = await clientA.client.callTool({
+        name: 'take_screenshot',
+        arguments: {
+          pageId: requiredPage(selectedA, PAGE_A_TITLE).id,
+          filePath: screenshotA,
+        },
+      });
+      assert.strictEqual(isToolError(screenshotResultA), false);
+      assert.strictEqual(await fileExists(screenshotA), true);
+
+      const screenshotResultB = await clientB.client.callTool({
+        name: 'take_screenshot',
+        arguments: {
+          pageId: requiredPage(selectedB, PAGE_B_TITLE).id,
+          filePath: screenshotB,
+        },
+      });
+      assert.strictEqual(isToolError(screenshotResultB), true);
+      assert.match(textFromToolResult(screenshotResultB), /Access denied/);
+      assert.strictEqual(await fileExists(screenshotB), false);
+
+      proxyClient = await connectProxyClient(service.url);
+      const proxyPages = await proxyClient.client.callTool({
+        name: 'list_pages',
+        arguments: {},
+      });
+      assert.strictEqual(isToolError(proxyPages), false);
+      assert.match(textFromToolResult(proxyPages), /http-multi-client-a/);
+
+      await clientA.transport.terminateSession();
+      await clientA.client.close();
+      clientA = undefined;
+
+      const afterClosePages = await waitForPages(clientB.client, [
+        PAGE_A_TITLE,
+        PAGE_B_TITLE,
+      ]);
+      assert.strictEqual(
+        requiredPage(afterClosePages, PAGE_B_TITLE).selected,
+        true,
+      );
+      const screenshotAfterClose = await clientB.client.callTool({
+        name: 'take_screenshot',
+        arguments: {
+          pageId: requiredPage(afterClosePages, PAGE_B_TITLE).id,
+          filePath: screenshotBAfterClose,
+        },
+      });
+      assert.strictEqual(isToolError(screenshotAfterClose), false);
+      assert.strictEqual(await fileExists(screenshotBAfterClose), true);
+    } finally {
+      await closeClient(clientA);
+      await closeClient(clientB);
+      await closeProxyClient(proxyClient);
+      if (service !== undefined) {
+        await service.close();
+      }
+      await closeBrowser();
+      await fs.rm(rootPath, {recursive: true, force: true});
+      await fs.rm(screenshotBAfterClose, {force: true});
+    }
+  });
+});

--- a/tests/http-server.test.ts
+++ b/tests/http-server.test.ts
@@ -1,0 +1,287 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert/strict';
+import {request as httpRequest} from 'node:http';
+import {describe, it} from 'node:test';
+
+import {parser} from '../src/config/mcp-options.js';
+import {startMcpHttpServer} from '../src/http-server.js';
+
+const ACCEPT_HEADER = 'application/json, text/event-stream';
+const PROTOCOL_VERSION = '2025-03-26';
+
+const serverArgs = parser(
+  '0.0.0',
+  ['node', 'http-server.test.js', '--no-usage-statistics'],
+  {},
+).parseSync();
+
+const initializeMessage = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {},
+    clientInfo: {
+      name: 'http-server-test',
+      version: '1.0.0',
+    },
+  },
+};
+
+function sessionId(response: Response): string {
+  const value = response.headers.get('mcp-session-id');
+  if (value === null) {
+    throw new Error('Expected an MCP session ID');
+  }
+  return value;
+}
+
+async function post(
+  url: URL,
+  message: object,
+  session?: string,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    Accept: ACCEPT_HEADER,
+    'Content-Type': 'application/json',
+  };
+  if (session !== undefined) {
+    headers['Mcp-Session-Id'] = session;
+    headers['Mcp-Protocol-Version'] = PROTOCOL_VERSION;
+  }
+  return await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(message),
+  });
+}
+
+async function initialize(url: URL): Promise<string> {
+  const response = await post(url, initializeMessage);
+  assert.equal(response.status, 200);
+  await response.text();
+  return sessionId(response);
+}
+function statusWithHost(url: URL, host: string): Promise<number> {
+  const {promise, resolve, reject} = Promise.withResolvers<number>();
+  const request = httpRequest(url, {headers: {Host: host}}, response => {
+    response.resume();
+    response.once('end', () => {
+      resolve(response.statusCode ?? 0);
+    });
+  });
+  request.once('error', reject);
+  request.end();
+  return promise;
+}
+
+describe('Streamable HTTP MCP server', () => {
+  it('rejects invalid routes, methods, hosts, and origins before protocol handling', async () => {
+    const service = await startMcpHttpServer(serverArgs, {port: 0});
+    try {
+      const wrongRoute = await fetch(`${service.url.origin}/not-mcp`);
+      assert.equal(wrongRoute.status, 404);
+
+      const queryRoute = await fetch(`${service.url.href}?query=true`);
+      assert.equal(queryRoute.status, 404);
+
+      const methodResponse = await fetch(service.url, {method: 'PUT'});
+      assert.equal(methodResponse.status, 405);
+      assert.equal(methodResponse.headers.get('allow'), 'GET, POST, DELETE');
+
+      assert.equal(await statusWithHost(service.url, 'attacker.example'), 403);
+
+      const originResponse = await fetch(service.url, {
+        headers: {Origin: 'https://attacker.example'},
+      });
+      assert.equal(originResponse.status, 403);
+    } finally {
+      await service.close();
+    }
+  });
+  it('admits only valid initialize requests and enforces request limits', async () => {
+    const service = await startMcpHttpServer(serverArgs, {
+      port: 0,
+      maxSessions: 1,
+    });
+    try {
+      const jsonBody = JSON.stringify(initializeMessage);
+      const missingAccept = await fetch(service.url, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: jsonBody,
+      });
+      assert.equal(missingAccept.status, 406);
+      await missingAccept.text();
+
+      const missingContentType = await fetch(service.url, {
+        method: 'POST',
+        headers: {Accept: ACCEPT_HEADER},
+        body: jsonBody,
+      });
+      assert.equal(missingContentType.status, 415);
+      await missingContentType.text();
+
+      const malformed = await fetch(service.url, {
+        method: 'POST',
+        headers: {
+          Accept: ACCEPT_HEADER,
+          'Content-Type': 'application/json',
+        },
+        body: '{',
+      });
+      assert.equal(malformed.status, 400);
+      await malformed.text();
+
+      const noInitialize = await fetch(service.url, {
+        method: 'POST',
+        headers: {
+          Accept: ACCEPT_HEADER,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({jsonrpc: '2.0', id: 1, method: 'ping'}),
+      });
+      assert.equal(noInitialize.status, 400);
+      await noInitialize.text();
+
+      const oversized = await fetch(service.url, {
+        method: 'POST',
+        headers: {
+          Accept: ACCEPT_HEADER,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {padding: 'x'.repeat(4 * 1024 * 1024)},
+        }),
+      });
+      assert.equal(oversized.status, 413);
+      await oversized.text();
+
+      const firstSession = await initialize(service.url);
+      const overLimit = await post(service.url, initializeMessage);
+      assert.equal(overLimit.status, 503);
+      await overLimit.text();
+
+      const ping = await post(
+        service.url,
+        {jsonrpc: '2.0', id: 2, method: 'ping'},
+        firstSession,
+      );
+      assert.equal(ping.status, 200);
+      await ping.text();
+    } finally {
+      await service.close();
+    }
+  });
+
+  it('expires idle sessions without retaining their transport', async () => {
+    const service = await startMcpHttpServer(serverArgs, {
+      port: 0,
+      sessionIdleTimeoutMs: 20,
+    });
+    try {
+      const session = await initialize(service.url);
+      const {promise, resolve} = Promise.withResolvers<void>();
+      setTimeout(resolve, 50);
+      await promise;
+      const expired = await post(
+        service.url,
+        {jsonrpc: '2.0', id: 2, method: 'ping'},
+        session,
+      );
+      assert.equal(expired.status, 404);
+      await expired.text();
+    } finally {
+      await service.close();
+    }
+  });
+
+  it('routes independent sessions and only closes the requested session', async () => {
+    const service = await startMcpHttpServer(serverArgs, {port: 0});
+    try {
+      const firstSession = await initialize(service.url);
+      const secondSession = await initialize(service.url);
+      assert.notEqual(firstSession, secondSession);
+
+      const missingSession = await fetch(service.url, {
+        headers: {Accept: ACCEPT_HEADER},
+      });
+      assert.equal(missingSession.status, 400);
+
+      const firstPing = await post(
+        service.url,
+        {jsonrpc: '2.0', id: 2, method: 'ping'},
+        firstSession,
+      );
+      assert.equal(firstPing.status, 200);
+      await firstPing.text();
+      const malformedEstablished = await fetch(service.url, {
+        method: 'POST',
+        headers: {
+          Accept: ACCEPT_HEADER,
+          'Content-Type': 'application/json',
+          'Mcp-Session-Id': firstSession,
+          'Mcp-Protocol-Version': PROTOCOL_VERSION,
+        },
+        body: '{',
+      });
+      assert.equal(malformedEstablished.status, 400);
+      await malformedEstablished.text();
+
+      const rejectedDelete = await fetch(service.url, {
+        method: 'DELETE',
+        headers: {
+          Accept: ACCEPT_HEADER,
+          'Mcp-Session-Id': firstSession,
+          'Mcp-Protocol-Version': 'unsupported-version',
+        },
+      });
+      assert.equal(rejectedDelete.status, 400);
+      await rejectedDelete.text();
+
+      const pingAfterRejectedDelete = await post(
+        service.url,
+        {jsonrpc: '2.0', id: 5, method: 'ping'},
+        firstSession,
+      );
+      assert.equal(pingAfterRejectedDelete.status, 200);
+      await pingAfterRejectedDelete.text();
+
+      const deleteFirst = await fetch(service.url, {
+        method: 'DELETE',
+        headers: {
+          Accept: ACCEPT_HEADER,
+          'Mcp-Session-Id': firstSession,
+          'Mcp-Protocol-Version': PROTOCOL_VERSION,
+        },
+      });
+      assert.equal(deleteFirst.status, 200);
+
+      const closedFirst = await post(
+        service.url,
+        {jsonrpc: '2.0', id: 3, method: 'ping'},
+        firstSession,
+      );
+      assert.equal(closedFirst.status, 404);
+
+      const secondPing = await post(
+        service.url,
+        {jsonrpc: '2.0', id: 4, method: 'ping'},
+        secondSession,
+      );
+      assert.equal(secondPing.status, 200);
+      await secondPing.text();
+    } finally {
+      await service.close();
+    }
+  });
+});

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,0 +1,496 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert/strict';
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import {describe, it} from 'node:test';
+
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import {
+  isJSONRPCNotification,
+  isJSONRPCRequest,
+  JSONRPCMessageSchema,
+  type JSONRPCMessage,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const SESSION_ID = 'proxy-test-session';
+const PROTOCOL_VERSION = '2025-06-18';
+const DELETE_WAIT_TIMEOUT_MS = 5_000;
+
+interface MockEndpoint {
+  readonly url: URL;
+  readonly messages: JSONRPCMessage[];
+  readonly protocolVersions: Array<string | undefined>;
+  readonly deletedSessionIds: string[];
+  waitForDelete(): Promise<void>;
+  waitForInitialize(): Promise<void>;
+  releaseInitialize(): void;
+  waitForInitializedNotification(): Promise<void>;
+  releaseInitializedNotification(): void;
+  releaseHeldToolCall(): void;
+  close(): Promise<void>;
+}
+
+function readBody(request: IncomingMessage): Promise<string> {
+  const bodyPromise = Promise.withResolvers<string>();
+  let body = '';
+  request.setEncoding('utf8');
+  request.on('data', chunk => {
+    body += chunk;
+  });
+  request.on('end', () => bodyPromise.resolve(body));
+  request.on('error', bodyPromise.reject);
+  return bodyPromise.promise;
+}
+
+function writeJson(
+  response: ServerResponse,
+  statusCode: number,
+  value: unknown,
+  headers: Record<string, string> = {},
+): void {
+  response.statusCode = statusCode;
+  response.setHeader('content-type', 'application/json');
+  for (const [name, valueToSet] of Object.entries(headers)) {
+    response.setHeader(name, valueToSet);
+  }
+  response.end(JSON.stringify(value));
+}
+
+async function createMockEndpoint(
+  options: {
+    rejectPosts?: boolean;
+    holdFirstToolCall?: boolean;
+    holdInitialize?: boolean;
+    holdInitializedNotification?: boolean;
+  } = {},
+): Promise<MockEndpoint> {
+  const messages: JSONRPCMessage[] = [];
+  const protocolVersions: Array<string | undefined> = [];
+  const deletedSessionIds: string[] = [];
+  const deleteWaiters: Array<() => void> = [];
+  let toolCallCount = 0;
+  const firstToolCallRelease = Promise.withResolvers<void>();
+  const initializeReceived = Promise.withResolvers<void>();
+  const initializeRelease = Promise.withResolvers<void>();
+  const initializedNotificationReceived = Promise.withResolvers<void>();
+  const initializedNotificationRelease = Promise.withResolvers<void>();
+
+  const server = createServer((request, response) => {
+    void handleRequest(request, response).catch(error => {
+      writeJson(response, 500, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  });
+
+  async function handleRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    if (request.url !== '/mcp') {
+      writeJson(response, 404, {error: 'not found'});
+      return;
+    }
+
+    if (request.method === 'DELETE') {
+      const sessionId = request.headers['mcp-session-id'];
+      if (typeof sessionId === 'string') {
+        deletedSessionIds.push(sessionId);
+      }
+      response.statusCode = 200;
+      response.end();
+      for (const resolve of deleteWaiters.splice(0)) {
+        resolve();
+      }
+      return;
+    }
+
+    if (request.method !== 'POST') {
+      response.statusCode = 405;
+      response.end();
+      return;
+    }
+
+    protocolVersions.push(
+      typeof request.headers['mcp-protocol-version'] === 'string'
+        ? request.headers['mcp-protocol-version']
+        : undefined,
+    );
+
+    if (options.rejectPosts) {
+      writeJson(response, 503, {error: 'unavailable'});
+      return;
+    }
+
+    const message = JSONRPCMessageSchema.parse(
+      JSON.parse(await readBody(request)),
+    );
+    messages.push(message);
+    if (isJSONRPCRequest(message) && message.method === 'initialize') {
+      initializeReceived.resolve();
+      if (options.holdInitialize) {
+        await initializeRelease.promise;
+      }
+    }
+
+    const sessionId = request.headers['mcp-session-id'];
+    if (isJSONRPCRequest(message) && message.method !== 'initialize') {
+      if (sessionId !== SESSION_ID) {
+        writeJson(response, 400, {error: 'missing session'});
+        return;
+      }
+    }
+
+    if (
+      isJSONRPCNotification(message) &&
+      message.method === 'notifications/initialized'
+    ) {
+      initializedNotificationReceived.resolve();
+      if (options.holdInitializedNotification) {
+        await initializedNotificationRelease.promise;
+      }
+    }
+    if (!isJSONRPCRequest(message)) {
+      response.statusCode = 202;
+      response.end();
+      return;
+    }
+
+    if (message.method === 'initialize') {
+      writeJson(
+        response,
+        200,
+        {
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            protocolVersion: PROTOCOL_VERSION,
+            capabilities: {tools: {}},
+            serverInfo: {name: 'proxy-test-server', version: '1.0.0'},
+          },
+        },
+        {'mcp-session-id': SESSION_ID},
+      );
+      return;
+    }
+
+    if (message.method === 'tools/list') {
+      writeJson(response, 200, {
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          tools: [
+            {
+              name: 'echo',
+              description: 'Returns the supplied value.',
+              inputSchema: {
+                type: 'object',
+                properties: {value: {type: 'string'}},
+                required: ['value'],
+              },
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    if (message.method === 'tools/call') {
+      toolCallCount++;
+      if (options.holdFirstToolCall && toolCallCount === 1) {
+        await firstToolCallRelease.promise;
+      } else if (options.holdFirstToolCall && toolCallCount === 2) {
+        firstToolCallRelease.resolve();
+      }
+
+      writeJson(response, 200, {
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          content: [{type: 'text', text: 'echoed'}],
+        },
+      });
+      return;
+    }
+
+    writeJson(response, 200, {
+      jsonrpc: '2.0',
+      id: message.id,
+      error: {code: -32601, message: 'Method not found'},
+    });
+  }
+
+  const serverReady = Promise.withResolvers<void>();
+  server.once('error', serverReady.reject);
+  server.listen(0, '127.0.0.1', () => serverReady.resolve());
+  await serverReady.promise;
+
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    const serverClosed = Promise.withResolvers<void>();
+    server.close(() => serverClosed.resolve());
+    await serverClosed.promise;
+    throw new Error('Mock endpoint did not receive a TCP address');
+  }
+
+  return {
+    url: new URL(`http://127.0.0.1:${address.port}/mcp`),
+    messages,
+    protocolVersions,
+    deletedSessionIds,
+    waitForDelete(): Promise<void> {
+      if (deletedSessionIds.length > 0) {
+        return Promise.resolve();
+      }
+      const deleteWaiter = Promise.withResolvers<void>();
+      const deleteTimeout = setTimeout(
+        () =>
+          deleteWaiter.reject(
+            new Error('Timed out waiting for HTTP session DELETE'),
+          ),
+        DELETE_WAIT_TIMEOUT_MS,
+      );
+      deleteWaiters.push(() => {
+        clearTimeout(deleteTimeout);
+        deleteWaiter.resolve();
+      });
+      return deleteWaiter.promise;
+    },
+    waitForInitialize(): Promise<void> {
+      return initializeReceived.promise;
+    },
+    releaseInitialize(): void {
+      initializeRelease.resolve();
+    },
+    waitForInitializedNotification(): Promise<void> {
+      return initializedNotificationReceived.promise;
+    },
+    releaseInitializedNotification(): void {
+      initializedNotificationRelease.resolve();
+    },
+    releaseHeldToolCall(): void {
+      firstToolCallRelease.resolve();
+    },
+    close(): Promise<void> {
+      firstToolCallRelease.resolve();
+      initializeRelease.resolve();
+      initializedNotificationRelease.resolve();
+      const serverClosed = Promise.withResolvers<void>();
+      server.close(error => {
+        if (error === undefined) {
+          serverClosed.resolve();
+        } else {
+          serverClosed.reject(error);
+        }
+      });
+      return serverClosed.promise;
+    },
+  };
+}
+
+function createProxyTransport(serverUrl: URL): StdioClientTransport {
+  const proxyModule = pathToFileURL(
+    fileURLToPath(new URL('../src/proxy.js', import.meta.url)),
+  ).href;
+  const script = [
+    `import {runStdioProxy} from ${JSON.stringify(proxyModule)};`,
+    `await runStdioProxy(new URL(${JSON.stringify(serverUrl.href)}));`,
+  ].join('\n');
+  return new StdioClientTransport({
+    command: process.execPath,
+    args: ['--input-type=module', '--eval', script],
+    cwd: process.cwd(),
+    stderr: 'pipe',
+  });
+}
+
+describe('stdio proxy', () => {
+  it('forwards MCP initialization and tool calls, then terminates its HTTP session', async () => {
+    const endpoint = await createMockEndpoint();
+    const transport = createProxyTransport(endpoint.url);
+    const client = new Client(
+      {name: 'proxy-test-client', version: '1.0.0'},
+      {capabilities: {roots: {listChanged: true}}},
+    );
+
+    try {
+      await client.connect(transport);
+      const tools = await client.listTools();
+      const result = await client.callTool({
+        name: 'echo',
+        arguments: {value: 'value'},
+      });
+
+      assert.deepEqual(
+        tools.tools.map(tool => tool.name),
+        ['echo'],
+      );
+      assert.deepEqual(result.content, [{type: 'text', text: 'echoed'}]);
+      assert.equal(endpoint.protocolVersions[0], undefined);
+      assert.ok(endpoint.protocolVersions.length > 1);
+      for (const protocolVersion of endpoint.protocolVersions.slice(1)) {
+        assert.equal(protocolVersion, PROTOCOL_VERSION);
+      }
+      assert.deepEqual(endpoint.deletedSessionIds, []);
+      assert.ok(
+        endpoint.messages.some(
+          message =>
+            isJSONRPCRequest(message) && message.method === 'initialize',
+        ),
+      );
+      assert.ok(
+        endpoint.messages.some(
+          message =>
+            isJSONRPCNotification(message) &&
+            message.method === 'notifications/initialized',
+        ),
+      );
+    } finally {
+      await client.close();
+      await endpoint.waitForDelete();
+      assert.deepEqual(endpoint.deletedSessionIds, [SESSION_ID]);
+      await endpoint.close();
+    }
+  });
+
+  it('sends post-initialize requests concurrently when an earlier call is pending', async () => {
+    const endpoint = await createMockEndpoint({holdFirstToolCall: true});
+    const transport = createProxyTransport(endpoint.url);
+    const client = new Client({name: 'proxy-test-client', version: '1.0.0'});
+
+    try {
+      await client.connect(transport);
+      const calls = await Promise.all([
+        client.callTool(
+          {name: 'echo', arguments: {value: 'first'}},
+          undefined,
+          {timeout: 2_000},
+        ),
+        client.callTool(
+          {name: 'echo', arguments: {value: 'second'}},
+          undefined,
+          {timeout: 2_000},
+        ),
+      ]);
+
+      assert.deepEqual(
+        calls.map(call => call.content),
+        [[{type: 'text', text: 'echoed'}], [{type: 'text', text: 'echoed'}]],
+      );
+      assert.equal(
+        endpoint.messages.filter(
+          message =>
+            isJSONRPCRequest(message) && message.method === 'tools/call',
+        ).length,
+        2,
+      );
+    } finally {
+      endpoint.releaseHeldToolCall();
+      await client.close();
+      await endpoint.waitForDelete();
+      await endpoint.close();
+    }
+  });
+
+  it('waits for the initialized notification before forwarding requests', async () => {
+    const endpoint = await createMockEndpoint({
+      holdInitializedNotification: true,
+    });
+    const transport = createProxyTransport(endpoint.url);
+    const client = new Client({name: 'proxy-test-client', version: '1.0.0'});
+
+    try {
+      await client.connect(transport);
+      const toolsPromise = client.listTools();
+      await endpoint.waitForInitializedNotification();
+      assert.equal(
+        endpoint.messages.filter(
+          message =>
+            isJSONRPCRequest(message) && message.method === 'tools/list',
+        ).length,
+        0,
+      );
+
+      endpoint.releaseInitializedNotification();
+      const tools = await toolsPromise;
+      assert.deepEqual(
+        tools.tools.map(tool => tool.name),
+        ['echo'],
+      );
+    } finally {
+      endpoint.releaseInitializedNotification();
+      await client.close();
+      await endpoint.waitForDelete();
+      await endpoint.close();
+    }
+  });
+
+  it('terminates a session when stdio closes during initialization', async () => {
+    const endpoint = await createMockEndpoint({holdInitialize: true});
+    const transport = createProxyTransport(endpoint.url);
+
+    try {
+      await transport.start();
+      await transport.send({
+        jsonrpc: '2.0',
+        id: 'initialize',
+        method: 'initialize',
+        params: {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: {name: 'proxy-test-client', version: '1.0.0'},
+        },
+      });
+      await endpoint.waitForInitialize();
+
+      const closePromise = transport.close();
+      const nextTurn = Promise.withResolvers<void>();
+      setImmediate(nextTurn.resolve);
+      await nextTurn.promise;
+      endpoint.releaseInitialize();
+      await closePromise;
+
+      await endpoint.waitForDelete();
+      assert.deepEqual(endpoint.deletedSessionIds, [SESSION_ID]);
+    } finally {
+      endpoint.releaseInitialize();
+      await transport.close();
+      await endpoint.close();
+    }
+  });
+
+  it('reports a remote connection failure instead of leaving the stdio client pending', async () => {
+    const endpoint = await createMockEndpoint({rejectPosts: true});
+    const transport = createProxyTransport(endpoint.url);
+    const stderr = transport.stderr;
+    if (stderr === null) {
+      throw new Error('Expected a piped proxy stderr stream');
+    }
+    let stderrText = '';
+    const stderrClosed = Promise.withResolvers<void>();
+    stderr.on('data', chunk => {
+      stderrText += chunk.toString();
+    });
+    stderr.once('end', () => stderrClosed.resolve());
+    const client = new Client({name: 'proxy-test-client', version: '1.0.0'});
+
+    try {
+      await assert.rejects(client.connect(transport));
+      await stderrClosed.promise;
+      assert.match(stderrText, /MCP stdio proxy HTTP error/);
+    } finally {
+      await client.close();
+      await endpoint.close();
+    }
+  });
+});

--- a/tests/telemetry/ClearcutLogger.test.ts
+++ b/tests/telemetry/ClearcutLogger.test.ts
@@ -57,6 +57,38 @@ describe('ClearcutLogger', () => {
       assert.strictEqual(msg.payload.tool_invocation?.success, true);
       assert.strictEqual(msg.payload.tool_invocation?.latency_ms, 250);
     });
+    it('serializes concurrent tool active events', async () => {
+      const logger = ClearcutLogger.initialize({
+        persistence: mockPersistence,
+        appVersion: '1.0.0',
+        watchdogClient: mockWatchdogClient,
+      });
+      await Promise.resolve();
+
+      await Promise.all([
+        logger.logToolInvocation({
+          toolName: 'first_tool',
+          params: {},
+          schema: {},
+          success: true,
+          latencyMs: 123,
+        }),
+        logger.logToolInvocation({
+          toolName: 'second_tool',
+          params: {},
+          schema: {},
+          success: true,
+          latencyMs: 123,
+        }),
+      ]);
+      await new Promise(resolve => setImmediate(resolve));
+
+      const activeMessages = mockWatchdogClient.send.args.filter(
+        call => call[0].payload.tool_active !== undefined,
+      );
+      assert.strictEqual(activeMessages.length, 1);
+    });
+
     it('sends context when provided', async () => {
       const logger = ClearcutLogger.initialize({
         persistence: mockPersistence,


### PR DESCRIPTION
## Why

Addresses https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/2188. Multiple MCP clients need to drive one long-lived Chrome without spawning one Chrome-connected server per client, leaking orphaned processes, contending for profiles, or sharing selected-page and filesystem state.

## What changed

- add a loopback-only Streamable HTTP endpoint at `http://127.0.0.1:<port>/mcp` via `--http-port`
- create an independent `McpServer` and `McpContext` for every HTTP session while sharing one process-level Chrome connection and page inventory
- isolate selected pages, roots, named isolated contexts, DevTools resource loading, tracing/recording state, telemetry attribution, and per-client request mutexes
- add `--server-url` / `CHROME_DEVTOOLS_MCP_SERVER_URL` as a transparent stdio-to-HTTP proxy for stdio-only clients
- preserve existing stdio mode when neither option is supplied
- support server-launched headed/headless Chrome, `--auto-connect`, and explicit remote-debugging `--browser-url` / `--ws-endpoint` modes

## Lifecycle and security

- bind only to `127.0.0.1`; reject non-loopback `Host` and `Origin`
- cap request bodies at 4 MiB and bound pending/established sessions
- close only the addressed session on accepted `DELETE`; inactive sessions expire after 30 minutes while active requests/streams suspend expiry
- drain active tools and stop session-owned traces, screencasts, and owned isolated browser contexts before disposal
- document SSH port forwarding as the only remote-access path

## Verification

- `npm run format`
- focused shared HTTP/proxy/browser/context/telemetry run: 169 passed
- `npm run test tests/http-server.test.ts tests/proxy.test.ts tests/http-multi-client.test.ts`: 10 passed
- `npm run test -- --retry`: final attempt 1,036 passed, 3 platform skips; earlier attempts hit existing extension teardown/network ordering flakes
- live smoke: two named `chrome-devtools-axi` sessions opened separate tabs through one service, saw the same page inventory, and retained different selected pages

## Companion

AXI upstream: https://github.com/kunchenguid/chrome-devtools-axi/pull/139

Fork review PRs: https://github.com/lmn451/chrome-devtools-mcp/pull/3 and https://github.com/lmn451/chrome-devtools-axi/pull/1

Supersedes the narrower per-session-browser approach in https://github.com/ChromeDevTools/chrome-devtools-mcp/pull/2730.