### PR TITLE
fix(logger): puppeteerLogger should check DEBUG before checking --log-file

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -50,6 +50,11 @@ export const logger: Logger = (...args: unknown[]) => {
 };
 
 export const puppeteerLogger = (prefix: string) => {
+  const dbg = util.debuglog(prefix);
+  if (!dbg.enabled) {
+    return undefined;
+  }
+
   if (logFileStream) {
     return (...args: unknown[]) => {
       logFileStream!.write(
@@ -58,10 +63,7 @@ export const puppeteerLogger = (prefix: string) => {
     };
   }
 
-  const dbg = util.debuglog(prefix);
-  return dbg.enabled
-    ? (...args: unknown[]) => {
-        dbg('%s %s', new Date().toISOString(), util.format(...args));
-      }
-    : undefined;
+  return (...args: unknown[]) => {
+    dbg('%s %s', new Date().toISOString(), util.format(...args));
+  };
 };

--- a/tests/utils/fixtures/puppeteer-logger-fixture.ts
+++ b/tests/utils/fixtures/puppeteer-logger-fixture.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Standalone fixture spawned as a child process by logger.test.ts.
+//
+// `util.debuglog(prefix).enabled` reflects the NODE_DEBUG environment
+// variable as it was when the *process* started, not a value that can be
+// toggled at runtime within a single process. Testing puppeteerLogger's
+// DEBUG-gating behavior for both the enabled and disabled cases therefore
+// requires spawning separate processes with different NODE_DEBUG values,
+// which is what this fixture is for.
+//
+// Usage: node <compiled-fixture> <prefix> <logFilePath | -->
+// If <logFilePath> is "--", saveLogsToFile is not called (no-log-file case).
+
+import {
+  saveLogsToFile,
+  flushLogs,
+  puppeteerLogger,
+} from '../../../src/utils/logger.js';
+
+const [, , prefix, logFilePathArg] = process.argv;
+
+if (!prefix || !logFilePathArg) {
+  console.error('usage: puppeteer-logger-fixture <prefix> <logFilePath|-->');
+  process.exit(2);
+}
+
+const logFile =
+  logFilePathArg !== '--' ? saveLogsToFile(logFilePathArg) : undefined;
+
+const write = puppeteerLogger(prefix);
+if (write) {
+  write('fixture message');
+}
+
+if (logFile) {
+  await flushLogs(logFile);
+}
+
+// `write` is undefined when the namespace is not DEBUG-enabled; print
+// whether a logger was returned so the parent test can assert on both the
+// in-process return value and (for the file case) the file's contents.
+console.log(write ? 'logger:defined' : 'logger:undefined');

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import {describe, it} from 'node:test';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, 'fixtures', 'puppeteer-logger-fixture.js');
+
+/**
+ * Runs the puppeteer-logger-fixture in a fresh child process with the given
+ * NODE_DEBUG value. A fresh process is required because
+ * `util.debuglog(...).enabled` reflects NODE_DEBUG as of process start, not
+ * a value that can be toggled at runtime (see the fixture's own comment).
+ */
+function runFixture(
+  prefix: string,
+  logFilePath: string | undefined,
+  nodeDebug: string | undefined,
+): string {
+  const env = {...process.env};
+  if (nodeDebug === undefined) {
+    delete env.NODE_DEBUG;
+  } else {
+    env.NODE_DEBUG = nodeDebug;
+  }
+  return execFileSync(
+    process.execPath,
+    [FIXTURE, prefix, logFilePath ?? '--'],
+    {env, encoding: 'utf8'},
+  ).trim();
+}
+
+describe('puppeteerLogger', () => {
+  it('does not log to a file when the namespace is not DEBUG-enabled', () => {
+    const logFilePath = path.join(
+      os.tmpdir(),
+      `puppeteer-logger-test-${process.pid}-${Date.now()}.log`,
+    );
+    try {
+      const result = runFixture(
+        'puppeteer:protocol:SEND',
+        logFilePath,
+        'mcp:log', // DEBUG is set, but does not include this prefix.
+      );
+      assert.strictEqual(result, 'logger:undefined');
+      // saveLogsToFile() creates the file unconditionally (--log-file is a
+      // global option, independent of any specific namespace), so the
+      // regression check is on CONTENT, not existence: the file must stay
+      // empty rather than receiving this namespace's traffic.
+      const contents = fs.existsSync(logFilePath)
+        ? fs.readFileSync(logFilePath, 'utf8')
+        : '';
+      assert.strictEqual(
+        contents,
+        '',
+        'puppeteerLogger must not write to the log file for a namespace ' +
+          'that is not enabled via NODE_DEBUG, even when --log-file is set',
+      );
+    } finally {
+      fs.rmSync(logFilePath, {force: true});
+    }
+  });
+
+  it('logs to a file when the namespace is DEBUG-enabled', () => {
+    const logFilePath = path.join(
+      os.tmpdir(),
+      `puppeteer-logger-test-${process.pid}-${Date.now()}.log`,
+    );
+    try {
+      const result = runFixture(
+        'puppeteer:protocol:SEND',
+        logFilePath,
+        'puppeteer:protocol:SEND',
+      );
+      assert.strictEqual(result, 'logger:defined');
+      const contents = fs.readFileSync(logFilePath, 'utf8');
+      assert.match(contents, /puppeteer:protocol:SEND fixture message/);
+    } finally {
+      fs.rmSync(logFilePath, {force: true});
+    }
+  });
+
+  it('logs to a file when NODE_DEBUG=* enables every namespace', () => {
+    const logFilePath = path.join(
+      os.tmpdir(),
+      `puppeteer-logger-test-${process.pid}-${Date.now()}.log`,
+    );
+    try {
+      const result = runFixture('puppeteer:protocol:RECV', logFilePath, '*');
+      assert.strictEqual(result, 'logger:defined');
+      const contents = fs.readFileSync(logFilePath, 'utf8');
+      assert.match(contents, /puppeteer:protocol:RECV fixture message/);
+    } finally {
+      fs.rmSync(logFilePath, {force: true});
+    }
+  });
+
+  it('returns undefined (no debuglog fallback either) when no log file and namespace is disabled', () => {
+    const result = runFixture('puppeteer:protocol:SEND', undefined, undefined);
+    assert.strictEqual(result, 'logger:undefined');
+  });
+});


### PR DESCRIPTION
Fixes #2731.

### Problem

Since v1.8.0 (#2562, replacing the `debug` npm package with Node's native `util.debuglog`), `puppeteerLogger()` in `src/utils/logger.ts` checks `logFileStream` truthiness *before* checking whether the namespace is DEBUG-enabled:

```ts
export const puppeteerLogger = (prefix: string) => {
  if (logFileStream) {
    return (...args) => { logFileStream!.write(...); };  // unconditional
  }
  const dbg = util.debuglog(prefix);
  return dbg.enabled ? (...) => dbg(...) : undefined;      // gated
};
```

So once `--log-file` is set, every `puppeteer:protocol:SEND`/`RECV` message (full CDP JSON payloads — network events, accessibility trees, etc.) gets written to the log file regardless of `DEBUG`, producing GB-scale log files instead of the KB-scale v1.7.0 behavior for the same traffic.

In v1.7.0, `saveLogsToFile()` called `debug.enable()` with the user's `DEBUG` namespaces plus `mcp:log`, so only explicitly-enabled namespaces were ever written — `mcp:log` always (since it was always added to the enabled set), everything else only if the user opted in.

### Fix

Reordered `puppeteerLogger` to check `dbg.enabled` first, so both the file-writing and `util.debuglog`-writing branches are gated the same way — matching v1.7.0 semantics. `logger()` (the separate function backing the always-on `mcp:log` namespace) is untouched; its unconditional file-write is correct, not a bug — `mcp:log` was always in the enabled set even in v1.7.0.

### How did you test it

Added `tests/utils/logger.test.ts` + a `tests/utils/fixtures/puppeteer-logger-fixture.ts` helper. `util.debuglog(...).enabled` reflects `NODE_DEBUG` as of process start, not a value togglable at runtime, so the fixture is spawned as a fresh child process per case (4 cases: namespace disabled + log file → file stays empty; namespace enabled + log file → file gets the message; `NODE_DEBUG=*` + log file → file gets the message; namespace disabled + no log file → returns `undefined`, matching existing behavior).

Verified fail-before/pass-after by running the equivalent logic directly against both the pre-fix and post-fix source (via `git stash`) — pre-fix, the "disabled + log file" case wrongly writes to the file; post-fix, it doesn't.

`eslint` and `prettier --check` both clean on all 3 changed/added files. I was not able to run the full `npm test` (`tsc && node scripts/post-build.ts` needs the `third_party/devtools-frontend` git submodule, which failed to fetch in my environment — appears to be a shallow-submodule/pinned-commit mismatch, unrelated to this change) or the full project `tsc` (blocked by the same missing submodule via `src/third_party/index.ts`'s import of it). I isolated my 3 changed files with a standalone `tsc --noEmit` invocation instead — confirmed zero type errors originate from any of them (the errors present in that run are 100% pre-existing, from unrelated `puppeteer-core`/`rxjs`/submodule type declarations, and disappear if those files are excluded). Happy to re-verify against a full build if a maintainer can point me at a working submodule fetch, or if this is a known environment quirk.